### PR TITLE
feat(skills): add pr-triage-digest — prioritized GitHub review queue across one or more repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Use cases, WASM tools, and SKILL.md skills for the IronClaw agent runtime.
 - `tools/whatsapp`. WhatsApp Cloud API via the Meta Graph API. Send messages (text, template, image, video, document, audio, location, contacts, interactive buttons and lists, reactions, read receipts), manage the business profile, read phone number metadata, and manage message templates. Permanent system-user access token via Bearer.
 - `tools/nova-submit`. Self-contained submission tool for IronClaw Hackathon: based on NOVA decentralized file-sharing, it allows the agent to submit to the hackathon in one command using the ironclaw-hackathon skill. Replicable by all NEAR Legion city nodes or any IronClaw hackathon organizer.
 - `skills/microsoft-365-workflow`. Business workflow patterns for the agent when operating inside the Microsoft 365 surface.
+- `skills/pr-triage-digest`. Cross-repo GitHub PR triage. Scores every open PR on CI, mergeability, staleness, size, and review state, then emits a single ranked digest grouped into Blockers, Quick wins, First contributors, Aging, and Normal. Silent-tier; uses the built-in `http` tool — no new tool dependency. Ships a deterministic Node.js reference implementation.
 
 See `tracking.md` for the full status table.
 

--- a/skills/pr-triage-digest/README.md
+++ b/skills/pr-triage-digest/README.md
@@ -1,0 +1,49 @@
+# pr-triage-digest
+
+> Triage open GitHub PRs across one or more repos. Score each on CI, mergeability, staleness, size, and review state. Emit a single ranked digest grouped into Blockers, Quick wins, First contributors, Aging, and Normal.
+
+This skill answers the question every maintainer has every morning: **what should I review first?** The GitHub UI sorts by recency or opens a flat list. This skill ranks across repos, surfaces blockers and stale work, and respects the rate budget so it never hangs mid-fan-out.
+
+- **Trunk:** built-in `http` tool — no new tool dependency.
+- **Tier:** silent (read-only). Never comments, labels, closes, or merges.
+- **Composability:** designed to be called by `chief-of-staff` for the morning briefing's "Code activity" section in compact mode.
+
+## What's in this directory
+
+```
+skills/pr-triage-digest/
+├── SKILL.md                # The skill prompt (source of truth)
+├── README.md               # This file
+└── reference/
+    └── triage.mjs          # Deterministic Node.js reference implementation
+```
+
+The SKILL.md prompt is canonical. `reference/triage.mjs` exists so the logic is
+reproducible without an LLM — useful for testing, partners porting the
+behavior, and verifying the digest format in CI.
+
+## Demo
+
+```sh
+# Anonymous (60 req/hr) — fine for one or two small repos
+node skills/pr-triage-digest/reference/triage.mjs nearai/ironhub
+
+# Authed (5000 req/hr) — recommended for cross-repo or busy repos
+GITHUB_TOKEN=ghp_... node skills/pr-triage-digest/reference/triage.mjs \
+  nearai/ironhub nearai/ironclaw
+```
+
+See `reference/sample-output.md` for a real digest captured against
+`nearai/ironhub`.
+
+## Scoring at a glance
+
+| Dimension | Best (0) | Worst (4) |
+|---|---|---|
+| CI status | all green | failing |
+| Mergeability | mergeable | conflicts |
+| Staleness | ≤ 2 days idle | > 30 days idle |
+| Size | ≤ 50 LOC, ≤ 2 files | > 2000 LOC or > 30 files |
+| Review state | approved | changes requested |
+
+Full rubric and bucketing rules in `SKILL.md`.

