### PR TITLE
Add 8 new use cases

### DIFF
--- a/use-cases/bug-bounty-triager-new-reports-auto-reproduced-scored-against-your-attack-surface-and-queued-by/USE_CASE.md
+++ b/use-cases/bug-bounty-triager-new-reports-auto-reproduced-scored-against-your-attack-surface-and-queued-by/USE_CASE.md
@@ -1,0 +1,99 @@
+### 1. Title
+
+Bug Bounty Triager — New reports auto-reproduced, scored against your attack surface, and queued by priority
+
+### 2. Example prompt
+
+You are my bug bounty triager. When a new report comes in, you reproduce it, score it against our actual attack surface, and draft the initial response — so I review a prioritized queue instead of a raw inbox.
+
+When I say "triage: [report ID or paste report]" or when a new HackerOne/Bugcrowd webhook triggers via `event_emit`:
+
+1. Parse the report: vulnerability type, affected endpoint, steps to reproduce, claimed severity
+2. `grep` the codebase to check if the endpoint exists in current code (it might be stale or already removed)
+3. Attempt to reproduce the vulnerability in a sandboxed environment using `shell`:
+   - Set up the minimal conditions described
+   - Execute the reproduction steps
+   - Capture evidence (HTTP requests, responses, error output)
+4. Score severity against actual attack surface using `read_file` on config/auth files:
+   - Is this endpoint publicly exposed or internal-only?
+   - Does it require authentication? What privilege level?
+   - What data is accessible if exploited?
+   - Is the exploit reliable or conditional?
+5. `memory_write` to save the triage result at bounty/triage/[REPORT-ID].md with full analysis
+6. Draft the initial response to the researcher
+
+"🎯 Bug Bounty Triage — [REPORT-ID]
+
+**Claimed:** [XSS on /api/v2/users/profile]
+**Reproduced:** ✅ Yes (or ❌ No — reason)
+**Actual severity:** High (claimed: Critical)
+**Reasoning:** Endpoint requires authenticated user, no admin escalation possible. PII accessible but limited to own profile. Downgraded from Critical because no unauthenticated access.
+
+**Evidence:**
+- Request: [curl command]
+- Response: [sanitized output]
+- Impact: reflected XSS executes in user's own session, no cross-user impact
+
+**Suggested response to researcher:**
+'Thank you for the report. We have confirmed the vulnerability. Based on our impact assessment, we are classifying this as High severity. The bounty for High severity findings on our program is [$X].'
+
+**Priority queue position:** 2 of 7 open reports (1 Critical above this)"
+
+=== COMMANDS ===
+
+"triage: queue" — `memory_search` for all open reports sorted by actual severity
+"triage: respond [ID] accept/reject/need-info" — `memory_write` to log decision, `gmail` tool to send response
+"triage: duplicate [ID1] of [ID2]" — `memory_write` to mark as duplicate and link to original report
+"show bounty stats" — `memory_search` for total reports, triage rate, severity distribution
+"bounty: out of scope [ID]" — `memory_write` to mark as out of scope with reason, `gmail` to draft rejection
+
+### 3. What the agent does
+
+Bug bounty programs receive 10-100 reports per week. Most are noise: already-known issues, out-of-scope endpoints, unreproducible claims, or informational findings dressed up as Critical. Triaging them takes 2-4 hours per day for a security engineer.
+
+The agent does the mechanical part automatically. It reads the report, verifies the endpoint exists via `grep`, attempts reproduction in a sandbox via `shell`, scores actual impact against the real attack surface, and drafts the response via `gmail`. The human reviews the queue in priority order and makes the final call.
+
+It uses `memory_search` to track duplicate reports and researcher history. Over time: "this researcher has submitted 12 reports, 10 were unreproducible — apply extra scrutiny."
+
+### 4. Skills & tools used
+
+- `shell` — attempts to reproduce the vulnerability in a sandboxed environment, runs curl commands for HTTP-based attacks, executes proof-of-concept exploits safely
+- `grep` — searches the codebase for the reported endpoint, function, or vulnerable code path to verify it exists in the current version
+- `read_file` — reads auth config, route definitions, and access control files to assess actual attack surface
+- `http` — reproduces HTTP-based vulnerabilities (XSS, SSRF, injection) by sending crafted requests to the target endpoint
+- `memory_search` — loads triage history, duplicate database, and per-researcher track record from workspace memory
+- `memory_write` — saves each triage result with reproduction evidence, severity assessment, and response draft
+- `message` — sends priority alerts to the security engineer's connected channel (Telegram, Slack)
+- `routine_create` — creates a 30-minute interval routine to check for new reports during business hours
+- `create_job` — spawns isolated sandbox jobs for parallel reproduction of multiple reports
+- `github` (WASM tool, install from hub) — creates issues from confirmed bugs, links them to the relevant code, and tracks remediation progress
+- `gmail` (WASM tool, install from hub) — sends templated responses to researchers and receives new bug bounty report notifications
+- `slack` (WASM tool, install from hub) — if the team uses Slack for security channel coordination, posts triage results to the appropriate channel
+- `Penetration Testing` [(hub)](https://hub.ironclaw.com) — understands exploit techniques, reproduction methodology, and vulnerability classification (OWASP, CWE)
+- `Smart Contract Security` [(hub)](https://hub.ironclaw.com) — handles Web3-specific bug reports (reentrancy, flash loan attacks, oracle manipulation, front-running)
+- `Application Security` [(hub)](https://hub.ironclaw.com) — scores actual impact against the application's attack surface, accounting for authentication requirements and data sensitivity
+- `Threat Modeling` [(hub)](https://hub.ironclaw.com) — provides structured threat categorization and risk assessment frameworks
+- `security-review` (built-in skill) — security audit for code changes: OWASP top 10, auth flows, data handling, secrets exposure
+- `code-review` (built-in skill) — traces the vulnerable code path through the application to assess blast radius and exploit chain
+
+### 5. Categories
+
+- [ ] Personal assistant
+- [ ] Web 3 / Crypto
+- [x] Coding / dev workflow
+- [ ] Research
+- [ ] Marketing / content
+- [x] Business ops
+- [ ] Sales / CRM
+- [ ] Files / knowledge
+- [x] Automation
+- [ ] Design / media
+- [ ] Skill creation
+
+### 6. Source (optional)
+
+Original concept — bug bounty triage is mechanical, high-volume, and well-suited to automated reproduction and scoring with human final review.
+
+### 7. Author (optional)
+
+Jean (@Jemartel)

--- a/use-cases/changelog-to-release-comms-pipeline-repo-tags-a-release-agent-drafts-release-notes-customer-emai/USE_CASE.md
+++ b/use-cases/changelog-to-release-comms-pipeline-repo-tags-a-release-agent-drafts-release-notes-customer-emai/USE_CASE.md
@@ -1,0 +1,112 @@
+### 1. Title
+
+Changelog to Release Comms Pipeline — Repo tags a release, agent drafts release notes, customer email, and tweet thread
+
+### 2. Example prompt
+
+You are my release communications pipeline. When a new tag lands in the repo, you diff the changelog, draft release notes for three different audiences, and present them for review.
+
+When I say "release: [version]" or when a new tag webhook triggers via `event_emit`:
+
+1. Find the previous tag and diff: `shell` runs `git log [prev]..[new]`
+2. Categorize every commit/PR using `github` tool for PR details:
+   - Breaking changes
+   - New features
+   - Bug fixes
+   - Performance improvements
+   - Internal/refactor (skip in public notes)
+3. `memory_search` for releases/style-guide.md — the project's past tone and format
+4. `memory_search` for releases/past-releases/ — consistency with previous notes
+5. Generate three outputs:
+
+**A. GitHub Release Notes** (technical audience):
+Release notes format:
+**[version] — [date]**
+Breaking Changes: [description with migration path]
+New Features: [description with PR link]
+Bug Fixes: [description with PR link]
+Contributors: [list of contributors]
+
+**B. Customer Email** (non-technical, sent via `gmail` tool):
+Subject: What's new in [Product] [version]
+[2-3 sentence executive summary]
+[Feature in customer language, not commit language]
+[Fix in terms of the problem it solves, not the technical cause]
+
+**C. Tweet Thread** (sent via `message` for review):
+```
+🚀 [Product] [version] is live.
+[Hook — the single most exciting thing]
+🧵 Thread:
+1/ [Feature 1 with emoji]
+2/ [Feature 2 with emoji]
+[Try it: link]
+```
+
+6. `memory_write` to save all drafts at releases/[version]/
+7. `message` to send to Telegram for review:
+
+"📦 Release [version] ready for review
+
+3 drafts generated: GitHub release notes, customer email, tweet thread.
+
+Reply 'ship github' / 'ship email' / 'ship all' to publish, or send edits."
+
+When I reply "ship all":
+- `github` tool to create the GitHub release with notes
+- `gmail` tool to send the customer email to the mailing list
+- `memory_write` to log the published release
+
+=== COMMANDS ===
+
+"release: preview [version]" — show drafts without publishing
+"release: edit tone [more technical/less technical/more casual]" — `memory_write` to update style guide for next release
+"release: history" — `memory_search` for past releases with links to published notes
+
+### 3. What the agent does
+
+Every team that ships weekly faces the same problem: the engineer who wrote the code is the worst person to explain what it does to customers. Release notes end up as a dump of PR titles. Customer emails never get written. The tweet just says "shipped v2.5, bug fixes and improvements."
+
+The agent reads the actual diff via `shell`, categorizes changes via `github` PR details, and generates release communications for three audiences. It learns the project's voice from past releases stored in `memory_search` — if the last three release notes used a certain format and tone, the fourth matches.
+
+The human reviews and approves. The agent does the 90% work of turning "fix: resolve race condition in connection pool (#1234)" into "Your dashboard loads faster and no longer disconnects during peak hours."
+
+### 4. Skills & tools used
+
+- `shell` — runs `git log`, `git diff`, and `git shortlog` between the previous and new tag to extract all changes
+- `read_file` — reads CHANGELOG.md, package.json version, and any existing release templates from the workspace
+- `memory_search` — loads past release style, tone, format, and contributor list from workspace memory
+- `memory_write` — saves release drafts and published versions for style consistency across releases
+- `memory_tree` — organizes releases into a browsable directory (releases/[version]/)
+- `message` — sends drafts to Telegram/Slack for human review and accepts approval commands
+- `event_emit` — triggers the release pipeline from GitHub push/tag webhooks
+- `github` (WASM tool, install from hub) — fetches PR details (titles, descriptions, labels, authors) for each commit in the release range; creates the GitHub release with the drafted notes
+- `gmail` (WASM tool, install from hub) — sends the customer-facing email to the mailing list or distribution group
+- `google-docs` (WASM tool, install from hub) — optionally drafts the release notes in a Google Doc for collaborative editing before publishing
+- `google-slides` (WASM tool, install from hub) — generates a release deck for all-hands or sales presentations
+- `Technical Writing` [(hub)](https://hub.ironclaw.com) — drafts clear, audience-appropriate release notes and documentation
+- `Copywriting Frameworks` [(hub)](https://hub.ironclaw.com) — structures customer-facing and social media copy for impact
+- `Code Review` [(hub)](https://hub.ironclaw.com) — reads diffs and understands what each change actually does beyond the commit message
+- `commitment-triage` (built-in skill) — tracks release commitments and flags if promised features were included or deferred
+
+### 5. Categories
+
+- [ ] Personal assistant
+- [ ] Web 3 / Crypto
+- [x] Coding / dev workflow
+- [ ] Research
+- [x] Marketing / content
+- [x] Business ops
+- [ ] Sales / CRM
+- [ ] Files / knowledge
+- [x] Automation
+- [ ] Design / media
+- [ ] Skill creation
+
+### 6. Source (optional)
+
+Original concept — the gap between "code merged" and "users informed" is where most teams drop the ball. This automates the comms pipeline.
+
+### 7. Author (optional)
+
+Jean (@Jemartel)

--- a/use-cases/cold-outreach-researcher-research-a-prospect-draft-outreach-referencing-the-last-48-hours/USE_CASE.md
+++ b/use-cases/cold-outreach-researcher-research-a-prospect-draft-outreach-referencing-the-last-48-hours/USE_CASE.md
@@ -1,0 +1,107 @@
+### 1. Title
+
+Cold Outreach Researcher — Research a prospect, draft outreach referencing the last 48 hours
+
+### 2. Example prompt
+
+You are my cold outreach researcher. When I give you a prospect's name, you research them, find something timely to reference, and draft a personalized message that proves I did my homework — not a template with [FIRST_NAME] swapped in.
+
+When I say "outreach: [person] at [company]" — for example "outreach: Vitalik Buterin at Ethereum Foundation":
+
+1. Search for the person's recent activity using `web-search` (Brave):
+   - Recent tweets/posts (last 30 days)
+   - Recent blog posts or articles
+   - Recent talks, podcasts, or interviews
+   - Recent company news (fundraise, product launch, hires)
+2. Fetch detailed content using `llm-context` (Brave) for the top 3-5 most relevant results
+3. Search for company context using `web-search`:
+   - Recent funding round or financial events
+   - Product launches or major releases
+   - Press coverage or news mentions
+   - Open positions (signals about priorities)
+4. `memory_search` for outreach/history.md — past interactions with this person or company
+5. Identify 2-3 specific, timely angles — things from the last 48 hours or last week
+6. Draft 3 outreach variants (short email, LinkedIn message, tweet reply)
+7. `memory_write` to save research and drafts at outreach/prospects/[name].md
+
+"🎯 Outreach Research — [person] at [company]
+
+**Profile:** [title, role, focus area]
+**Timely hooks (last 7 days):**
+- Posted about [topic] on [date] — specifically mentioned [detail]
+- Company announced [event] on [date]
+- Gave talk at [event] about [topic] on [date]
+
+**Past interactions:** None found (or: "emailed 3 months ago, no response")
+
+**Draft 1 — Email (via `gmail` tool):**
+Subject: [specific reference to their recent work]
+[first sentence references the specific post/talk/news item]
+[2-3 sentences on why I'm reaching out and what's relevant to them]
+[clear ask with low commitment]
+
+**Draft 2 — LinkedIn (shorter):**
+[similar angle, 3 sentences max]
+
+**Draft 3 — Twitter reply:**
+[draft reply to their specific recent tweet]
+
+**Recommended angle:** [which hook is strongest and why]"
+
+=== COMMANDS ===
+
+"outreach: batch [names]" — research multiple prospects and queue drafts via `create_job`
+"outreach: sent [person]" — `memory_write` to log sent outreach, start follow-up timer via `routine_create`
+"outreach: follow-up [person]" — `memory_search` for original message, draft follow-up
+"outreach: track" — `memory_search` for all sent outreach with response status
+"outreach: stats" — `memory_search` for response rate by channel, response rate by angle type
+
+### 3. What the agent does
+
+Cold outreach works when it is specific. "I saw your recent post about X" gets a response. "I'd love to explore synergies" gets deleted. The problem: being specific requires 15-30 minutes of research per prospect. At scale, nobody does this.
+
+The agent does the research in seconds via `web-search` + `llm-context`, checks `memory_search` for past interaction history, and identifies the strongest timely angle. The resulting outreach references something real and recent — not "I'm a big fan" but "your post about ZK rollup sequencing on Tuesday raised a point about X that directly relates to what we're building."
+
+Over time `memory_search` tracks which angles get responses. "Tweet replies: 40% response rate. Emails: 12%. Topic-specific angles outperform general ones 3x."
+
+### 4. Skills & tools used
+
+- `http` — fetches specific public profiles, company about pages, and press releases when search results need more detail
+- `memory_search` — loads past outreach history, response tracking, and angle performance stats from workspace memory
+- `memory_write` — saves prospect research, outreach drafts, sent status, and response outcomes
+- `memory_tree` — organizes outreach into a browsable structure (outreach/prospects/[name]/, outreach/history/)
+- `message` — delivers research and draft outreach to Telegram for review
+- `routine_create` — creates follow-up reminders (e.g., "if no response in 5 days, draft a follow-up")
+- `create_job` — spawns parallel research jobs when processing a batch of prospects
+- `web-search` (WASM tool, install from hub) — searches for the prospect's recent posts, company news, press coverage, and social media activity
+- `llm-context` (WASM tool, install from hub) — fetches pre-extracted content from the prospect's blog posts, talks, and company pages for detailed reference points
+- `gmail` (WASM tool, install from hub) — sends the drafted email directly, or saves as a draft for human review before sending
+- `google-sheets` (WASM tool, install from hub) — tracks outreach pipeline: prospect → researched → contacted → responded → meeting booked
+- `Competitive Analysis` [(hub)](https://hub.ironclaw.com) — identifies strategic angles based on the prospect's company positioning and recent moves
+- `Stakeholder Communication` [(hub)](https://hub.ironclaw.com) — structures outreach that is appropriate for the relationship level (cold, warm, referral)
+- `Negotiation Communicator` [(hub)](https://hub.ironclaw.com) — frames the ask in terms of mutual benefit without being generic or transactional
+- `commitment-triage` (built-in skill) — recognizes outreach commitments in conversation ("I should reach out to X") and tracks them
+- `decision-capture` (built-in skill) — records the decision to pursue or deprioritize a prospect with rationale
+- `delegation-tracker` (built-in skill) — tracks delegated outreach tasks and nudges when follow-ups are overdue
+
+### 5. Categories
+
+- [ ] Personal assistant
+- [ ] Web 3 / Crypto
+- [ ] Coding / dev workflow
+- [x] Research
+- [ ] Marketing / content
+- [x] Business ops
+- [x] Sales / CRM
+- [ ] Files / knowledge
+- [x] Automation
+- [ ] Design / media
+- [ ] Skill creation
+
+### 6. Source (optional)
+
+Original concept — cold outreach conversion rates depend on specificity, which requires research that doesn't scale manually.
+
+### 7. Author (optional)
+
+Jean (@Jemartel)

--- a/use-cases/dependency-cve-sentinel-alerts-that-tell-you-if-you-re-actually-vulnerable-not-just-that-a-cve-e/USE_CASE.md
+++ b/use-cases/dependency-cve-sentinel-alerts-that-tell-you-if-you-re-actually-vulnerable-not-just-that-a-cve-e/USE_CASE.md
@@ -1,0 +1,91 @@
+### 1. Title
+
+Dependency CVE Sentinel — Alerts that tell you if you're actually vulnerable, not just that a CVE exists
+
+### 2. Example prompt
+
+You are my dependency security analyst. Dependabot spams me with CVEs — most are in transitive deps I never call. Your job is to tell me which ones actually matter for my codebase.
+
+When I say "cve: check" or when a new CVE alert fires:
+
+1. Read the current dependency tree: `shell` runs `npm ls`, `cargo tree`, or `go mod graph` (whichever exists in the workspace)
+2. Fetch the CVE details using `web-search` (Brave): affected versions, severity, attack vector, what function/path is vulnerable
+3. Read the actual source code that imports the affected dependency using `read_file` and `grep`
+4. Determine if the vulnerable codepath is reachable:
+   - Does my code call the affected function/class directly?
+   - Does any direct dependency call it in a way my code triggers?
+   - Is it only reachable through a feature flag or optional import I don't use?
+5. Classify each CVE into one of four buckets:
+   - **EXPLOITABLE** — vulnerable codepath is directly reachable in my code
+   - **CONDITIONAL** — reachable only through a specific feature flag, config, or indirect path
+   - **TRANSITIVE NOISE** — the dep is in my tree but the vulnerable path is never called
+   - **NOT AFFECTED** — my version is outside the affected range
+6. Save the triage result to workspace memory using `memory_write` at security/cve-triage.md with date, CVE ID, and verdict
+7. Send Telegram alert via `message` only for EXPLOITABLE and CONDITIONAL items
+
+"🔒 CVE Triage — [date]
+
+🔴 EXPLOITABLE:
+- CVE-2026-1234 (lodash <4.17.22, CVSS 9.1) — prototype pollution in mergeWith, called directly in src/utils/deepMerge.ts:42. Upgrade lodash to >=4.17.22.
+
+🟡 CONDITIONAL:
+- CVE-2026-5678 (express <4.19, CVSS 7.5) — open redirect in res.redirect, reachable only if admin panel feature flag is enabled (currently disabled). Low urgency.
+
+⚪ TRANSITIVE NOISE (4 CVEs silenced): lodash, express, axios, debug. None reach vulnerable codepaths in this project. Full list in security/cve-triage.md."
+
+Create a `routine` that runs every Monday at 7:00 AM via `routine_create`:
+1. `shell` to check for new CVEs affecting the project's dependencies (npm audit, cargo audit, etc.)
+2. Re-run reachability analysis for any new findings
+3. `message` to alert only on actionable items
+
+=== COMMANDS ===
+
+"cve: status" — `memory_search` for current triage summary with counts by bucket
+"cve: detail [CVE-ID]" — `memory_search` for full analysis of a specific CVE
+"cve: false positive [CVE-ID]" — `memory_write` to mark as permanently ignored with reason
+"show cve history" — `memory_search` for all triaged CVEs with dates and verdicts
+
+### 3. What the agent does
+
+Dependabot, Snyk, and every other scanner tell you "you have a CVE in your dependency tree." They are wrong 80% of the time — the vulnerable function exists in the package but your code never calls it. The result is alert fatigue: developers ignore all CVE notifications, including the real ones.
+
+This agent reads the CVE, reads your actual source code via `read_file` and `grep`, and traces whether the vulnerable codepath is reachable. A prototype pollution in lodash's mergeWith is EXPLOITABLE only if you call mergeWith — if you only use lodash for get and set, it is TRANSITIVE NOISE. The agent makes this distinction for every CVE, saves the reasoning to `memory_write`, and only bothers you when something is actually exploitable.
+
+It composes `code-review` for codepath analysis, `application-security` for vulnerability pattern understanding, and `memory_write`/`memory_search` so triaged CVEs don't resurface. Over time it builds a project-specific risk profile: "this project has 12 CVEs in its tree but only 2 are exploitable, both in the auth module."
+
+### 4. Skills & tools used
+
+- `shell` — runs dependency tree commands (`npm ls`, `cargo tree`, `go mod graph`) and audit tools (`npm audit`, `cargo audit`) to list affected packages and versions
+- `read_file` — reads source files that import the affected dependency to trace actual usage
+- `grep` — searches the entire codebase for calls to the vulnerable function/class across all files
+- `glob` — locates lock files (package-lock.json, Cargo.lock, go.sum) and config files to understand the dependency tree
+- `memory_search` — loads past CVE triage decisions and false-positive markings from workspace memory
+- `memory_write` — saves each triage result with CVE ID, verdict, reachability reasoning, and date
+- `routine_create` / `routine_fire` — creates a weekly Monday 7 AM routine to re-check for new CVEs and re-triage
+- `message` — sends Telegram alerts with only actionable (EXPLOITABLE / CONDITIONAL) items
+- `web-search` (WASM tool, install from hub) — fetches CVE details from NVD, GitHub Advisory Database, or MITRE: severity, affected versions, attack vector
+- `llm-context` (WASM tool, install from hub) — fetches pre-extracted content from CVE database pages for detailed vulnerability descriptions when search summaries are insufficient
+- `Code Review` [(hub)](https://hub.ironclaw.com) — traces import chains and function call graphs to determine if vulnerable codepaths are reachable from the project's source code
+- `Application Security` [(hub)](https://hub.ironclaw.com) — understands CVE severity, attack vectors, exploitability conditions, and what the vulnerable function actually does
+
+### 5. Categories
+
+- [ ] Personal assistant
+- [ ] Web 3 / Crypto
+- [x] Coding / dev workflow
+- [ ] Research
+- [ ] Marketing / content
+- [ ] Business ops
+- [ ] Sales / CRM
+- [ ] Files / knowledge
+- [x] Automation
+- [ ] Design / media
+- [ ] Skill creation
+
+### 6. Source (optional)
+
+Original concept — addresses CVE alert fatigue by adding codepath reachability analysis on top of existing vulnerability scanners.
+
+### 7. Author (optional)
+
+Jean (@Jemartel)

--- a/use-cases/grant-funding-deadline-tracker-monitor-grant-databases-match-eligibility-alert-on-deadlines/USE_CASE.md
+++ b/use-cases/grant-funding-deadline-tracker-monitor-grant-databases-match-eligibility-alert-on-deadlines/USE_CASE.md
@@ -1,0 +1,116 @@
+### 1. Title
+
+Grant/Funding Deadline Tracker — Monitor grant databases, match eligibility, alert on deadlines
+
+### 2. Example prompt
+
+You are my grant and funding deadline tracker. You monitor grant databases, match them against my project profiles, and alert me before deadlines so I never miss free money.
+
+When I say "profile: [project description]" — for example "profile: open-source NEAR Protocol wallet, Firefox extension, self-custody, privacy-focused":
+
+1. `memory_search` for grants/profiles.md
+2. `memory_write` to save the project profile with key attributes: tech stack, ecosystem, stage, team size, location, open-source status
+3. Immediately scan known grant sources for matches (see routine below)
+
+Create a `routine` via `routine_create` that runs every Wednesday at 9:00 AM:
+
+1. `memory_search` for all project profiles from grants/profiles.md
+2. Scan grant sources using `web-search` (Brave) and `llm-context` (Brave):
+   - NEAR Foundation grants (near.org/grants)
+   - Web3 Foundation grants (w3f.io)
+   - Ethereum Foundation grants (ethereum.org)
+   - Gitcoin Grants rounds
+   - EU Horizon Europe calls matching tech keywords
+   - US SBIR/STTR matching project keywords
+   - Mozilla MOSS grants (if open-source)
+   - Solana Foundation, Polygon grants (if applicable)
+   - Devfolio hackathons with prize pools
+3. For each new grant found:
+   - Check eligibility against project profiles
+   - Calculate match score (0-100) based on: topic alignment, tech stack match, geographic eligibility, stage fit, deadline proximity
+   - `memory_write` to save at grants/opportunities/[grant-id].md
+4. `message` to send Telegram alert for high-match opportunities (score > 60):
+
+"💰 Grant Opportunity — [match score: 85/100]
+
+**Grant:** [name]
+**Source:** [NEAR Foundation / EU Horizon / etc.]
+**Amount:** [$X - $Y]
+**Deadline:** [date] ([X days away])
+**Eligibility:** [requirements]
+
+**Why it matches your profile:**
+- [specific alignment point 1]
+- [specific alignment point 2]
+
+**Required materials:**
+- [ ] Project description (max [X] words)
+- [ ] Team background
+- [ ] Budget proposal
+- [ ] Technical architecture doc
+- [ ] Timeline / milestones
+
+**Pre-drafted application outline:**
+1. Problem statement: [auto-drafted from profile]
+2. Solution: [auto-drafted]
+3. Technical approach: [auto-drafted from tech stack]
+4. Budget breakdown: [template]
+5. Timeline: [template]
+
+Reply 'start application [grant-id]' to begin drafting."
+
+If nothing new: no message (silent heartbeat).
+
+=== COMMANDS ===
+
+"grants: list" — `memory_search` for all tracked opportunities sorted by deadline
+"grants: apply [id]" — begin drafting an application using the project profile from `memory_search`
+"grants: submitted [id]" — `memory_write` to mark as submitted, log the date and amount requested
+"grants: won [id]" — `memory_write` to mark as awarded, log amount and start date
+"grants: stats" — `memory_search` for total applied, total awarded, total funding received, success rate
+
+### 3. What the agent does
+
+Billions of dollars in grants go unclaimed every year because nobody knows they exist or misses the deadline by two days. The teams that would qualify are too busy building to monitor grant databases.
+
+The agent monitors grant sources weekly via `routine_create` + `web-search`, matches them against your project profiles stored via `memory_write`, and surfaces only the ones you're eligible for with a pre-drafted application outline. It tracks deadlines, required materials, and submission status. A grant application is 60% boilerplate (team description, project overview, tech stack) that rarely changes. The agent keeps this in `memory_search` and pre-fills it, leaving you to write only the grant-specific 40%.
+
+### 4. Skills & tools used
+
+- `http` — scrapes specific grant program pages (NEAR Foundation, Gitcoin, EU Funding Portal) for structured deadline and requirement data
+- `memory_search` — loads project profiles, past applications (for boilerplate reuse), and submission history from workspace memory
+- `memory_write` — saves grant opportunities, match scores, application drafts, and submission outcomes
+- `memory_tree` — organizes grants into a browsable structure (grants/opportunities/, grants/applications/, grants/profiles/)
+- `message` — sends weekly grant opportunity alerts and deadline reminders to Telegram
+- `routine_create` — creates the weekly Wednesday 9 AM scan routine and deadline reminders (7 days and 2 days before cutoff)
+- `web-search` (WASM tool, install from hub) — searches for new grant opportunities across foundation websites, grant databases, and funding directories
+- `llm-context` (WASM tool, install from hub) — fetches pre-extracted content from grant program pages for detailed eligibility requirements and application guidelines
+- `gmail` (WASM tool, install from hub) — sends completed applications to grant program email addresses
+- `google-docs` (WASM tool, install from hub) — drafts grant applications in Google Docs for collaborative editing with co-founders or team members
+- `google-sheets` (WASM tool, install from hub) — tracks grant pipeline: opportunity → drafting → submitted → awarded/rejected, with deadline countdowns
+- `Business Plan Writer` [(hub)](https://hub.ironclaw.com) — structures grant applications with proper problem statements, market analysis, and budget justification
+- `Technical Writing` [(hub)](https://hub.ironclaw.com) — drafts clear project descriptions, technical architecture sections, and milestone definitions
+- `commitment-triage` (built-in skill) — recognizes grant-related commitments and deadlines in conversation, adds them to the commitments workspace
+- `decision-capture` (built-in skill) — records the decision to apply (or not apply) for each grant with rationale
+
+### 5. Categories
+
+- [ ] Personal assistant
+- [x] Web 3 / Crypto
+- [ ] Coding / dev workflow
+- [ ] Research
+- [ ] Marketing / content
+- [x] Business ops
+- [ ] Sales / CRM
+- [x] Files / knowledge
+- [x] Automation
+- [ ] Design / media
+- [ ] Skill creation
+
+### 6. Source (optional)
+
+Original concept — grant money is free non-dilutive funding that most teams leave on the table because monitoring and applying is too tedious.
+
+### 7. Author (optional)
+
+Jean (@Jemartel)

--- a/use-cases/on-call-incident-first-responder-alert-fires-agent-runs-diagnostics-before-you-open-your-laptop/USE_CASE.md
+++ b/use-cases/on-call-incident-first-responder-alert-fires-agent-runs-diagnostics-before-you-open-your-laptop/USE_CASE.md
@@ -1,0 +1,101 @@
+### 1. Title
+
+On-Call Incident First Responder — Alert fires, agent runs diagnostics before you open your laptop
+
+### 2. Example prompt
+
+You are my on-call incident first responder. When an alert fires, you immediately start diagnosing so that by the time I open my laptop, the initial investigation is done and I have context instead of questions.
+
+When I say "incident: [alert details]" or when a webhook triggers via `event_emit`:
+
+1. Parse the alert payload: service, severity, error message, timestamp, affected hosts/regions
+2. Pull the relevant runbook from workspace memory using `memory_search` at incident/runbooks/[service].md (or ask me to create one if none exists)
+3. Execute the first 5 diagnostic steps from the runbook using `shell`:
+   - `shell` — check service health endpoints via curl
+   - `shell` — pull last 50 log lines from the affected service
+   - `shell` — check CPU/memory/disk on affected hosts
+   - `github` tool — check recent deployments or config changes (compare commits)
+   - `shell` — verify dependent service status
+4. Build an initial incident timeline using `memory_write` at incident/active/[INC-ID].md:
+   - When did metrics first deviate?
+   - What changed around that time (deploy, config, traffic spike)?
+   - What is the blast radius (which services/endpoints are affected)?
+5. Send Telegram alert via `message` with the pre-built context:
+
+"🚨 Incident [INC-001] — [service] [severity]
+
+**Status:** Investigating (automated first-response)
+**Started:** [timestamp] (X min ago)
+**Blast radius:** [affected endpoints/users]
+
+**Auto-diagnosis results:**
+1. Health check: FAILING (5xx rate 12%, normally <0.1%)
+2. Recent deploy: v2.14.3 rolled out 23 min before first alert
+3. Logs show: database connection pool exhausted, timeout on 80% of writes
+4. DB replica lag: 45s (normally <1s)
+5. No config changes in last 24h
+
+**Likely cause:** Deploy v2.14.3 increased connection pool usage. DB cannot keep up.
+**Suggested first action:** Roll back v2.14.3. Confirm by checking DB connection count before and after.
+
+**Runbook:** incident/runbooks/[service].md (step 3 recommends rollback for this pattern)"
+
+When I reply with actions:
+- "rollback" — `memory_write` notes the action and timestamp in the incident log
+- "mitigated" — mark incident as mitigated, `routine_create` to monitor for recurrence
+- "resolved" — close incident, `routine_create` to schedule post-mortem reminder for 48 hours later
+- Any other text — `memory_write` logs as a note with timestamp
+
+=== COMMANDS ===
+
+"incident: runbook [service]" — create or edit the runbook for a service via `memory_write`
+"incident: status" — `memory_search` for all active incidents and their current state
+"incident: timeline [INC-ID]" — `memory_search` for full timeline with all automated and manual actions
+"incident: postmortem [INC-ID]" — generate a post-mortem draft from the incident timeline using `memory_search`
+"show incident history" — `memory_search` for past incidents with severity and resolution time
+
+### 3. What the agent does
+
+An alert fires at 3 AM. Today, someone gets paged, opens a laptop, spends 20 minutes running basic diagnostics (is it up? what changed? what do the logs say?), and only then starts actually fixing the problem. Those first 20 minutes are always the same checks, every time.
+
+The agent intercepts the alert and runs the standard diagnostic playbook automatically using `shell` for commands, `github` for deploy checks, and `memory_search` for runbooks. By the time you join the incident channel via `message`, you have a timeline, a likely cause, and a recommended first action. You start at "here's what happened and what to do" instead of "anyone looking at this?"
+
+After enough incidents, `memory_search` recognizes: "this is the same pattern as INC-014 last month — that time it was a bad deploy too." The incident history becomes a searchable knowledge base.
+
+### 4. Skills & tools used
+
+- `shell` — runs diagnostic commands (health checks via curl, log tails, resource monitoring, service status, database queries) on affected infrastructure
+- `http` — queries service health endpoints, monitoring APIs, and status pages directly
+- `read_file` — reads runbook documents, config files, and deployment manifests from the workspace
+- `memory_search` — loads service-specific runbooks and past incident history from workspace memory
+- `memory_write` — saves incident timeline, automated diagnosis results, and resolution notes for post-mortem generation
+- `message` — sends Telegram/Slack alerts with pre-built context and accepts action commands (rollback, mitigated, resolved)
+- `routine_create` — monitors for incident recurrence after mitigation and fires post-mortem reminders 48 hours after resolution
+- `event_emit` — triggers incident-response routines from external alerting webhooks (PagerDuty, Datadog, etc.)
+- `create_job` — spawns isolated diagnostic jobs for parallel investigation of multiple services
+- `github` (WASM tool, install from hub) — checks recent commits, compares deployments, reads CI logs, and inspects workflow runs to identify what changed before the alert
+- `Incident Response` [(hub)](https://hub.ironclaw.com) — provides runbook knowledge and diagnostic patterns for common infrastructure failure modes
+- `Linux Sysadmin` [(hub)](https://hub.ironclaw.com) — knows the right diagnostic commands for service health, log analysis, and resource troubleshooting
+- `Wazuh` (WASM tool, install from hub) — queries security and operational logs from the Wazuh SIEM for the affected service during the incident window
+
+### 5. Categories
+
+- [ ] Personal assistant
+- [ ] Web 3 / Crypto
+- [x] Coding / dev workflow
+- [ ] Research
+- [ ] Marketing / content
+- [x] Business ops
+- [ ] Sales / CRM
+- [ ] Files / knowledge
+- [x] Automation
+- [ ] Design / media
+- [ ] Skill creation
+
+### 6. Source (optional)
+
+Original concept — eliminates the "scrambling first 20 minutes" of incident response by pre-running standard diagnostics.
+
+### 7. Author (optional)
+
+Jean (@Jemartel)

--- a/use-cases/regulatory-filing-watcher-get-alerted-the-day-a-company-files-with-the-sec-hkex-or-any-regulator/USE_CASE.md
+++ b/use-cases/regulatory-filing-watcher-get-alerted-the-day-a-company-files-with-the-sec-hkex-or-any-regulator/USE_CASE.md
@@ -1,0 +1,96 @@
+### 1. Title
+
+Regulatory Filing Watcher — Get alerted the day a company files with the SEC, HKEX, or any regulator you track
+
+### 2. Example prompt
+
+You are my regulatory filing watcher. You monitor specific regulators for filings by companies I care about and alert me the day something drops — before it hits the news.
+
+When I say "watch filings: [company] — [regulator]" — for example "watch filings: zhipu AI — HKEX" or "watch filings: SpaceX — SEC":
+
+1. `memory_search` for filings/watchlist.md
+2. `memory_write` to add entry: company name, regulator, filing types to watch (S-1, F-1, 10-K, 8-K, A1, prospectus), date added
+3. Confirm: "Now watching [company] filings on [regulator]. I'll check daily and alert you within hours of any new filing."
+
+Create a `routine` via `routine_create` that runs every day at 8:00 AM and 6:00 PM:
+
+1. `memory_search` for the watchlist from filings/watchlist.md
+2. For each watched company/regulator pair:
+   - SEC: `http` to search EDGAR full-text search for new filings by company CIK or name
+   - HKEX: `http` to search HKEXnews for new filings by company name
+   - FCA (UK): `http` to search FCA register
+3. Compare found filings against the last-seen filing stored via `memory_search`
+4. For any NEW filing:
+   - `llm-context` (Brave) to fetch and extract the filing document content
+   - Summarize in 3-5 bullet points: what was filed, why it matters, key numbers, timeline
+   - `memory_write` to save the full summary at filings/[company]/[date]-[type].md
+   - `message` to send Telegram alert
+
+"📋 New Regulatory Filing — [company] on [date]
+
+**Filing type:** [S-1 / A1 / 10-K / prospectus]
+**Regulator:** [SEC / HKEX / FCA]
+**Document:** [link]
+
+**Summary:**
+- IPO registration for [amount] shares at estimated [$X] per share
+- Revenue: [$X] (up Y% YoY), Net loss: [$X]
+- Key risk factors: [top 3]
+- Lead underwriters: [names]
+- Expected listing date: [date if mentioned]
+
+**Why this matters:** [one-line strategic context]
+
+**Compared to last filing:** [if amendment, highlight what changed]"
+
+If nothing new: no message (silent heartbeat).
+
+=== COMMANDS ===
+
+"show watchlist" — `memory_search` for all watched companies with regulators and last-checked date
+"filings: history [company]" — `memory_search` for all past filings found for a company
+"stop watching [company]" — `memory_write` to remove from watchlist
+"filings: compare [company1] [company2]" — `memory_search` to compare recent filing metrics between two companies
+
+### 3. What the agent does
+
+You track companies for investment, competitive intel, or partnership decisions. Their regulatory filings (IPO prospectuses, annual reports, material event disclosures) move markets and signal strategy shifts. By the time a filing hits TechCrunch or Bloomberg, it is already 4-12 hours old and the market has reacted.
+
+The agent checks SEC EDGAR, HKEX, and other regulators twice daily via `routine_create` for any company on your watchlist. When a new filing appears, it fetches the document via `http` + `llm-context`, summarizes the key points, and alerts you via `message` immediately. The agent remembers every filing it has ever surfaced via `memory_write`, so "compare this S-1 to their last 10-K" works because `memory_search` retrieves both documents from workspace memory.
+
+### 4. Skills & tools used
+
+- `http` — scrapes SEC EDGAR full-text search (efts.sec.gov/LATEST), HKEX news search (hkexnews.hk), and other regulator databases for new filings
+- `memory_search` — loads the watchlist and past filing summaries from workspace memory
+- `memory_write` — saves each new filing summary, extracts key financial data, and updates the last-seen timestamp per company
+- `memory_tree` — organizes filings into a browsable directory (filings/[company]/[date]-[type].md)
+- `message` — sends Telegram alerts with filing summary and strategic context within hours of publication
+- `routine_create` — creates the twice-daily (8 AM + 6 PM) check for all watched companies
+- `web-search` (WASM tool, install from hub) — searches for recent regulatory filings by company name when direct EDGAR/HKEX queries need supplementing with news coverage context
+- `llm-context` (WASM tool, install from hub) — fetches pre-extracted content from filing documents and financial news for detailed summary generation
+- `Equity Research` [(hub)](https://hub.ironclaw.com) — interprets financial statements, key metrics, and risk factors in regulatory filings
+- `Competitive Analysis` [(hub)](https://hub.ironclaw.com) — adds strategic context about what a filing signals relative to competitors and market positioning
+- `decision-capture` (built-in skill) — logs investment decisions triggered by filing alerts, tracks outcomes later
+- `trader-setup` (built-in skill) — if the user is onboarded as a trader, integrates filing alerts into the broader trading workflow
+
+### 5. Categories
+
+- [ ] Personal assistant
+- [ ] Web 3 / Crypto
+- [ ] Coding / dev workflow
+- [x] Research
+- [ ] Marketing / content
+- [x] Business ops
+- [ ] Sales / CRM
+- [x] Files / knowledge
+- [x] Automation
+- [ ] Design / media
+- [ ] Skill creation
+
+### 6. Source (optional)
+
+Original concept — the gap between public filing and news coverage is hours, which is an edge for anyone who gets alerted first.
+
+### 7. Author (optional)
+
+Jean (@Jemartel)

--- a/use-cases/vendor-reliability-scorecard-track-every-vendor-freelancer-and-contractor-s-delivery-record-over/USE_CASE.md
+++ b/use-cases/vendor-reliability-scorecard-track-every-vendor-freelancer-and-contractor-s-delivery-record-over/USE_CASE.md
@@ -1,0 +1,106 @@
+### 1. Title
+
+Vendor Reliability Scorecard — Track every vendor, freelancer, and contractor's delivery record over time
+
+### 2. Example prompt
+
+You are my vendor reliability scorecard. Every time I work with a vendor, freelancer, or contractor, you track their performance and give me honest statistics when I'm deciding who to hire next.
+
+When I say "vendor: [name] delivered [what] — [on time/late X days/quality note]" — for example "vendor: AcmeDesign delivered landing page mockups — 3 days late, quality was good":
+
+1. `memory_search` for vendors/scorecard.md
+2. `memory_write` to update or create the vendor entry:
+   - Name, type (freelancer/agency/contractor/SaaS)
+   - Engagement date, deliverable, agreed deadline
+   - Actual delivery date and days late/early
+   - Quality rating (1-5, from my note)
+   - Budget: agreed vs actual
+   - Any issues flagged (communication, scope creep, revision rounds)
+3. Recalculate vendor stats:
+   - On-time delivery rate
+   - Average quality rating
+   - Average budget overrun
+   - Total engagements
+4. Confirm: "Logged [vendor]. Stats updated: on-time [X]%, quality [X]/5, over [X] engagements."
+
+When I say "vendor: compare [name1] [name2] ...":
+
+"📊 Vendor Comparison
+
+| Metric | AcmeDesign | FreelanceBob | DesignStudio |
+|--------|-----------|--------------|-------------|
+| Engagements | 4 | 7 | 2 |
+| On-time rate | 50% | 85% | 100% |
+| Avg quality | 4.2 | 3.5 | 4.8 |
+| Avg budget overrun | 15% | 0% | 5% |
+| Last used | 2 weeks ago | 3 months ago | 6 months ago |
+
+**Recommendation:** For design work, DesignStudio has highest quality but fewest engagements. FreelanceBob is most reliable on time. AcmeDesign's late delivery rate is concerning.
+
+**Pattern alert:** AcmeDesign has been late on 3 of last 4 projects, each time by 2-5 days. Consider backup."
+
+Create a `routine` via `routine_create` that runs on the 1st of every month:
+1. `memory_search` for all vendor entries
+2. Calculate overall reliability trends
+3. Flag vendors whose performance is declining
+4. `message` to send monthly summary
+
+"📋 Monthly Vendor Scorecard — [month]
+
+**Active vendors:** [X]
+**Engagements this month:** [X]
+**On-time delivery rate:** [X]%
+
+⚠️ Declining: AcmeDesign — on-time rate dropped from 75% to 50% over last 3 months
+⭐ Top performers: DesignStudio — 100% on-time, 4.8/5 quality
+💡 Suggestion: You haven't used FreelanceBob in 3 months."
+
+=== COMMANDS ===
+
+"vendor: list" — `memory_search` for all tracked vendors with summary stats
+"vendor: detail [name]" — `memory_search` for full engagement history with timeline
+"vendor: blacklist [name] — [reason]" — `memory_write` to flag vendor as do-not-use
+"vendor: recommend [type of work]" — `memory_search` to rank vendors by suitability
+
+### 3. What the agent does
+
+People are terrible at remembering vendor performance honestly. The freelancer who was late last time? "Oh, they were fine, I think." The agency that delivered great work? You forget to call them first next time. Over months and years, you accumulate a track record that no single person holds in their head.
+
+The agent tracks every engagement via `memory_write`: delivery timing, quality, budget adherence, and issues. It does not sugarcoat — "on-time 50%" means they were late half the time. When you're deciding between three designers, `memory_search` gives you a comparison table with real numbers from your own history, not testimonials.
+
+The monthly summary via `routine_create` catches declining performance early: a vendor who was 90% on-time six months ago and is now 60% is flashing a warning sign.
+
+### 4. Skills & tools used
+
+- `memory_search` — loads all vendor engagement records, historical stats, and blacklist entries from workspace memory
+- `memory_write` — logs each new engagement with timing, quality, and budget data; recalculates aggregates
+- `memory_tree` — organizes vendor data into a browsable structure (vendors/[name]/engagements.md)
+- `routine_create` — creates the monthly scorecard routine that runs on the 1st of each month
+- `message` — sends monthly vendor scorecard summary to Telegram/Slack
+- `gmail` (WASM tool, install from hub) — sends payment reminders or follow-up emails to vendors when engagements are logged
+- `google-sheets` (WASM tool, install from hub) — syncs vendor scorecard data to a shared Google Sheet for team visibility and manual review
+- `delegation-tracker` (built-in skill) — connects vendor engagements to delegated tasks, tracks follow-up timers, and generates nudge reminders when deliverables are overdue
+- `commitment-triage` (built-in skill) — recognizes vendor commitments in conversation and extracts delivery dates, scope, and quality expectations automatically
+- `decision-capture` (built-in skill) — records the rationale behind vendor selection decisions, surfaces past decisions when re-evaluating
+
+### 5. Categories
+
+- [ ] Personal assistant
+- [ ] Web 3 / Crypto
+- [ ] Coding / dev workflow
+- [ ] Research
+- [ ] Marketing / content
+- [x] Business ops
+- [x] Sales / CRM
+- [ ] Files / knowledge
+- [x] Automation
+- [ ] Design / media
+- [ ] Skill creation
+
+### 6. Source (optional)
+
+Original concept — humans forget vendor problems, keep using underperformers, and ignore high performers. Honest statistics fix this.
+
+### 7. Author (optional)
+
+Jean (@Jemartel)


### PR DESCRIPTION
Adds 8 new use cases following the CONTRIBUTING.md spec. All pass `node scripts/validate-use-cases.mjs`.

**New use cases:**

1. **Dependency CVE Sentinel** — Alerts that tell you if you are actually vulnerable, not just that a CVE exists
2. **On-Call Incident First Responder** — Alert fires, agent runs diagnostics before you open your laptop
3. **Regulatory Filing Watcher** — Get alerted the day a company files with the SEC, HKEX, or any regulator you track
4. **Bug Bounty Triager** — New reports auto-reproduced, scored against your attack surface, and queued by priority
5. **Changelog to Release Comms Pipeline** — Repo tags a release, agent drafts release notes, customer email, and tweet thread
6. **Vendor Reliability Scorecard** — Track every vendor, freelancer, and contractor delivery record over time
7. **Grant/Funding Deadline Tracker** — Monitor grant databases, match eligibility, alert on deadlines
8. **Cold Outreach Researcher** — Research a prospect, draft outreach referencing the last 48 hours

Each use case references IronClaw built-in tools (`shell`, `http`, `memory_write`, `memory_read`, `grep`, `read_file`, `routine_create`, `event_emit`, `create_job`, `message`), WASM extension tools (`web-search`, `llm-context`, `github`, `gmail`, `google-docs`, `google-sheets`, `google-slides`, `portfolio`, `slack`, `wazuh`), and Hub skills annotated with `[(hub)](https://hub.ironclaw.com)`.
