### PR TITLE
add use case: remind me when government documents need renewal

### DIFF
--- a/use-cases/remind-me-when-government-documents-need-renewal/USE_CASE.md
+++ b/use-cases/remind-me-when-government-documents-need-renewal/USE_CASE.md
@@ -1,0 +1,39 @@
+### 1. Title
+
+Remind me when government documents need renewal
+
+### 2. Example prompt
+
+"Track my passport, driving license, insurance, and ID expiry dates. Remind me before renewal."
+
+### 3. What the agent does
+
+Scans uploaded document photos or PDFs using OCR/Vision, extracts the expiry dates, and builds a personal renewal tracker. It creates calendar reminders at configurable lead times — for example, 6 months before a passport expires, 30 days before insurance renewal — so you're never caught off guard. It can also suggest which documents to renew together to save trips.
+
+### 4. Skills & tools used
+
+- Document Expiry Tracker skill — identifies document type and extracts expiry dates from passports, driving licenses, insurance cards, national IDs, and similar documents
+- OCR / Vision tool — reads text from uploaded photos or scanned PDFs of documents
+- Calendar tool — schedules renewal reminders at configurable lead times (e.g. 6 months, 30 days, 1 week before expiry)
+
+### 5. Categories
+
+- [x] Personal assistant
+- [ ] Web 3 / Crypto
+- [ ] Coding / dev workflow
+- [ ] Research
+- [ ] Marketing / content
+- [ ] Business ops
+- [ ] Sales / CRM
+- [x] Files / knowledge
+- [x] Automation
+- [ ] Design / media
+- [ ] Skill creation
+
+### 6. Source (optional)
+
+_No response_
+
+### 7. Author (optional)
+
+Halfblood


### PR DESCRIPTION
## Summary

Adds a use case for tracking government document expiry dates (passport, driving license, insurance, ID) using OCR and scheduling reminders before renewal deadlines.

## Closes

Closes #

## Type

- [x] Use case