--- a/skills/pr-triage-digest/SKILL.md
+++ b/skills/pr-triage-digest/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: pr-triage-digest
+version: 1.0.0
+description: Triage open GitHub pull requests across one or more repositories and produce a prioritized, bucketed review digest. Scores each PR on CI status, mergeability, staleness, size, and review state, then groups them into Blockers, Quick wins, First contributors, Aging, and Normal so the reviewer knows what to look at first instead of paging through the GitHub UI. Read-only — never comments, labels, closes, or merges.
+activation:
+  keywords:
+    - "pr triage"
+    - "triage prs"
+    - "triage pull requests"
+    - "review queue"
+    - "review backlog"
+    - "pr digest"
+    - "pr backlog"
+    - "open prs"
+    - "open pull requests"
+    - "github inbox"
+    - "github queue"
+    - "morning prs"
+    - "merge queue"
+    - "what should I review"
+    - "what to review"
+    - "prioritize prs"
+    - "prioritise prs"
+    - "review priorities"
+    - "code review queue"
+  patterns:
+    - "(?i)triage\\s+(my\\s+|the\\s+|open\\s+|all\\s+)?(open\\s+)?(pull\\s+requests?|prs?)"
+    - "(?i)(what|which)\\s+prs?\\s+(should\\s+I\\s+)?review"
+    - "(?i)(prioritize|prioritise|rank|sort|order)\\s+(my\\s+|the\\s+)?(open\\s+)?prs?"
+    - "(?i)(review|pr)\\s+(queue|backlog|inbox|digest)"
+    - "(?i)open\\s+prs?\\s+(across|in|on|for)\\s+"
+    - "(?i)(blocked|stale|aging|aged)\\s+prs?"
+  tags:
+    - "github"
+    - "code-review"
+    - "triage"
+    - "developer-workflow"
+    - "productivity"
+    - "engineering"
+  exclude_keywords:
+    - "merge this pr"
+    - "approve pr"
+    - "close pr"
+    - "comment on pr"
+    - "write a pr"
+    - "create a pr"
+  max_context_tokens: 4000
+requires:
+  bins: []
+  env: []
+---
+
+## Persona
+
+The agent is a senior reviewer's morning radar. The user is a maintainer, tech lead, or staff engineer who watches one or more repos and is responsible for keeping the review queue moving without burning their own focus time. The agent does not write code, does not approve, and does not comment on PRs. It looks at what is open, decides what matters most this hour, and tells the user — and stops.
+
+Default mode is **terse, ranked, and actionable**. The user opens the digest, picks one bucket, opens those PRs in tabs, and starts reviewing. Every word the agent writes that does not help that loop is waste.
+
+## When to Use
+
+- **Morning triage.** The user opens their day and wants a one-screen answer to "what should I review first."
+- **Cross-repo backlog.** The user owns multiple repos and the GitHub UI cannot rank across them. The digest unifies them.
+- **Stale-PR sweep.** Before a release or end-of-week, the user wants to find PRs that have been sitting for more than two weeks.
+- **First-contributor triage.** The user wants to be polite to new contributors and prioritize PRs from authors who have not landed code in this repo before.
+- **Composable inside `chief-of-staff`.** When a chief-of-staff morning briefing needs a "code activity" section, this skill produces it as a single sub-call.
+
+## Do NOT Use This Skill For
+
+- **Reviewing the code itself.** This skill ranks; it does not read diffs and form opinions on correctness. Use the agent's normal review flow once the user opens the PR.
+- **Writing comments or approving.** Those are mutating actions in the wrong tier. Refuse and route the user to do it themselves.
+- **Filing new PRs.** Out of scope; that is a `github` tool action, not a triage skill.
+- **Issue triage.** Issues need a different signal set (reproduction steps, labels, age vs. severity). A sibling `issue-triage-digest` skill is the right shape; this one is for PRs.
+
+## Required Tools
+
+This skill uses one tool surface — the built-in `http` tool. It calls the GitHub REST API v3 directly. No new tool dependency.
+
+Endpoints used:
+
+- `GET /repos/{owner}/{repo}/pulls?state=open&per_page=100&page=N` — paginated list of open PRs.
+- `GET /repos/{owner}/{repo}/pulls/{number}` — enriched detail (mergeable flag, additions, deletions, changed files, requested reviewers, labels).
+- `GET /repos/{owner}/{repo}/commits/{head_sha}/check-runs` — combined check-run status for the PR head.
+- `GET /repos/{owner}/{repo}/pulls/{number}/reviews` — review states (only when needed to disambiguate).
+- `GET /search/issues?q=author:USER+repo:owner/repo+type:pr+is:merged` — first-contributor detection.
+- `GET /rate_limit` — pre-flight before bulk enrichment.
+
+## Pre-Flight: Auth and Rate Budget
+
+Before any enrichment fan-out, do two things:
+
+1. **Resolve auth.** Probe in this order: `GITHUB_TOKEN`, then `GH_TOKEN`, then `github_access_token` from the secret store. If any is present, send it as `Authorization: Bearer <token>` on every request. If none is present, run unauthenticated and warn the user once in the digest footer.
+2. **Check the rate budget.** Call `GET /rate_limit` and read `resources.core.remaining`. Anon = 60/hr, authed = 5000/hr. The list-PRs call is 1 request per page; each PR enrichment is 1 to 3. Compute a hard ceiling:
+
+   ```
+   max_prs_to_enrich = (remaining - 5) / 3
+   ```
+
+   The `-5` is a safety buffer for the search-based first-contributor lookup. If the count of open PRs exceeds this ceiling, enrich the most signal-dense ones first (see the priority order below) and emit a footer: `Enriched 32 of 47 PRs (rate budget). Re-run with auth for the full digest.`
+
+If a credential is missing, **do not** prompt the user mid-flow to add one. Run with what is present and surface the limitation in the digest. Approval-tier behavior matters here — see the `chief-of-staff` skill — and triage should never block on a credential request.
+
+## Inputs
+
+The skill accepts one of:
+
+- A single repo: `owner/repo`.
+- A list: `["owner/repo", "owner/other-repo"]`.
+- An owner with a `*` wildcard: `owner/*` — resolves to all public repos via `GET /users/{owner}/repos?per_page=100&sort=pushed`, capped at the first 10 by `pushed_at` descending to keep the fan-out bounded.
+- An optional `since` filter (default 30 days): exclude PRs whose `updated_at` is older than `now - since` AND have zero open reviews. Older-than-30 abandoned PRs are noise.
+
+If the user says "my repos" or "the repos I review", resolve to the union of repos where the authenticated user is `OWNER`, `MAINTAINER`, or `WRITE` via `GET /user/repos?per_page=100&affiliation=owner,collaborator,organization_member` — but only when authed. Anon mode requires explicit repo names.
+
+## Scoring Model
+
+Each PR gets a per-dimension subscore from 0 (best) to 4 (worst). The skill does not need to be precise; consistent ordering is enough.
+
+| Dimension | 0 | 1 | 2 | 3 | 4 |
+|---|---|---|---|---|---|
+| **CI status** | all green | none configured | pending | flaky (mixed) | failing |
+| **Mergeability** | mergeable | unknown | — | — | conflicts (`mergeable: false`) |
+| **Staleness** | ≤ 2 days since `updated_at` | 3–7 | 8–14 | 15–30 | > 30 |
+| **Size** | ≤ 50 LOC, ≤ 2 files | ≤ 200, ≤ 5 | ≤ 500, ≤ 10 | ≤ 2000, ≤ 30 | > 2000 or > 30 files |
+| **Review state** | approved, no requested changes | one approval | none yet | requested-changes recorded | conflicts with requested-reviewers list |
+
+Bucketing rules — evaluated in order, first match wins:
+
+1. **Blockers.** Any of: CI = 4 (failing), Mergeability = 4 (conflicts), or label contains `security` / `incident` / `priority:high`.
+2. **First contributors.** Author has zero prior merged PRs in this repo (use the search endpoint, cache per author per repo for the run).
+3. **Quick wins.** Size ≤ 1, CI ≤ 1, Mergeability = 0, Review state ≤ 2. These are 5-minute reviews.
+4. **Aging.** Staleness ≥ 3 AND review state ≤ 2.
+5. **Normal.** Everything else.
+
+Within a bucket, sort by `total_score = ci + mergeability + staleness + size + review_state`, ascending (lowest = easiest to act on).
+
+## Output Format
+
+Lead line, then one bucket per heading, then a footer. Max one screen on a phone. No preamble.
+
+```
+**TL;DR** 47 open PRs across nearai/ironhub + nearai/ironclaw · 3 blockers · 8 quick wins · 2 first-time contributors · 4 aging · 30 normal.
+
+### 🚨 Blockers
+- nearai/ironhub#221 · Bump tokio breaks polymarket build · @octocat · 2d · ❌ CI · +312/-44 · changes-requested
+- nearai/ironclaw#1894 · Race in router under load · @secbot · 4d · ❌ CI · +28/-12 · merge-conflicts
+
+### ⚡ Quick wins
+- nearai/ironhub#234 · Typo in tracking.md · @docs-bot · 6h · ✅ CI · +1/-1 · no-reviews
+- nearai/ironclaw#1901 · Tighten clippy on workers crate · @julien · 1d · ✅ CI · +18/-9 · approved-once
+
+### 👋 First contributors
+- nearai/ironhub#230 · Add hedera-rpc tool stub · @new-dev-42 · 3d · ⏳ CI · +482/-0 · no-reviews
+
+### 🕰 Aging
+- nearai/ironclaw#1770 · Refactor secret_list error paths · @brandon · 22d (idle 14d) · ✅ CI · +96/-71 · approved-once
+
+### 📋 Normal
+- nearai/ironhub#228 · Add gitlab merge-request comments action · @kent · 4d · ✅ CI · +204/-3 · one-review
+
+_Auth: github_access_token from secret store. Enriched 41/41 PRs. Budget: 4912/5000 remaining._
+```
+
+Row rules:
+
+- One line per PR. Wrapping is the renderer's problem, not yours.
+- Title truncated to 60 characters with `…` if cut. Backticks around `code` in titles only if the title already used them.
+- Age in compact form: `Xh`, `Xd`, or `Xw`. If aging bucket, append `(idle Yd)`.
+- CI glyph: `✅` green · `❌` failing · `⏳` pending · `⚠️` mixed · `—` no checks configured.
+- Show `+A/-D` lines changed; never the file count unless > 30 (then append ` · 47 files`).
+- Review state shorthand: `no-reviews`, `one-review`, `approved-once`, `approved-2`, `changes-requested`, `merge-conflicts`.
+- Drop a bucket entirely if it would be empty. Do not write "No blockers."
+
+If the TL;DR would say "0 open PRs" — write `No open PRs across the requested repos. Inbox zero.` and stop. The user does not want a six-line footer.
+
+## Approval Tier
+
+This skill is **silent-tier** for every action it takes (read-only HTTP GETs). It never falls into the draft or explicit tier because it never mutates state.
+
+If the user follows the digest with "approve #221" or "comment on #234", do not handle it here. Hand the request to the `github` tool's typed action with the normal draft-first protocol used elsewhere.
+
+## Caching Discipline
+
+Within a single skill invocation:
+
+- Cache `is_first_contributor(author, repo)` results in a per-run map. The same author across multiple PRs in the same repo is one lookup.
+- Cache the per-repo `pushed_at` ceiling so the wildcard resolver does not re-paginate.
+- Do not persist anything across invocations. The next morning the user wants a fresh read.
+
+Between invocations on the same conversation:
+
+- If the user just ran the digest and asks "what about ironclaw only," do not re-fetch ironhub. Filter the prior result and re-emit. Save the user a 30-second round trip and a chunk of the rate budget.
+
+## Failure Modes
+
+| Condition | Behavior |
+|---|---|
+| `GET /pulls` returns 404 | Repo does not exist or is private and we are unauthed. Skip with one footer line: `nearai/ironhub: not accessible. Skipped.` |
+| `GET /rate_limit` says `remaining = 0` | Refuse to fan-out. Emit: `GitHub rate-limited until HH:MM UTC. Re-run after that.` |
+| Auth token is invalid | One retry without auth. If that fails on a private repo, surface and stop. |
+| One PR's enrichment call fails | Skip that PR's enrichment, score it on what the list call returned, mark it with `?` in the CI column. |
+| Wildcard resolves to 0 repos | Say so explicitly: `owner/* matched no public repos.` |
+
+The digest must always finish. Partial output beats a thrown error every time.
+
+## Composition
+
+This skill is meant to be called as a sub-step by `chief-of-staff` for the "Code activity" section of the morning briefing. When that happens:
+
+- Cap output at 6 PRs total (top 2 blockers + top 2 quick wins + top 2 aging).
+- Drop the footer.
+- The parent skill prepends a single-line `## Code activity` header.
+
+Detect this mode by the presence of `compact: true` in the invocation context. Default is full-width.
+
+## Routing
+
+| Intent | Goes to |
+|--------|---------|
+| "Triage my PRs" | This skill. |
+| "Approve #221" / "Comment on #221" | `github` tool typed actions (draft-first). |
+| "Why is CI failing on #221" | `github` tool — fetch the failed check-run logs, then summarize. |
+| "Write a new PR for X" | Out of scope. Decline politely; that needs branch + diff + write access. |
+| "Triage issues" | Out of scope here. Defer to a future `issue-triage-digest`. |
+
+## Reference Implementation
+
+A deterministic reference implementation in JavaScript lives at `skills/pr-triage-digest/reference/triage.mjs`. It demonstrates the exact paging, scoring, bucketing, and rendering rules above and runs as a one-shot CLI (`node triage.mjs nearai/ironhub nearai/ironclaw`). The skill prompt is the source of truth; the reference is illustrative — useful for testing, for partners porting the logic to a different runtime, and for the agent to mirror line-for-line when producing the final digest.

