### PR TITLE
(usecase): watch support channel and draft team-approved replies

### DIFF
--- a/use-cases/watch-support-channel-and-draft-team-approved-replies/USE_CASE.md
+++ b/use-cases/watch-support-channel-and-draft-team-approved-replies/USE_CASE.md
@@ -1,0 +1,41 @@
+### 1. Title
+
+Watch support channel and draft team-approved replies
+
+### 2. Example prompt
+
+"Monitor any Telegram support group, and for every new question or feedback, draft a friendly reply in any brand voice and drop it in a common team group to approve before it goes out."
+
+### 3. What the agent does
+
+Watches any Telegram or Discord support channel for new messages. When a question, issue report, or feedback comes in, it drafts a friendly, on-brand reply using the configured tone guidelines, then posts the draft to a designated internal team group for a human to approve or edit before it goes out. Useful for any organization with a busy support channel that wants to keep response quality high without slowing down the team.
+
+### 4. Skills & tools used
+
+- Telegram Monitor tool — listens for new messages in any specified Telegram channel or group
+- Discord tool — same monitoring capability for Discord servers
+- Brand Voice skill — drafts replies in any configured tone and style
+- Telegram / Discord Send tool — posts the draft to the internal approval group
+- Human-in-the-loop approval flow — holds the reply until a team member approves before sending
+
+### 5. Categories
+
+- [ ] Personal assistant
+- [ ] Web 3 / Crypto
+- [ ] Coding / dev workflow
+- [ ] Research
+- [ ] Marketing / content
+- [x] Business ops
+- [ ] Sales / CRM
+- [ ] Files / knowledge
+- [x] Automation
+- [ ] Design / media
+- [ ] Skill creation
+
+### 6. Source (optional)
+
+_No response_
+
+### 7. Author (optional)
+
+Halfblood


### PR DESCRIPTION
## Summary

Adds a new use case: "Watch support channel and draft team-approved replies" — monitors any Telegram or Discord support channel, drafts on-brand replies for each new message, and posts them to an internal team group for approval before sending.

## Closes

## Type

- [x] Use case
- [ ] New tool
- [ ] New skill
- [ ] Bug fix