### PR TITLE
Add use case: Dependency CVE Sentinel

### DIFF
--- a/use-cases/dependency-cve-sentinel-alerts-that-tell-you-if-you-re-actually-vulnerable-not-just-that-a-cve-e/USE_CASE.md
+++ b/use-cases/dependency-cve-sentinel-alerts-that-tell-you-if-you-re-actually-vulnerable-not-just-that-a-cve-e/USE_CASE.md
@@ -1,0 +1,91 @@
+### 1. Title
+
+Dependency CVE Sentinel — Alerts that tell you if you're actually vulnerable, not just that a CVE exists
+
+### 2. Example prompt
+
+You are my dependency security analyst. Dependabot spams me with CVEs — most are in transitive deps I never call. Your job is to tell me which ones actually matter for my codebase.
+
+When I say "cve: check" or when a new CVE alert fires:
+
+1. Read the current dependency tree: `shell` runs `npm ls`, `cargo tree`, or `go mod graph` (whichever exists in the workspace)
+2. Fetch the CVE details using `web-search` (Brave): affected versions, severity, attack vector, what function/path is vulnerable
+3. Read the actual source code that imports the affected dependency using `read_file` and `grep`
+4. Determine if the vulnerable codepath is reachable:
+   - Does my code call the affected function/class directly?
+   - Does any direct dependency call it in a way my code triggers?
+   - Is it only reachable through a feature flag or optional import I don't use?
+5. Classify each CVE into one of four buckets:
+   - **EXPLOITABLE** — vulnerable codepath is directly reachable in my code
+   - **CONDITIONAL** — reachable only through a specific feature flag, config, or indirect path
+   - **TRANSITIVE NOISE** — the dep is in my tree but the vulnerable path is never called
+   - **NOT AFFECTED** — my version is outside the affected range
+6. Save the triage result to workspace memory using `memory_write` at security/cve-triage.md with date, CVE ID, and verdict
+7. Send Telegram alert via `message` only for EXPLOITABLE and CONDITIONAL items
+
+"🔒 CVE Triage — [date]
+
+🔴 EXPLOITABLE:
+- CVE-2026-1234 (lodash <4.17.22, CVSS 9.1) — prototype pollution in mergeWith, called directly in src/utils/deepMerge.ts:42. Upgrade lodash to >=4.17.22.
+
+🟡 CONDITIONAL:
+- CVE-2026-5678 (express <4.19, CVSS 7.5) — open redirect in res.redirect, reachable only if admin panel feature flag is enabled (currently disabled). Low urgency.
+
+⚪ TRANSITIVE NOISE (4 CVEs silenced): lodash, express, axios, debug. None reach vulnerable codepaths in this project. Full list in security/cve-triage.md."
+
+Create a `routine` that runs every Monday at 7:00 AM via `routine_create`:
+1. `shell` to check for new CVEs affecting the project's dependencies (npm audit, cargo audit, etc.)
+2. Re-run reachability analysis for any new findings
+3. `message` to alert only on actionable items
+
+=== COMMANDS ===
+
+"cve: status" — `memory_search` for current triage summary with counts by bucket
+"cve: detail [CVE-ID]" — `memory_search` for full analysis of a specific CVE
+"cve: false positive [CVE-ID]" — `memory_write` to mark as permanently ignored with reason
+"show cve history" — `memory_search` for all triaged CVEs with dates and verdicts
+
+### 3. What the agent does
+
+Dependabot, Snyk, and every other scanner tell you "you have a CVE in your dependency tree." They are wrong 80% of the time — the vulnerable function exists in the package but your code never calls it. The result is alert fatigue: developers ignore all CVE notifications, including the real ones.
+
+This agent reads the CVE, reads your actual source code via `read_file` and `grep`, and traces whether the vulnerable codepath is reachable. A prototype pollution in lodash's mergeWith is EXPLOITABLE only if you call mergeWith — if you only use lodash for get and set, it is TRANSITIVE NOISE. The agent makes this distinction for every CVE, saves the reasoning to `memory_write`, and only bothers you when something is actually exploitable.
+
+It composes `code-review` for codepath analysis, `application-security` for vulnerability pattern understanding, and `memory_write`/`memory_search` so triaged CVEs don't resurface. Over time it builds a project-specific risk profile: "this project has 12 CVEs in its tree but only 2 are exploitable, both in the auth module."
+
+### 4. Skills & tools used
+
+- `shell` — runs dependency tree commands (`npm ls`, `cargo tree`, `go mod graph`) and audit tools (`npm audit`, `cargo audit`) to list affected packages and versions
+- `read_file` — reads source files that import the affected dependency to trace actual usage
+- `grep` — searches the entire codebase for calls to the vulnerable function/class across all files
+- `glob` — locates lock files (package-lock.json, Cargo.lock, go.sum) and config files to understand the dependency tree
+- `memory_search` — loads past CVE triage decisions and false-positive markings from workspace memory
+- `memory_write` — saves each triage result with CVE ID, verdict, reachability reasoning, and date
+- `routine_create` / `routine_fire` — creates a weekly Monday 7 AM routine to re-check for new CVEs and re-triage
+- `message` — sends Telegram alerts with only actionable (EXPLOITABLE / CONDITIONAL) items
+- `web-search` (WASM tool, install from hub) — fetches CVE details from NVD, GitHub Advisory Database, or MITRE: severity, affected versions, attack vector
+- `llm-context` (WASM tool, install from hub) — fetches pre-extracted content from CVE database pages for detailed vulnerability descriptions when search summaries are insufficient
+- `Code Review` [(hub)](https://hub.ironclaw.com) — traces import chains and function call graphs to determine if vulnerable codepaths are reachable from the project's source code
+- `Application Security` [(hub)](https://hub.ironclaw.com) — understands CVE severity, attack vectors, exploitability conditions, and what the vulnerable function actually does
+
+### 5. Categories
+
+- [ ] Personal assistant
+- [ ] Web 3 / Crypto
+- [x] Coding / dev workflow
+- [ ] Research
+- [ ] Marketing / content
+- [ ] Business ops
+- [ ] Sales / CRM
+- [ ] Files / knowledge
+- [x] Automation
+- [ ] Design / media
+- [ ] Skill creation
+
+### 6. Source (optional)
+
+Original concept — addresses CVE alert fatigue by adding codepath reachability analysis on top of existing vulnerability scanners.
+
+### 7. Author (optional)
+
+Jean (@Jemartel)


### PR DESCRIPTION
Adds the **Dependency CVE Sentinel** use case following the CONTRIBUTING.md spec. Alerts that tell you if you're actually vulnerable, not just that a CVE exists.

Closes #98