--- a/skills/pr-triage-digest/reference/sample-output.md
+++ b/skills/pr-triage-digest/reference/sample-output.md
@@ -1,0 +1,183 @@
+# Sample output
+
+Generated 2026-06-16 against the real `nearai/ironhub` + `nearai/ironclaw` repos using an authed GitHub token.
+
+```md
+**TL;DR** 164 open PRs across nearai/ironhub + nearai/ironclaw · 60 blockers · 20 quick wins · 20 first-time contributors · 9 aging · 55 normal.
+
+### 🚨 Blockers
+- nearai/ironclaw#4943 · feat(reborn): auto-wire Google OAuth in run-reborn-webui.sh · @thisisjoshford · <1d · ❌ CI · +43/-0 · no-reviews
+- nearai/ironclaw#3705 · chore(deps): bump rand from 0.8.5 to 0.8.6 in /channels-src… · @dependabot[bot] · 4w · ❌ CI · +2/-2 · no-reviews
+- nearai/ironclaw#4498 · build(deps): bump serde_yml from 0.0.12 to 0.0.13 in the se… · @dependabot[bot] · 2w · ❌ CI · +32/-34 · no-reviews
+- nearai/ironclaw#4691 · feat(cli): add config validate for blueprints · @loopstring · 6d · ❌ CI · +282/-0 · no-reviews
+- nearai/ironclaw#4905 · [codex] Gate operator logs in WebUI v2 · @krishna-505 · 1d · ❌ CI · +64/-19 · no-reviews
+- nearai/ironclaw#3942 · refactor(trace): PilotAllowlist enum + caller-level error-b… · @zmanian · 3w · ✅ CI · +160/-74 · no-reviews
+- nearai/ironclaw#4567 · [hooks] Record hook quarantine in durable audit · @zmanian · 1w · ✅ CI · +370/-36 · no-reviews
+- nearai/ironclaw#4641 · fix(extensions/gsuite): default calendar list_events to upc… · @BenKurrek · 1w · ❌ CI · +91/-2 · no-reviews
+- nearai/ironclaw#4975 · reborn(learning) WS-3: lightweight reflection service · @serrrfirat · <1d · ❌ CI · +726/-5 · no-reviews
+- nearai/ironclaw#3584 · fix(mission): route outcome notifications to originating ch… · @italic-jinxin · 5w · ❌ CI · +1419/-28 · no-reviews
+- nearai/ironclaw#4941 · feat(tools): add Slack personal (user-token) tool · @sergeiest · <1d · ❌ CI · +732/-0 · no-reviews
+- nearai/ironclaw#3708 · chore: release · @ironclaw-ci[bot] · 4w · ❌ CI · +92/-30 · no-reviews
+- nearai/ironclaw#4906 · test: live-tier + multi-gate sequence coverage for resume-o… · @henrypark133 · 1d · ✅ CI · +1224/-18 · no-reviews
+- nearai/ironclaw#4584 · refactor(host_api): centralize system-sentinel id minting a… · @matiasbenary · 1w · ❌ CI · +303/-21 · changes-requested
+- nearai/ironclaw#4777 · [codex] Persist Slack connected state in WebUI · @serrrfirat · 5d · ✅ CI · +1162/-201 · no-reviews
+- nearai/ironclaw#4765 · [codex] Fix subagent inline prompt body budget · @serrrfirat · 5d · ✅ CI · +164/-75 · no-reviews
+- nearai/ironclaw#4756 · fix(triggers): surface validation errors and clarify trigge… · @henrypark133 · 5d · ✅ CI · +438/-29 · no-reviews
+- nearai/ironclaw#4583 · feat(llm): NormalizingProvider Layer-3 decorator (RC3/M9 Ph… · @henrypark133 · 1w · ❌ CI · +519/-4 · approved-once
+- nearai/ironclaw#4653 · feat(cli): non-interactive tool setup with --secret flag · @Kampouse · 1w · ❌ CI · +230/-8 · no-reviews
+- nearai/ironclaw#4298 · feat: upgrade MiniMax default model to M3 · @octo-patch · 2w · ❌ CI · +7/-6 · no-reviews
+- nearai/ironclaw#3890 · [codex] Add Reborn multi-tenant isolation contract tests · @serrrfirat · 4w · ❌ CI · +987/-15 · changes-requested
+- nearai/ironclaw#4787 · [NO MERGE] - Barcelona Hackathon · @elliotBraem · 4d · ❌ CI · +45869/-177 · 323 files · no-reviews
+- nearai/ironclaw#4978 · Fix Reborn WebUI approval-deny activity ordering · @hanakannzashi · <1d · ❌ CI · +3012/-211 · 62 files · no-reviews
+- nearai/ironclaw#4841 · reborn: no run-borking failures — failure explanation + ret… · @serrrfirat · 3d · ✅ CI · +6825/-566 · 112 files · no-reviews
+- nearai/ironclaw#4876 · build(deps): bump the everything-else group across 1 direct… · @dependabot[bot] · 1d · ❌ CI · +1390/-645 · 41 files · no-reviews
+- nearai/ironclaw#3952 · feat(filesystem): TOCTOU-harden LocalFilesystem via fd-rela… · @zmanian · 3w · ❌ CI · +1645/-617 · no-reviews
+- nearai/ironclaw#4650 · fix(llm): drop temperature for models that reject it (Opus … · @abbyshekit · 1w · ✅ CI · +325/-10 · changes-requested
+- nearai/ironclaw#4501 · ci: avoid runtime tests for dependabot config updates · @serrrfirat · 2w · ✅ CI · +125/-42 · no-reviews
+- nearai/ironclaw#4648 · feat(mcp): thread-scoped sessions + SEP-414 context propaga… · @kirikov · 1w · ❌ CI · +1391/-135 · no-reviews
+- nearai/ironclaw#4379 · feat: migrate read-only commands `doctor`, `status` and `co… · @denbite · 2w · ✅ CI · +1594/-36 · no-reviews
+- nearai/ironclaw#4128 · Enable extension lifecycle tools for production profiles · @serrrfirat · 3w · ✅ CI · +368/-97 · no-reviews
+- nearai/ironclaw#4022 · fix(tools): HTTP response error is recoverable, not a run-a… · @zmanian · 3w · ✅ CI · +91/-56 · no-reviews
+- nearai/ironclaw#4080 · chore: update WASM artifact checksums and version-pinned UR… · @github-actions[bot] · 3w · ✅ CI · +10/-5 · no-reviews
+- nearai/ironclaw#3976 · fix(slack): support file attachments in inbound messages · @sergeiest · 3w · ❌ CI · +72/-87 · no-reviews
+- nearai/ironclaw#3707 · chore(deps): bump jsonwebtoken from 9.3.1 to 10.3.0 · @dependabot[bot] · 4w · ❌ CI · +7/-6 · no-reviews
+- nearai/ironclaw#4712 · Move Slack setup into WebUI · @serrrfirat · 6d · ✅ CI · +2853/-1258 · no-reviews
+- nearai/ironclaw#4661 · feat(extensions): read-only NEAR mainnet first-party extens… · @abbyshekit · 6d · ✅ CI · +1847/-1 · changes-requested
+- nearai/ironclaw#4284 · feat: adds NEAR SSO to WebChat V2 · @italic-jinxin · 2w · ✅ CI · +1907/-72 · no-reviews
+- nearai/ironclaw#3949 · [codex] Refine host runtime crate boundaries · @serrrfirat · 3w · ✅ CI · +34/-147 · no-reviews
+- nearai/ironclaw#3885 · feat(product-workflow): add read-path guard and command rou… · @danielwpz · 4w · ✅ CI · +193/-56 · changes-requested
+- nearai/ironclaw#3860 · Freeze tool package readiness contract (Lane 2) · @nickpismenkov · 4w · ✅ CI · +628/-90 · no-reviews
+- nearai/ironclaw#3775 · feat(reborn): add memory product surface contracts · @hanakannzashi · 4w · ✅ CI · +1968/-4 · no-reviews
+- nearai/ironclaw#3926 · Harden NoExposureGuard composition and audit coverage · @serrrfirat · 3w · ❌ CI · +256/-76 · no-reviews
+- nearai/ironclaw#4492 · [codex] fix configured extension credential staging · @serrrfirat · 2w · ✅ CI · +4820/-3446 · 36 files · changes-requested
+- nearai/ironclaw#4662 · docs(reborn): project-scoped ownership plan + contract revi… · @henrypark133 · 6d · ✅ CI · +2677/-1333 · changes-requested
+- nearai/ironclaw#4239 · feat(reborn): project product-auth accounts into runtime cr… · @serrrfirat · 3w · ✅ CI · +5536/-503 · 33 files · no-reviews
+- nearai/ironclaw#3767 · Add lean host NoExposureGuard service · @serrrfirat · 4w · ✅ CI · +797/-50 · changes-requested
+- nearai/ironclaw#3766 · fix: (auth) Seal dispatch authority with AuthorizedDispatch… · @serrrfirat · 4w · ✅ CI · +991/-397 · 37 files · no-reviews
+- nearai/ironclaw#4671 · feat(reborn): extra-capabilities seam — register host-suppl… · @pranavraja99 · 6d · ❌ CI · +515/-14 · no-reviews
+- nearai/ironclaw#4550 · Support full SHA GitHub branch creation · @serrrfirat · 1w · ❌ CI · +98/-30 · no-reviews
+- nearai/ironclaw#1378 · feat(routing): per-channel MCP and built-in tool filtering · @nick-stebbings · 3mo · ✅ CI · +2120/-61 · changes-requested
+- nearai/ironclaw#3960 · feat(signing): SigningProvider trait crate + plan doc (atte… · @zmanian · 3w · ✅ CI · +3578/-46 · changes-requested
+- nearai/ironclaw#3590 · feat(reborn): Telegram v2 inbound tracer (webhook → ledger … · @nickpismenkov · 5w · ✅ CI · +5236/-1613 · 46 files · changes-requested
+- nearai/ironclaw#4685 · feat(blueprint): add ironclaw.config/v1 parser · @loopstring · 6d · ❌ CI · +1806/-1 · changes-requested
+- nearai/ironclaw#4663 · feat(reborn): project-scoped automation ownership core model · @henrypark133 · 6d · ❌ CI · +5654/-841 · 40 files · no-reviews
+- nearai/ironclaw#4544 · Add scoped lifecycle admin foundation for Reborn capabiliti… · @serrrfirat · 1w · ❌ CI · +3337/-17 · no-reviews
+- nearai/ironclaw#4145 · [codex] Anchor Reborn turn objective in loop context · @serrrfirat · 3w · ❌ CI · +405/-8 · changes-requested
+- nearai/ironclaw#2066 · feat(slack): fetch thread history when bot is mentioned in … · @synner88 · 2mo · ❌ CI · +317/-24 · no-reviews
+- nearai/ironclaw#4479 · feat(reborn-ironhub) port IronHub install flow to Reborn · @serrrfirat · 2w · ❌ CI · +2853/-21 · no-reviews
+- nearai/ironclaw#3703 · arch(reborn): futureproof RebornRuntime surface for epic #3… · @serrrfirat · 4w · ❌ CI · +2124/-182 · no-reviews
+
+### ⚡ Quick wins
+- nearai/ironclaw#4968 · [codex] fix gsuite refresh auth classification · @serrrfirat · <1d · ✅ CI · +16/-5 · approved-once
+- nearai/ironclaw#4979 · fix(reborn): sidebar new conversation button style · @think-in-universe · <1d · ✅ CI · +12/-2 · approved-once
+- nearai/ironclaw#4924 · refactor(webui): replace Logs/Docs icons with text labels · @danielwpz · 1d · ✅ CI · +4/-29 · no-reviews
+- nearai/ironclaw#4930 · test(setup): clear DATABASE_URL after wizard reloads .env i… · @standardtoaster · 1d · ✅ CI · +8/-2 · no-reviews
+- nearai/ironclaw#4911 · fix(auth-resume): keep prior approval metadata atomic · @serrrfirat · 1d · ✅ CI · +22/-5 · no-reviews
+- nearai/ironclaw#4575 ·  Fix system ResourceScope JSON round-trip · @matiasbenary · 1w · ✅ CI · +53/-3 · approved-once
+- nearai/ironclaw#3511 · fix(prompt): avoid repeated compact tool schema lookups · @hanakannzashi · 5w · ✅ CI · +23/-8 · no-reviews
+- nearai/ironclaw#4990 · [codex] Fix NEAR AI MCP ready state projection · @think-in-universe · <1d · ✅ CI · +107/-6 · no-reviews
+- nearai/ironclaw#4971 · [codex] Clarify trigger active state output · @serrrfirat · <1d · ✅ CI · +48/-12 · no-reviews
+- nearai/ironclaw#4970 · fix(reborn): record Delivered (not Skipped) for non-OAuth a… · @serrrfirat · <1d · ✅ CI · +39/-29 · no-reviews
+- nearai/ironclaw#4927 · fix(reborn): allow credential-free hosted MCP providers to … · @standardtoaster · 1d · ✅ CI · +117/-5 · no-reviews
+- nearai/ironclaw#4830 · ci: run Reborn E2E in the merge queue with internal scope g… · @serrrfirat · 3d · ✅ CI · +78/-10 · no-reviews
+- nearai/ironclaw#4411 · chore: update WASM artifact checksums and version-pinned UR… · @github-actions[bot] · 2w · ✅ CI · +4/-4 · no-reviews
+- nearai/ironclaw#2957 · fix(mcp): skip OAuth discovery for stdio/unix transports (#… · @rajulbhatnagar · 7w · ✅ CI · +59/-0 · no-reviews
+- nearai/ironclaw#3834 · test: canary for /benchmark dispatcher (will close, do not … · @pranavraja99 · 4w · ✅ CI · +0/-0 · no-reviews
+- nearai/ironclaw#2457 · fix(oidc): make audience claim optional for OIDC-proxying l… · @synner88 · 2mo · ✅ CI · +12/-7 · no-reviews
+- nearai/ironclaw#2960 · fix(mcp): skip OAuth discovery for stdio/unix transports (f… · @willamhou · 7w · ✅ CI · +61/-0 · no-reviews
+- nearai/ironclaw#4090 · chore: allow configuring log truncation size with `IRONCLAW… · @denbite · 3w · ✅ CI · +49/-2 · no-reviews
+- nearai/ironclaw#3758 · [codex] Disable ANSI colors in worker containers · @serrrfirat · 4w · ✅ CI · +135/-5 · no-reviews
+- nearai/ironclaw#3512 · fix(web-ui): failed tool card history rendering · @hanakannzashi · 5w · ✅ CI · +181/-5 · no-reviews
+
+### 👋 First contributors
+- nearai/ironclaw#4934 · build(deps-dev): bump js-yaml from 4.1.1 to 4.2.0 in /docs/… · @dependabot[bot] · 1d · ✅ CI · +14/-3 · no-reviews
+- nearai/ironclaw#4499 · build(deps): bump the tokio-ecosystem group across 1 direct… · @dependabot[bot] · 2w · ✅ CI · +40/-70 · no-reviews
+- nearai/ironclaw#4032 · build(deps): bump the wasm group across 1 directory with 2 … · @dependabot[bot] · 3w · ✅ CI · +61/-61 · no-reviews
+- nearai/ironclaw#4521 · Add JSON cleaner for formatting and sanitization · @Dannye013 · 1w · ✅ CI · +40/-0 · changes-requested
+- nearai/ironclaw#4649 · fix(embeddings): honor config precedence, validate provider… · @abbyshekit · 1w · ✅ CI · +399/-23 · approved-once
+- nearai/ironclaw#4955 · fix(reborn): correlate run logs with thread_id/run_id for o… · @loopstring · <1d · ✅ CI · +416/-49 · changes-requested
+- nearai/ironclaw#4002 · build(deps): bump the actions group across 1 directory with… · @dependabot[bot] · 3w · ✅ CI · +134/-134 · no-reviews
+- nearai/ironclaw#4264 · feat(gateway): add routine create endpoint · @wcc945 · 2w · ✅ CI · +291/-5 · no-reviews
+- nearai/ironclaw#4689 · feat(harness): add ironclaw.harness/v1 manifest parser · @loopstring · 6d · ✅ CI · +480/-1 · no-reviews
+- nearai/ironclaw#4040 · feat: Add dictionary-skill v0.1.0 · @aryandudhagaralearning · 3w · ✅ CI · +29/-0 · no-reviews
+- nearai/ironclaw#4038 · feat(skills): YouTube Video Summarizer — transform any vide… · @radhe01q-star · 3w · ✅ CI · +37/-0 · no-reviews
+- nearai/ironclaw#3975 · fix(channels): Updates the Discord channel config parser to… · @GenesisX · 3w · ✅ CI · +38/-1 · no-reviews
+- nearai/ironclaw#4735 · feat(extensions): programmatic MCP server config + PATCH up… · @kirikov · 6d · ✅ CI · +901/-26 · no-reviews
+- nearai/ironclaw#4687 · feat(blueprint): add apply engine · @loopstring · 6d · ✅ CI · +655/-1 · no-reviews
+- nearai/ironclaw#3549 · fix: upgrade base images to debian trixie, pin image and ad… · @umglurf · 5w · ✅ CI · +28/-12 · no-reviews
+- nearai/ironclaw#4039 · feat(skill): add news-summarizer skill v0.1.0 · @dd9825817844-max · 3w · ✅ CI · +120/-0 · no-reviews
+- nearai/ironclaw#3892 · Add near ecosystem summary skill · @imrohitom · 4w · ✅ CI · +106/-0 · no-reviews
+- nearai/ironclaw#3853 · Add Web Summarizer Skill by ridham · @righamgadhesriya · 4w · ✅ CI · +76/-0 · no-reviews
+- nearai/ironclaw#3256 · feat(wasm): credential signers for HMAC, EIP-712, NEP-413, … · @neo-sky · 6w · ✅ CI · +5768/-146 · approved-once
+- nearai/ironclaw#3737 · feat(ironhub): install tools and skills from IronHub (CLI, … · @neo-sky · 4w · ✅ CI · +8285/-32 · 45 files · changes-requested
+
+### 🕰 Aging
+- nearai/ironclaw#3966 · feat(signing): turns BlockedAttested gate + AttestedResumeP… · @zmanian · 3w (idle 3w) · ✅ CI · +1678/-68 · approved-once
+- nearai/ironclaw#3676 · docs: rework the security section — secrets, sandboxing, le… · @thisisjoshford · 5w (idle 4w) · ✅ CI · +370/-107 · no-reviews
+- nearai/ironclaw#3974 · feat(signing): injected wallet provider + gate/resolve wiri… · @zmanian · 3w (idle 3w) · ✅ CI · +2246/-10 · approved-once
+- nearai/ironclaw#3994 · feat(signing): ironclaw_attested_runtime — reborn AttestedR… · @zmanian · 3w (idle 3w) · ✅ CI · +12528/-47 · 56 files · approved-once
+- nearai/ironclaw#4104 · feat(signing): grant expiry + binding tenant-key + retryabl… · @zmanian · 3w (idle 3w) · ✅ CI · +638/-180 · no-reviews
+- nearai/ironclaw#3992 · feat(signing): WalletConnect v2 backend (attested-signing P… · @zmanian · 3w (idle 3w) · ✅ CI · +2586/-24 · approved-once
+- nearai/ironclaw#3993 · feat(signing): NEAR redirect provider + outbound delivery w… · @zmanian · 3w (idle 3w) · ✅ CI · +2207/-12 · approved-once
+- nearai/ironclaw#3964 · feat(signing): durable one-shot challenge store + WebAuthn … · @zmanian · 3w (idle 3w) · ✅ CI · +3839/-17 · approved-once
+- nearai/ironclaw#4083 · docs(extensions): use snake_case IDs in install/auth comman… · @matiasbenary · 3w (idle 3w) · ✅ CI · +27/-27 · no-reviews
+
+### 📋 Normal
+- nearai/ironclaw#3947 · [codex] Add Reborn event and scheduling parity coverage · @serrrfirat · 3w · ✅ CI · +415/-1 · no-reviews
+- nearai/ironclaw#4989 · Persist Engine V2 LLM usage · @think-in-universe · <1d · ✅ CI · +408/-26 · no-reviews
+- nearai/ironclaw#4821 · ci(test): shard ironclaw_webui_v2 Reborn tests · @think-in-universe · 4d · ✅ CI · +259/-11 · no-reviews
+- nearai/ironclaw#4969 · [codex] fix google wasm auth required errors · @serrrfirat · <1d · ✅ CI · +121/-26 · no-reviews
+- nearai/ironclaw#4859 · feat(reborn): complete operator setup state · @think-in-universe · 2d · ✅ CI · +329/-64 · no-reviews
+- nearai/ironclaw#4561 · fix(hooks): record MCP direct-lease denials in SecurityAudi… · @zmanian · 1w · ✅ CI · +89/-42 · no-reviews
+- nearai/ironclaw#4058 · feat(signing): KMS curve-capability fail-closed on the cust… · @zmanian · 3w · ✅ CI · +586/-23 · approved-once
+- nearai/ironclaw#3940 · test(arch): assert production composition populates securit… · @zmanian · 3w · ✅ CI · +283/-0 · no-reviews
+- nearai/ironclaw#4993 · fix(agent-loop): no-progress stop fails honestly instead of… · @serrrfirat · <1d · ⏳ CI · +101/-85 · no-reviews
+- nearai/ironclaw#4953 · fix(reborn): gate triggered Slack OAuth URL on a verified p… · @henrypark133 · <1d · ✅ CI · +1469/-98 · no-reviews
+- nearai/ironclaw#4984 · fix(reborn): fix failed tool activity updates in WebUI · @think-in-universe · <1d · ✅ CI · +580/-40 · no-reviews
+- nearai/ironclaw#4976 · [codex] Improve binary HTTP and PDF read_file harness paths · @serrrfirat · <1d · ✅ CI · +203/-32 · no-reviews
+- nearai/ironclaw#4858 · fix(reborn): show sanitized command details · @think-in-universe · 2d · ✅ CI · +1689/-144 · no-reviews
+- nearai/ironclaw#4860 · feat(reborn): wire local service lifecycle backend · @think-in-universe · 2d · ✅ CI · +1327/-7 · no-reviews
+- nearai/ironclaw#4967 · [codex] Recover invalid model output in loop · @serrrfirat · <1d · ✅ CI · +690/-46 · no-reviews
+- nearai/ironclaw#4801 · feat(reborn): wire Reborn operator diagnostics · @think-in-universe · 4d · ✅ CI · +617/-16 · no-reviews
+- nearai/ironclaw#4820 · ci(test): shard legacy all-features tests · @think-in-universe · 4d · ✅ CI · +576/-15 · no-reviews
+- nearai/ironclaw#4804 · feat(reborn): support Reborn operator log tail/follow · @think-in-universe · 4d · ✅ CI · +538/-45 · no-reviews
+- nearai/ironclaw#4902 · feat(openai-compat): vision support for inline images (#464… · @ilblackdragon · 1d · ✅ CI · +951/-117 · no-reviews
+- nearai/ironclaw#4937 · reborn(learning): WS-1 — memory learning semantics + A/B ga… · @serrrfirat · <1d · ✅ CI · +1104/-28 · no-reviews
+- nearai/ironclaw#4938 · reborn(learning): WS-2 — learning persona + /learn surface … · @serrrfirat · <1d · ✅ CI · +1481/-27 · no-reviews
+- nearai/ironclaw#4785 · docs(plans): Reborn persistent tenant sandbox & agent-built… · @serrrfirat · 4d · ✅ CI · +987/-0 · no-reviews
+- nearai/ironclaw#4565 · [hooks] Record credential-boundary egress blocks · @zmanian · 1w · ✅ CI · +411/-63 · changes-requested
+- nearai/ironclaw#4563 · [hooks] Record no-exposure egress blocks · @zmanian · 1w · ✅ CI · +287/-19 · changes-requested
+- nearai/ironclaw#2341 · fix(tools): bound file history memory, add job cleanup, uni… · @zmanian · 2mo · ✅ CI · +794/-130 · no-reviews
+- nearai/ironclaw#4829 · ci: retire dormant reborn-integration workflow, add Reborn … · @serrrfirat · 3d · ✅ CI · +23/-203 · no-reviews
+- nearai/ironclaw#4728 · [codex] Allow Reborn secure production without process back… · @serrrfirat · 6d · ✅ CI · +347/-11 · no-reviews
+- nearai/ironclaw#4518 · [codex] Add Reborn extension lifecycle e2e coverage · @serrrfirat · 1w · ⏳ CI · +1570/-16 · no-reviews
+- nearai/ironclaw#4994 · reborn(learning) WS-4: reflection never-repeat E2E + accept… · @serrrfirat · <1d · ⏳ CI · +644/-2 · no-reviews
+- nearai/ironclaw#4678 · Scrub provider reasoning metadata · @henrypark133 · 6d · ✅ CI · +501/-87 · changes-requested
+- nearai/ironclaw#4265 · test: implement live E2E tests following codeact preamble g… · @denbite · 2w · ✅ CI · +678/-0 · no-reviews
+- nearai/ironclaw#4021 · test(tools): CI boundary test ratcheting tool execution thr… · @zmanian · 3w · ✅ CI · +513/-0 · no-reviews
+- nearai/ironclaw#3772 · docs(audit): crate boundary & ownership audit (reborn-integ… · @nickpismenkov · 4w · ✅ CI · +609/-0 · no-reviews
+- nearai/ironclaw#4026 · feat(tools): route engine-v2 effect bridge through the audi… · @zmanian · 3w · ✅ CI · +605/-35 · no-reviews
+- nearai/ironclaw#4025 · feat(tools): route bridge/command tool execution through th… · @zmanian · 3w · ✅ CI · +508/-55 · no-reviews
+- nearai/ironclaw#4024 · feat(tools): route scheduler + routine-engine tool executio… · @zmanian · 3w · ✅ CI · +626/-111 · no-reviews
+- nearai/ironclaw#4060 · fix(signing): continuation asserts caller scope/run/gate_re… · @zmanian · 3w · ✅ CI · +476/-13 · changes-requested
+- nearai/ironclaw#4023 · feat(tools): route chat tool execution through the audited … · @zmanian · 3w · ✅ CI · +613/-59 · no-reviews
+- nearai/ironclaw#4067 · fix(signing): fail-closed wire encoding for attestation can… · @zmanian · 3w · ✅ CI · +622/-121 · no-reviews
+- nearai/ironclaw#4315 · Fix engine v2 vision attachments · @hanakannzashi · 2w · ✅ CI · +1405/-139 · no-reviews
+- nearai/ironclaw#3669 · engine v2: expose channel-supplied thread/response ids to t… · @zetyquickly · 5w · ✅ CI · +880/-23 · no-reviews
+- nearai/ironclaw#3548 · Add DISABLE_TOOLS_LIST flag and security regression test · @zetyquickly · 5w · ✅ CI · +516/-9 · no-reviews
+- nearai/ironclaw#4954 · fix(reborn): surface approval-gate denial to model instead … · @henrypark133 · <1d · — CI · +0/-0 · no-reviews
+- nearai/ironclaw#4664 · refactor(reborn): project vocabulary on the product surface · @henrypark133 · 6d · ✅ CI · +2169/-146 · changes-requested
+- nearai/ironclaw#4656 · feat(reborn): WU-C2 durable gate resolution store + capacit… · @henrypark133 · 6d · ✅ CI · +5309/-1 · changes-requested
+- nearai/ironclaw#4304 · [codex] plan runtime context prompt stage · @henrypark133 · 2w · ✅ CI · +1256/-0 · changes-requested
+- nearai/ironclaw#4178 · feat: add Feishu websocket event intake · @hanakannzashi · 3w · ✅ CI · +7019/-457 · 35 files · no-reviews
+- nearai/ironclaw#4054 · test(signing): multi-tenant operating model + cross-tenant … · @zmanian · 3w · ✅ CI · +694/-13 · changes-requested
+- nearai/ironclaw#4015 · feat(signing): request_signature tool + attested gate-model… · @zmanian · 3w · ✅ CI · +1614/-97 · changes-requested
+- nearai/ironclaw#4055 · feat(signing): TrustEnrollment ceremony + connected-wallet … · @zmanian · 3w · ✅ CI · +3150/-187 · changes-requested
+- nearai/ironclaw#3996 · feat(signing): durable PG+libSQL attested stores + per-chai… · @zmanian · 3w · ✅ CI · +3348/-122 · 36 files · changes-requested
+- nearai/ironclaw#3997 · feat(signing): register NEAR/WC providers + flip production… · @zmanian · 3w · ✅ CI · +5118/-135 · changes-requested
+- nearai/ironclaw#3995 · feat(signing): reborn webui attested gate/resolve ingress (… · @zmanian · 3w · ✅ CI · +2702/-131 · changes-requested
+- nearai/ironclaw#3963 · feat(signing): sealed one-shot grant store + signing ledger… · @zmanian · 3w · ✅ CI · +1939/-122 · changes-requested
+- nearai/ironclaw#3965 · feat(signing): ironclaw_chain_signing — custodial multi-cha… · @zmanian · 3w · ✅ CI · +6567/-25 · 32 files · changes-requested
+
+_Auth: token present. Enriched 164/164 PRs. Budget: 4975 remaining._
+```

--- a/skills/pr-triage-digest/reference/triage.mjs
+++ b/skills/pr-triage-digest/reference/triage.mjs
@@ -1,0 +1,357 @@
+#!/usr/bin/env node
+// Reference implementation for the `pr-triage-digest` skill.
+//
+// Usage:
+//   node triage.mjs owner/repo [owner/other-repo ...]
+//
+// Auth: reads GITHUB_TOKEN or GH_TOKEN from env. Runs unauthenticated otherwise.
+//
+// This file mirrors the scoring, bucketing, and rendering rules in ../SKILL.md.
+// The SKILL.md prompt is the source of truth; this script exists so partners
+// can port the logic to a different runtime and so the digest is reproducible
+// in CI without relying on an LLM.
+
+const TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || "";
+const SINCE_DAYS = Number(process.env.TRIAGE_SINCE_DAYS || 30);
+const NOW = new Date(process.env.TRIAGE_NOW || Date.now());
+
+const GH = "https://api.github.com";
+
+const headers = {
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2022-11-28",
+  "User-Agent": "ironhub-pr-triage-digest/1.0",
+  ...(TOKEN ? { Authorization: `Bearer ${TOKEN}` } : {}),
+};
+
+async function gh(path) {
+  const r = await fetch(`${GH}${path}`, { headers });
+  if (!r.ok) {
+    const e = new Error(`GitHub ${r.status} on ${path}`);
+    e.status = r.status;
+    throw e;
+  }
+  return r.json();
+}
+
+async function rateLimit() {
+  try {
+    const j = await gh("/rate_limit");
+    return j.resources?.core ?? { remaining: TOKEN ? 5000 : 60 };
+  } catch {
+    return { remaining: TOKEN ? 5000 : 60 };
+  }
+}
+
+async function listOpenPRs(owner, repo) {
+  const out = [];
+  for (let page = 1; page <= 10; page++) {
+    const batch = await gh(
+      `/repos/${owner}/${repo}/pulls?state=open&per_page=100&page=${page}&sort=updated&direction=desc`
+    );
+    out.push(...batch);
+    if (batch.length < 100) break;
+  }
+  return out;
+}
+
+async function enrich(owner, repo, number) {
+  return gh(`/repos/${owner}/${repo}/pulls/${number}`);
+}
+
+async function checkRuns(owner, repo, sha) {
+  try {
+    const j = await gh(`/repos/${owner}/${repo}/commits/${sha}/check-runs?per_page=100`);
+    return j.check_runs || [];
+  } catch {
+    return [];
+  }
+}
+
+const firstContribCache = new Map();
+async function isFirstContributor(owner, repo, author) {
+  const key = `${owner}/${repo}::${author}`;
+  if (firstContribCache.has(key)) return firstContribCache.get(key);
+  try {
+    const q = encodeURIComponent(`author:${author} repo:${owner}/${repo} type:pr is:merged`);
+    const j = await gh(`/search/issues?q=${q}&per_page=1`);
+    const isFirst = (j.total_count ?? 0) === 0;
+    firstContribCache.set(key, isFirst);
+    return isFirst;
+  } catch {
+    firstContribCache.set(key, false);
+    return false;
+  }
+}
+
+function days(dateStr) {
+  const d = new Date(dateStr);
+  return Math.max(0, Math.floor((NOW - d) / 86400000));
+}
+
+function ciStatus(runs) {
+  if (!runs.length) return { score: 1, glyph: "—" };
+  const states = runs.map(r => r.conclusion || r.status);
+  const fail = states.some(s => s === "failure" || s === "cancelled" || s === "timed_out");
+  const pending = states.some(s => s === "queued" || s === "in_progress" || s === null);
+  const success = states.every(s => s === "success" || s === "neutral" || s === "skipped");
+  if (fail) return { score: 4, glyph: "❌" };
+  if (success) return { score: 0, glyph: "✅" };
+  if (pending) return { score: 2, glyph: "⏳" };
+  return { score: 3, glyph: "⚠️" };
+}
+
+function sizeScore(additions, deletions, changedFiles) {
+  const loc = (additions || 0) + (deletions || 0);
+  if (loc <= 50 && changedFiles <= 2) return 0;
+  if (loc <= 200 && changedFiles <= 5) return 1;
+  if (loc <= 500 && changedFiles <= 10) return 2;
+  if (loc <= 2000 && changedFiles <= 30) return 3;
+  return 4;
+}
+
+function stalenessScore(d) {
+  if (d <= 2) return 0;
+  if (d <= 7) return 1;
+  if (d <= 14) return 2;
+  if (d <= 30) return 3;
+  return 4;
+}
+
+function mergeScore(mergeable) {
+  if (mergeable === true) return 0;
+  if (mergeable === false) return 4;
+  return 1;
+}
+
+function reviewShort(pr) {
+  const requested = (pr.requested_reviewers?.length || 0) + (pr.requested_teams?.length || 0);
+  if (pr._reviewSummary === "changes_requested") return { score: 3, label: "changes-requested" };
+  if (pr._reviewSummary === "approved") {
+    const n = pr._approvals || 1;
+    return { score: n >= 2 ? 0 : 1, label: n >= 2 ? `approved-${n}` : "approved-once" };
+  }
+  if (requested > 0) return { score: 2, label: "no-reviews" };
+  return { score: 2, label: "no-reviews" };
+}
+
+async function summarizeReviews(owner, repo, number) {
+  try {
+    const reviews = await gh(`/repos/${owner}/${repo}/pulls/${number}/reviews?per_page=100`);
+    const latestByUser = new Map();
+    for (const r of reviews) {
+      const k = r.user?.login;
+      if (!k) continue;
+      const cur = latestByUser.get(k);
+      if (!cur || new Date(r.submitted_at) > new Date(cur.submitted_at)) latestByUser.set(k, r);
+    }
+    const states = [...latestByUser.values()].map(r => r.state);
+    if (states.some(s => s === "CHANGES_REQUESTED")) return { summary: "changes_requested" };
+    const approvals = states.filter(s => s === "APPROVED").length;
+    if (approvals > 0) return { summary: "approved", approvals };
+    return { summary: "none" };
+  } catch {
+    return { summary: "none" };
+  }
+}
+
+function truncate(s, n) {
+  if (!s) return "";
+  return s.length > n ? s.slice(0, n - 1) + "…" : s;
+}
+
+function compactAge(d) {
+  if (d < 1) return "<1d";
+  if (d < 7) return `${d}d`;
+  if (d < 60) return `${Math.round(d / 7)}w`;
+  return `${Math.round(d / 30)}mo`;
+}
+
+function bucketize(scored) {
+  const blockers = [];
+  const firstContrib = [];
+  const quick = [];
+  const aging = [];
+  const normal = [];
+  for (const p of scored) {
+    if (
+      p.scores.ci === 4 ||
+      p.scores.merge === 4 ||
+      (p.labels || []).some(l => /security|incident|priority:high/i.test(l))
+    ) {
+      blockers.push(p);
+      continue;
+    }
+    if (p.firstContributor) {
+      firstContrib.push(p);
+      continue;
+    }
+    if (p.scores.size <= 1 && p.scores.ci <= 1 && p.scores.merge === 0 && p.scores.review <= 2) {
+      quick.push(p);
+      continue;
+    }
+    if (p.scores.staleness >= 3 && p.scores.review <= 2) {
+      aging.push(p);
+      continue;
+    }
+    normal.push(p);
+  }
+  const sort = arr => arr.sort((a, b) => a.total - b.total);
+  return {
+    blockers: sort(blockers),
+    quick: sort(quick),
+    firstContrib: sort(firstContrib),
+    aging: sort(aging),
+    normal: sort(normal),
+  };
+}
+
+function renderRow(p) {
+  const ageStr = p.bucket === "aging" ? `${compactAge(p.ageDays)} (idle ${compactAge(p.idleDays)})` : compactAge(p.ageDays);
+  const sizeStr = `+${p.additions}/-${p.deletions}${p.changedFiles > 30 ? ` · ${p.changedFiles} files` : ""}`;
+  return `- ${p.slug}#${p.number} · ${truncate(p.title, 60)} · @${p.author} · ${ageStr} · ${p.ciGlyph} CI · ${sizeStr} · ${p.reviewLabel}`;
+}
+
+function render(buckets, meta) {
+  const total = Object.values(buckets).reduce((a, b) => a + b.length, 0);
+  if (total === 0) {
+    return `No open PRs across ${meta.repos.join(" + ")}. Inbox zero.\n`;
+  }
+  const lines = [];
+  lines.push(
+    `**TL;DR** ${total} open PRs across ${meta.repos.join(" + ")} · ` +
+      `${buckets.blockers.length} blockers · ${buckets.quick.length} quick wins · ${buckets.firstContrib.length} first-time contributors · ${buckets.aging.length} aging · ${buckets.normal.length} normal.`
+  );
+  const section = (title, arr) => {
+    if (!arr.length) return;
+    lines.push("");
+    lines.push(`### ${title}`);
+    for (const p of arr) lines.push(renderRow(p));
+  };
+  section("🚨 Blockers", buckets.blockers);
+  section("⚡ Quick wins", buckets.quick);
+  section("👋 First contributors", buckets.firstContrib);
+  section("🕰 Aging", buckets.aging);
+  section("📋 Normal", buckets.normal);
+  lines.push("");
+  lines.push(
+    `_Auth: ${meta.authed ? "token present" : "anonymous"}. Enriched ${meta.enriched}/${meta.totalSeen} PRs. Budget: ${meta.remaining} remaining._`
+  );
+  return lines.join("\n") + "\n";
+}
+
+async function triage(repoSpecs) {
+  const rate = await rateLimit();
+  let remaining = rate.remaining ?? (TOKEN ? 5000 : 60);
+  const repos = [];
+
+  for (const spec of repoSpecs) {
+    const [owner, repo] = spec.split("/");
+    if (!owner || !repo || repo === "*") {
+      process.stderr.write(`Skipping ${spec}: only explicit owner/repo supported in reference impl\n`);
+      continue;
+    }
+    repos.push({ owner, repo, slug: `${owner}/${repo}` });
+  }
+
+  if (remaining <= 5) {
+    return `GitHub rate-limited. Re-run later (remaining=${remaining}).\n`;
+  }
+
+  const sinceCutoff = new Date(NOW.getTime() - SINCE_DAYS * 86400000);
+  const collected = [];
+
+  for (const r of repos) {
+    let prs;
+    try {
+      prs = await listOpenPRs(r.owner, r.repo);
+    } catch (e) {
+      process.stderr.write(`${r.slug}: not accessible (${e.status || e.message}). Skipping.\n`);
+      continue;
+    }
+    prs = prs.filter(p => new Date(p.updated_at) >= sinceCutoff);
+    for (const p of prs) collected.push({ repo: r, raw: p });
+  }
+
+  const totalSeen = collected.length;
+  const maxEnrich = Math.max(0, Math.floor((remaining - 5) / 3));
+  const toEnrich = collected.slice(0, maxEnrich);
+  const enriched = [];
+
+  for (const { repo: r, raw: p } of toEnrich) {
+    let detail = p;
+    let runs = [];
+    let reviewSummary = { summary: "none" };
+    try {
+      detail = await enrich(r.owner, r.repo, p.number);
+      runs = await checkRuns(r.owner, r.repo, p.head?.sha || detail.head?.sha);
+      reviewSummary = await summarizeReviews(r.owner, r.repo, p.number);
+    } catch {
+      // Fall back to list-call data; mark CI as unknown.
+    }
+
+    const author = detail.user?.login || p.user?.login || "unknown";
+    const firstContributor = author === "unknown"
+      ? false
+      : await isFirstContributor(r.owner, r.repo, author);
+
+    const ageDays = days(detail.created_at || p.created_at);
+    const idleDays = days(detail.updated_at || p.updated_at);
+    const ci = ciStatus(runs);
+    const merge = mergeScore(detail.mergeable);
+    const size = sizeScore(detail.additions, detail.deletions, detail.changed_files);
+    const stale = stalenessScore(idleDays);
+
+    const prObj = {
+      slug: r.slug,
+      number: p.number,
+      title: detail.title || p.title,
+      author,
+      ageDays,
+      idleDays,
+      additions: detail.additions ?? 0,
+      deletions: detail.deletions ?? 0,
+      changedFiles: detail.changed_files ?? 0,
+      labels: (detail.labels || []).map(l => (typeof l === "string" ? l : l.name)),
+      ciGlyph: ci.glyph,
+      firstContributor,
+      _reviewSummary: reviewSummary.summary,
+      _approvals: reviewSummary.approvals || 0,
+      scores: {
+        ci: ci.score,
+        merge,
+        size,
+        staleness: stale,
+        review: 0,
+      },
+    };
+    const rev = reviewShort(prObj);
+    prObj.scores.review = rev.score;
+    prObj.reviewLabel = rev.label;
+    prObj.total =
+      prObj.scores.ci + prObj.scores.merge + prObj.scores.size + prObj.scores.staleness + prObj.scores.review;
+    enriched.push(prObj);
+  }
+
+  // Tag aging items so the renderer can mention idle days.
+  const buckets = bucketize(enriched);
+  for (const p of buckets.aging) p.bucket = "aging";
+
+  return render(buckets, {
+    repos: repos.map(r => r.slug),
+    authed: !!TOKEN,
+    enriched: enriched.length,
+    totalSeen,
+    remaining,
+  });
+}
+
+const repos = process.argv.slice(2);
+if (!repos.length) {
+  process.stderr.write("Usage: node triage.mjs owner/repo [owner/other-repo ...]\n");
+  process.exit(2);
+}
+triage(repos).then(out => process.stdout.write(out)).catch(e => {
+  process.stderr.write(`triage error: ${e.message}\n`);
+  process.exit(1);
+});

