### PR TITLE
add use case: build onboarding packs for new hires

### DIFF
--- a/use-cases/build-onboarding-packs-for-new-hires/USE_CASE.md
+++ b/use-cases/build-onboarding-packs-for-new-hires/USE_CASE.md
@@ -1,0 +1,40 @@
+### 1. Title
+
+Build onboarding packs for new hires
+
+### 2. Example prompt
+
+"Create an onboarding pack for our new designer: accounts to create, docs to read, people to meet, and first-week tasks."
+
+### 3. What the agent does
+
+Reads the role, team, and start date, then pulls relevant internal docs and org context. It generates a role-specific first-week plan with day-by-day tasks, builds an access checklist (tools, accounts, permissions), schedules intro meetings with key teammates, and assembles everything into a clean onboarding doc ready to share with the new hire before day one.
+
+### 4. Skills & tools used
+
+- HR Onboarding skill — generates role-specific onboarding plans, task lists, and people-to-meet sections
+- Google Calendar / Calendar MCP — schedules intro meetings with relevant teammates during the first week
+- Google Drive / Docs MCP — finds and links internal docs, wikis, and resources relevant to the role
+- Access Request / Password Manager tool — produces a checklist of accounts and permissions to provision
+
+### 5. Categories
+
+- [x] Personal assistant
+- [ ] Web 3 / Crypto
+- [ ] Coding / dev workflow
+- [ ] Research
+- [ ] Marketing / content
+- [x] Business ops
+- [ ] Sales / CRM
+- [x] Files / knowledge
+- [x] Automation
+- [ ] Design / media
+- [ ] Skill creation
+
+### 6. Source (optional)
+
+_No response_
+
+### 7. Author (optional)
+
+Halfblood


### PR DESCRIPTION
## Summary

Adds a use case for generating role-specific onboarding packs: first-week plans, access checklists, intro meetings, and curated internal docs — assembled before day one.

## Closes

Closes #

## Type

- [x] Use case