### PR TITLE
add use case: extract risky contract clauses

### DIFF
--- a/use-cases/extract-risky-contract-clauses/USE_CASE.md
+++ b/use-cases/extract-risky-contract-clauses/USE_CASE.md
@@ -1,0 +1,40 @@
+### 1. Title
+
+Extract risky contract clauses
+
+### 2. Example prompt
+
+"Read these vendor contracts and flag any auto-renewal, termination, liability, exclusivity, and payment penalty clauses."
+
+### 3. What the agent does
+
+Reads uploaded contracts (PDF or Word), extracts key legal clauses, and summarizes each one in plain English with a risk rating. It builds a side-by-side comparison table across multiple contracts, highlights missing standard clauses, and flags unusual or high-risk terms — giving you a clear picture of what you're agreeing to before you sign.
+
+### 4. Skills & tools used
+
+- PDF / Document Parser tool — reads and parses uploaded contract files (PDF or DOCX)
+- Contract Clause Extractor skill — identifies and summarizes auto-renewal, termination, liability, exclusivity, IP, and payment penalty clauses
+- Risk Review skill — flags unusual, one-sided, or high-risk terms with plain-English explanations
+- Spreadsheet tool (xlsx) — produces a comparison table of clauses across multiple contracts
+
+### 5. Categories
+
+- [ ] Personal assistant
+- [ ] Web 3 / Crypto
+- [ ] Coding / dev workflow
+- [ ] Research
+- [ ] Marketing / content
+- [x] Business ops
+- [ ] Sales / CRM
+- [x] Files / knowledge
+- [x] Automation
+- [ ] Design / media
+- [ ] Skill creation
+
+### 6. Source (optional)
+
+_No response_
+
+### 7. Author (optional)
+
+Halfblood


### PR DESCRIPTION
## Summary

Adds a use case for reading uploaded contracts, extracting key clauses, and flagging risky or unusual terms in plain English with a comparison table.

## Closes

Closes #

## Type

- [x] Use case