--- a/tracking.md
+++ b/tracking.md
@@ -2,12 +2,12 @@
 
 Status of every tool and skill currently in this repository. Updated in the same commit that adds, modifies, or removes an entry.
 
-Last updated: 2026-06-11
+Last updated: 2026-06-16
 
 ## Summary
 
 - 3 tools live
-- 1 skill live
+- 2 skills live
 - 0 open bugs against shipped integrations
 
 ## Tools
@@ -24,6 +24,7 @@ Last updated: 2026-06-11
 | Name | Status | Version | Use Cases | Value Tags | Description | Trunk | Author |
 |---|---|---|---|---|---|---|---|
 | `microsoft-365-workflow` | live | 1.0.0 | Automate Outlook email drafts and replies, Read and write Excel range data directly, Post status updates to Teams channels | Automation, Productivity | Microsoft 365 business workflow patterns. 18 activation keywords, 6 regex patterns, 6,500 token budget. | `microsoft-365` | Brandon |
+| `pr-triage-digest` | live | 1.0.0 | Morning PR-review triage across one or more repos, Cross-repo backlog ranking, Stale-PR sweep before release, First-contributor surfacing for friendly review | Engineering, Productivity, Code-review | Triages open GitHub pull requests across one or more repos. Scores each on CI status, mergeability, staleness, size, and review state, then groups into Blockers, Quick wins, First contributors, Aging, and Normal. Silent-tier (read-only). 19 activation keywords, 6 regex patterns, 4,000 token budget. Ships a deterministic Node.js reference implementation. | `http` | Skytonet2 |
 
 ## Open work
 


