### PR TITLE
add use case: turn support tickets into help articles

### DIFF
--- a/use-cases/turn-support-tickets-into-help-articles/USE_CASE.md
+++ b/use-cases/turn-support-tickets-into-help-articles/USE_CASE.md
@@ -1,0 +1,40 @@
+### 1. Title
+
+Turn support tickets into help articles
+
+### 2. Example prompt
+
+"Review this week's repeated support tickets and draft help center articles for the questions customers keep asking."
+
+### 3. What the agent does
+
+Pulls tickets from your helpdesk (Zendesk, Intercom, Freshdesk, or email inbox), clusters repeated questions by topic, and identifies gaps in your existing documentation. For each recurring issue it drafts a polished help center article — with a suggested title, tags, and recommended placement in your knowledge base — ready for a human to review and publish.
+
+### 4. Skills & tools used
+
+- Helpdesk connector (Zendesk / Intercom / Freshdesk MCP) — reads and queries open and closed support tickets
+- Duplicate Question Clustering — groups semantically similar tickets to surface the most common pain points
+- Knowledge Base Writer skill — drafts clear, on-brand help articles from clustered ticket content
+- Document Export tool — packages finished articles as Markdown or HTML files ready for upload
+
+### 5. Categories
+
+- [ ] Personal assistant
+- [ ] Web 3 / Crypto
+- [ ] Coding / dev workflow
+- [ ] Research
+- [ ] Marketing / content
+- [x] Business ops
+- [ ] Sales / CRM
+- [x] Files / knowledge
+- [x] Automation
+- [ ] Design / media
+- [ ] Skill creation
+
+### 6. Source (optional)
+
+_No response_
+
+### 7. Author (optional)
+
+Halfblood


### PR DESCRIPTION
## Summary

Adds a use case for automatically clustering repeated support tickets and drafting help center articles from them.

## Closes

Closes #

## Type

- [x] Use case