### PR DESCRIPTION
Closes #145.

Adds the `pr-triage-digest` skill: a cross-repo GitHub PR review-queue ranker. Given one or more repos, the agent scores every open PR on CI status, mergeability, staleness, size, and review state, then emits a single ranked digest grouped into Blockers, Quick wins, First contributors, Aging, and Normal. The skill is silent-tier — it reads, ranks, and reports; it never comments, labels, closes, or merges.

## Why

The maintainer's morning question is "what should I review first?" The GitHub UI sorts by recency, not priority. When you own several repos, the question gets harder. This skill answers it in one screen, respects the rate budget, and degrades gracefully when run unauthenticated.

## What's in the PR

- `skills/pr-triage-digest/SKILL.md` — the prompt. Persona, when-to-use, do-not-use, required tools, pre-flight (auth probe + rate-budget math), scoring rubric, bucketing rules, output format, approval-tier discipline, caching, failure modes, composition hook for `chief-of-staff`'s morning briefing "Code activity" section.
- `skills/pr-triage-digest/reference/triage.mjs` — deterministic Node.js reference implementation that mirrors the SKILL.md rules line-for-line. Runs as a CLI: `node triage.mjs nearai/ironhub nearai/ironclaw`. Useful for testing the format in CI, and for partners porting the logic to a different runtime.
- `skills/pr-triage-digest/reference/sample-output.md` — real captured digest against `nearai/ironhub` + `nearai/ironclaw` (164 PRs). Shows the rubric working against the actual repo state.
- `skills/pr-triage-digest/README.md` — quick-start and demo command.
- Updates to `tracking.md` (skills table + summary count) and root `README.md` ("Currently shipped").

## Trunk and tier

- **Trunk:** built-in `http` tool. No new tool dependency.
- **Tier:** silent (read-only). All side effects from this skill are `GET`s against the GitHub REST API.

## Scoring at a glance

| Dimension | 0 (best) | 4 (worst) |
|---|---|---|
| CI status | all green | failing |
| Mergeability | mergeable | conflicts |
| Staleness | ≤ 2 days idle | > 30 days idle |
| Size | ≤ 50 LOC, ≤ 2 files | > 2000 LOC or > 30 files |
| Review state | approved | changes requested |

Bucketing is evaluated in order — first match wins:

1. **Blockers** — failing CI, merge conflicts, or `security`/`incident`/`priority:high` label.
2. **First contributors** — author has zero prior merged PRs in this repo.
3. **Quick wins** — small, clean CI, no requested changes.
4. **Aging** — open > 14 days with no recent reviewer activity.
5. **Normal** — everything else.

## Output sample

From `sample-output.md`, real run against `nearai/ironhub` + `nearai/ironclaw`:

```
**TL;DR** 164 open PRs across nearai/ironhub + nearai/ironclaw · 60 blockers · 20 quick wins · 20 first-time contributors · 9 aging · 55 normal.

### 🚨 Blockers
- nearai/ironclaw#4943 · feat(reborn): auto-wire Google OAuth in run-reborn-webui.sh · @thisisjoshford · <1d · ❌ CI · +43/-0 · no-reviews
- nearai/ironclaw#3705 · chore(deps): bump rand from 0.8.5 to 0.8.6 in /channels-src… · @dependabot[bot] · 4w · ❌ CI · +2/-2 · no-reviews
…

### ⚡ Quick wins
- nearai/ironclaw#4968 · [codex] fix gsuite refresh auth classification · @serrrfirat · <1d · ✅ CI · +16/-5 · approved-once
…

_Auth: token present. Enriched 164/164 PRs. Budget: 4894 remaining._
```

Full file: `skills/pr-triage-digest/reference/sample-output.md`.

## How to reproduce

```sh
GITHUB_TOKEN=ghp_… node skills/pr-triage-digest/reference/triage.mjs \
  nearai/ironhub nearai/ironclaw
```

Runs anonymously (60 req/hr) without `GITHUB_TOKEN` — fine for one or two small repos.

## Notes for review

- The skill is composable: `chief-of-staff` can call it with `compact: true` and get a 6-PR summary suitable for the "Code activity" section of the morning briefing.
- Rate-budget math is in the SKILL.md and mirrored in `triage.mjs`. If the budget would be exceeded, the digest emits a `stopped at N/M PRs` footer rather than throwing.
- The first-contributor lookup uses `GET /search/issues` and is cached per-author-per-repo for the run. This is the only enrichment that costs a search-quota request; everything else is core quota.
- The reference implementation is illustrative — the SKILL.md prompt is the source of truth. A partner that wants to port to Python or Rust just needs to follow the rubric.

## Author

@zrah231z
