### PR TITLE
feat(skill): add 42 trading skills pack - Closes #148

### DIFF
--- a/skills/alpha-hunter/SKILL.md
+++ b/skills/alpha-hunter/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: alpha-hunter
+version: 1.0.0
+description: Spot early alpha signals from on-chain data, whale wallet moves, and smart money activity
+activation:
+  keywords:
+    - "alpha"
+    - "whale move"
+    - "smart money"
+    - "on-chain signal"
+    - "whale wallet"
+    - "early signal"
+    - "what are whales doing"
+    - "large transaction"
+    - "whale alert"
+  patterns:
+    - "(?i)(find|spot|hunt|look for).*(alpha|signal|whale|smart money)"
+    - "(?i)(what are|where are).*(whales|smart money|big players).*(doing|moving|buying)"
+    - "(?i)(on.?chain|large transaction|whale).*(signal|alert|move|activity)"
+  tags:
+    - "trading"
+    - "alpha"
+    - "on-chain"
+  max_context_tokens: 2000
+---
+
+# Alpha Hunter Skill
+
+Identifies early trading alpha by tracking whale wallet movements, smart money on-chain activity, and early signals before they become public knowledge.
+
+## When to Use
+
+- User wants to find early signals before the market moves
+- User asks what whales or smart money are doing
+- User wants to track large on-chain transactions
+- User wants to find information asymmetry (alpha)
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Follow the money, not the narrative** — what wallets DO matters more than what people SAY
+2. **Whales move first, retail follows** — on-chain accumulation often precedes price moves by days/weeks
+3. **Alpha decays fast** — once a signal is public, most of the edge is gone; speed matters
+4. **Not all whale moves are bullish** — distinguish accumulation from distribution
+
+### Alpha Signal Categories
+
+**Whale Wallet Signals**
+- Large wallet accumulating unknown token → early buy signal
+- Known smart money wallet (tracked on Nansen) buying → follow
+- Whale moving tokens from cold wallet to exchange → potential sell incoming
+- Whale moving tokens from exchange to cold wallet → long-term hold signal
+
+**Exchange Flow Signals**
+- Large inflow to exchange → whale preparing to sell
+- Large outflow from exchange → whale accumulating/holding
+- Stablecoin inflow to exchange → whale preparing to buy
+
+**DeFi Signals**
+- Sudden large liquidity addition to new pool → team/insider seeding
+- Governance token accumulation before vote → directional bet on outcome
+- Large borrow position opened → leveraged directional bet
+
+**Derivatives Signals**
+- Unusually large options purchase at specific strike → directional bet
+- Massive open interest increase → large player positioning
+- Funding rate divergence across exchanges → arbitrage or directional flow
+
+### Alpha Hunting Tools
+
+| Tool | What It Tracks |
+|------|---------------|
+| Nansen | Smart money wallet labels and flows |
+| Arkham Intelligence | Wallet identity and transaction tracking |
+| Whale Alert | Large on-chain transactions in real time |
+| Lookonchain | Curated whale and smart money moves |
+| Glassnode | On-chain analytics (exchange flows, holder behavior) |
+| Dune Analytics | Custom on-chain queries |
+| DeBank | DeFi wallet portfolio tracking |
+
+### Smart Money Wallet Types
+
+- **Exchange wallets**: Large inflows/outflows signal sell/buy pressure
+- **VC/Fund wallets**: Tracked on Nansen — their buys often precede listings
+- **Protocol treasuries**: Large moves signal strategic decisions
+- **Known trader wallets**: Historically profitable wallets worth following
+
+### Alpha Validation Checklist
+
+Before acting on a signal:
+- ✅ Is the wallet historically profitable? (check Nansen/Arkham)
+- ✅ Is this accumulation or a one-time transaction?
+- ✅ Is there a fundamental reason for the move?
+- ✅ Is the signal still fresh? (>24h old = likely priced in)
+- ✅ Does it align with chart structure and sentiment?
+
+### Mistakes to Avoid
+
+- Don't blindly follow every whale move — some are hedges, not directional bets
+- Don't act on stale signals — on-chain alpha has a short shelf life
+- Don't ignore context — a whale selling 5% of holdings is not the same as selling everything
+
+## Guidelines
+
+- Always identify: wallet history, transaction size, direction (buy/sell), and asset
+- Cross-reference on-chain signal with price action and sentiment
+- Flag if the signal is fresh (<6 hours) vs. stale (>24 hours)
+- Source every signal with the tool/link where it was found

--- a/skills/api-caller/SKILL.md
+++ b/skills/api-caller/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: api-caller
+version: 1.0.0
+description: Structure, format, and debug API requests and responses across REST, GraphQL, and RPC protocols
+activation:
+  keywords:
+    - "api call"
+    - "api request"
+    - "rest api"
+    - "graphql"
+    - "fetch request"
+    - "http request"
+    - "call this endpoint"
+    - "api response"
+    - "json request"
+    - "curl"
+  patterns:
+    - "(?i)(make|build|structure|format).*(api|http|rest|graphql).*(call|request)"
+    - "(?i)(call|hit|query).*(endpoint|api|url)"
+    - "(?i)(post|get|put|delete|patch).*(request|endpoint|api)"
+  tags:
+    - "dev"
+    - "api"
+    - "integration"
+  max_context_tokens: 2000
+---
+
+# API Caller Skill
+
+Helps the agent correctly structure, format, execute, and debug API requests across REST, GraphQL, and RPC protocols.
+
+## When to Use
+
+- User wants to call an external API
+- User needs help formatting headers, body, or auth
+- User is debugging a failed API request
+- User wants to integrate a service (Plaid, CoinGecko, NEAR RPC, OpenAI, etc.)
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Method matters** — GET for reading, POST for creating, PUT/PATCH for updating, DELETE for removing
+2. **Auth first** — always establish the authentication method before building the request
+3. **Validate the response** — always check status code, then parse the body
+4. **Handle errors** — every API call must have error handling for 4xx and 5xx responses
+
+### Request Structure
+
+```
+Method: GET | POST | PUT | PATCH | DELETE
+URL: https://api.example.com/endpoint
+Headers:
+  Content-Type: application/json
+  Authorization: Bearer <token>
+Body (POST/PUT): { "key": "value" }
+```
+
+### Auth Patterns
+
+| Auth Type | How to Apply |
+|-----------|-------------|
+| API Key | Header: `X-API-Key: key` or query param |
+| Bearer Token | Header: `Authorization: Bearer token` |
+| Basic Auth | Header: `Authorization: Basic base64(user:pass)` |
+| OAuth 2.0 | Exchange code for token, then use Bearer |
+
+### Common APIs
+
+- **CoinGecko**: `GET https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd`
+- **NEAR RPC**: `POST https://rpc.mainnet.near.org` with JSON-RPC body
+- **OpenAI**: `POST https://api.openai.com/v1/chat/completions` with Bearer token
+
+### Mistakes to Avoid
+
+- Never hardcode API keys in code — use environment variables
+- Don't ignore rate limits — check the API docs for limits and add retry logic
+- Don't assume success — always check `response.ok` or status code
+
+## Guidelines
+
+- Always provide a complete working code snippet (JS fetch, Python requests, or curl)
+- Include error handling in every example
+- If the user's API key is visible, remind them to keep it secret
+- For NEAR RPC specifically, use JSON-RPC 2.0 format

--- a/skills/arbitrage-spotter/SKILL.md
+++ b/skills/arbitrage-spotter/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: arbitrage-spotter
+version: 1.0.0
+description: Identify price differences across exchanges and chains to find arbitrage opportunities
+activation:
+  keywords:
+    - "arbitrage"
+    - "price difference"
+    - "arb opportunity"
+    - "same price on different exchange"
+    - "cross exchange"
+    - "spread between exchanges"
+    - "price discrepancy"
+  patterns:
+    - "(?i)(arbitrage|arb).*(opportunity|between|across|spot)"
+    - "(?i)(price difference|spread|discrepancy).*(between|across).*(exchange|chain|dex|cex)"
+    - "(?i)(is.*(cheaper|more expensive) on).*(exchange|chain|dex)"
+  tags:
+    - "trading"
+    - "arbitrage"
+    - "execution"
+  max_context_tokens: 2000
+---
+
+# Arbitrage Spotter Skill
+
+Identifies price discrepancies across centralized exchanges, DEXs, and chains that can be exploited for risk-reduced profit through arbitrage.
+
+## When to Use
+
+- User wants to find arbitrage opportunities across exchanges
+- User notices a price difference between two platforms
+- User asks if a token is cheaper on one exchange vs. another
+- User wants to understand cross-chain or CEX-DEX arbitrage
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Arb exists because of inefficiency** — price differences appear due to fragmented liquidity, slow information, and friction
+2. **Speed and fees determine viability** — an arb that looks profitable may not be after fees, gas, and slippage
+3. **Most arb is competed away fast** — bots dominate pure arb; human opportunities are in slower, more complex arbs
+4. **Risk is never zero** — execution risk, withdrawal delays, and price moves can turn an arb into a loss
+
+### Types of Arbitrage
+
+**Simple Cross-Exchange Arb**
+- Asset is $100 on Exchange A and $101 on Exchange B
+- Buy on A, transfer, sell on B
+- Profit = spread minus fees minus withdrawal time risk
+- Risk: price moves during transfer window (usually 10–60 min for crypto)
+
+**CEX-DEX Arbitrage**
+- Token price differs between a CEX and a DEX
+- Buy cheap side, sell expensive side
+- Fast execution required — bots dominate this
+- Human edge: larger spreads on smaller/newer tokens
+
+**Triangular Arbitrage**
+- Within one exchange: trade A→B→C→A and profit from pricing inefficiency
+- Example: USDC→BTC→ETH→USDC and end up with more USDC than you started
+- Rare on major assets; more common on small altcoin pairs
+
+**Cross-Chain Arbitrage**
+- Same token priced differently on different chains (ETH on Ethereum vs ETH on Arbitrum)
+- Bridge the cheap side, sell the expensive side
+- Risk: bridge time (minutes to hours), bridge fees, smart contract risk
+
+**Funding Rate Arbitrage**
+- Buy spot + short perpetual = earn funding without directional risk
+- Works when funding rates are significantly positive
+- Best risk-adjusted arb for retail traders
+
+**Basis Trading**
+- Buy spot + short futures at premium = capture the basis (futures premium) at expiry
+- Low risk, predictable return, requires capital locking
+
+### Viability Calculator
+
+Before executing any arb:
+```
+Gross spread = Price B - Price A (as %)
+Costs:
+  - Exchange A trading fee: ~0.1%
+  - Exchange B trading fee: ~0.1%
+  - Withdrawal fee: [check current fee]
+  - Gas (if DeFi involved): [check current gas]
+  - Slippage on both sides: ~0.1–0.5%
+
+Net profit = Gross spread - All costs
+
+Only proceed if Net profit > 0.3% (to account for execution risk)
+```
+
+### Where to Find Arb Opportunities
+
+| Tool | What It Shows |
+|------|--------------|
+| Coingecko / CMC | Price across exchanges for any token |
+| Paraswap / 1inch | CEX vs DEX price comparison |
+| DeFi Llama | Cross-chain token prices |
+| Funding rate arb | Coinglass (compare rates across exchanges) |
+| CryptoArbitrageScanner | Automated spread scanner |
+
+### Best Arb Opportunities for Retail
+
+1. **Funding rate arb** — easiest, most accessible, no speed requirement
+2. **New token listings** — CEX lists token that's been on DEX; price often differs initially
+3. **Regional exchange spreads** — some Asian exchanges price differently from Western ones
+4. **Cross-chain new tokens** — same token on two chains before bridges equilibrate
+
+### Mistakes to Avoid
+
+- Don't ignore transfer/withdrawal times — price can move against you while waiting
+- Don't forget to factor ALL fees (trading, withdrawal, gas, bridge)
+- Don't arb with more capital than you can afford to have locked for hours
+- Don't manually compete with bots on CEX-DEX arb — you will lose
+
+## Guidelines
+
+- Always calculate net profit after ALL fees before recommending an arb
+- Flag the execution time risk for any arb involving transfers
+- Recommend funding rate arb as the most accessible option for most users
+- For specific opportunities, always verify prices live — arb windows close in seconds to minutes

--- a/skills/bug-finder/SKILL.md
+++ b/skills/bug-finder/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: bug-finder
+version: 1.0.0
+description: Identify, diagnose, and fix bugs in code with root cause analysis
+activation:
+  keywords:
+    - "find the bug"
+    - "why is this broken"
+    - "not working"
+    - "error in my code"
+    - "debug this"
+    - "fix this bug"
+    - "why does this crash"
+    - "unexpected behavior"
+  patterns:
+    - "(?i)(find|spot|fix|debug).*(bug|error|issue|problem)"
+    - "(?i)(why|what).*(not working|broken|failing|crashing|wrong)"
+    - "(?i)(getting|receiving|throwing).*(error|exception|traceback)"
+  tags:
+    - "dev"
+    - "debugging"
+    - "code"
+  max_context_tokens: 2000
+---
+
+# Bug Finder Skill
+
+Identifies the root cause of bugs, errors, and unexpected behavior in code — then provides a clear fix with explanation.
+
+## When to Use
+
+- User shares code that isn't working as expected
+- User pastes an error message or stack trace
+- User describes unexpected behavior in their program
+- User asks "why does this crash/fail/return wrong output"
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Find the root cause, not the symptom** — don't just fix the line that throws; find why it throws
+2. **Reproduce mentally** — trace through the code step by step as if executing it
+3. **One bug at a time** — identify the primary bug first; list secondary issues separately
+4. **Explain before fixing** — always explain what the bug is and why it happens before showing the fix
+
+### Debugging Process
+
+1. **Read the error** — parse the error type, message, and line number
+2. **Locate the failure point** — identify which line/function fails
+3. **Trace backwards** — find what leads to that failure (bad input, wrong state, off-by-one, etc.)
+4. **Identify root cause** — what is the actual mistake (logic error, type mismatch, async issue, etc.)?
+5. **Provide the fix** — show corrected code with comments explaining the change
+
+### Common Bug Categories
+
+| Bug Type | Common Causes |
+|----------|--------------|
+| Type errors | Wrong data type passed, missing conversion |
+| Null/undefined | Missing null check, uninitialized variable |
+| Off-by-one | Loop boundary wrong, index starts at 1 not 0 |
+| Async bugs | Missing await, race condition, unhandled promise |
+| Logic errors | Wrong operator, inverted condition |
+| Scope errors | Variable shadowing, closure capture issues |
+
+### Mistakes to Avoid
+
+- Don't guess — trace the code before concluding
+- Don't fix without explaining — the user needs to understand
+- Don't introduce new bugs while fixing
+
+## Guidelines
+
+- Always show: ❌ Buggy code → ✅ Fixed code, side by side
+- If the error message is pasted, parse it first before looking at the code
+- If multiple bugs are found, fix the blocking one first, list the rest as follow-ups

--- a/skills/chart-reader/SKILL.md
+++ b/skills/chart-reader/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: chart-reader
+version: 1.0.0
+description: Interpret price charts, candlestick patterns, support/resistance levels, and chart structures
+activation:
+  keywords:
+    - "read this chart"
+    - "what does the chart say"
+    - "candlestick"
+    - "support level"
+    - "resistance level"
+    - "price action"
+    - "chart pattern"
+    - "double top"
+    - "head and shoulders"
+    - "bull flag"
+  patterns:
+    - "(?i)(read|interpret|analyze|look at).*(chart|candle|price action)"
+    - "(?i)(support|resistance|level).*(at|around|near)"
+    - "(?i)(what (is|does)).*(chart|pattern|candle).*(saying|showing|mean)"
+  tags:
+    - "trading"
+    - "technical-analysis"
+    - "charts"
+  max_context_tokens: 2000
+---
+
+# Chart Reader Skill
+
+Interprets price charts by identifying candlestick patterns, support/resistance levels, chart structures, and what they imply about future price direction.
+
+## When to Use
+
+- User shares a chart or describes price action and wants interpretation
+- User asks about support, resistance, or key price levels
+- User wants to identify a chart pattern (flag, wedge, head & shoulders, etc.)
+- User wants to know if a chart is bullish or bearish
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Price action is the primary signal** — what the candles are doing matters more than any indicator
+2. **Support and resistance are zones, not lines** — price respects areas, not exact numbers
+3. **Pattern context matters** — a bullish pattern in a downtrend is weaker than in an uptrend
+4. **Volume confirms structure** — any breakout or reversal without volume is suspect
+
+### Candlestick Patterns
+
+**Bullish Reversal**
+- Hammer: small body, long lower wick — buyers stepped in hard
+- Bullish Engulfing: green candle fully engulfs previous red — momentum shift
+- Morning Star: 3-candle reversal — indecision → rejection → confirmation
+- Doji at support: indecision at key level — potential reversal
+
+**Bearish Reversal**
+- Shooting Star: small body, long upper wick — sellers rejected the push
+- Bearish Engulfing: red candle fully engulfs previous green — sellers took over
+- Evening Star: 3-candle top reversal
+- Doji at resistance: indecision at key level — potential rejection
+
+**Continuation**
+- Bullish Flag: tight pullback after strong move up — likely to continue up
+- Bear Flag: tight bounce after strong move down — likely to continue down
+- Inside Bar: consolidation — breakout direction determines next move
+
+### Chart Structures
+
+| Pattern | Implication |
+|---------|------------|
+| Higher highs + higher lows | Uptrend intact |
+| Lower highs + lower lows | Downtrend intact |
+| Head & Shoulders | Major top reversal |
+| Inverse H&S | Major bottom reversal |
+| Double Top | Bearish reversal at resistance |
+| Double Bottom | Bullish reversal at support |
+| Ascending Triangle | Bullish breakout likely |
+| Descending Triangle | Bearish breakdown likely |
+| Symmetrical Triangle | Breakout either direction — watch volume |
+
+### Support & Resistance Rules
+
+- Previous highs become resistance; previous lows become support
+- The more times a level is tested, the more significant it is
+- A level that flips (support becomes resistance or vice versa) is very strong
+- Round numbers ($50,000, $100, $1.00) act as psychological S/R
+
+### Mistakes to Avoid
+
+- Don't identify a pattern and ignore the broader trend context
+- Don't treat a single candle as a confirmed signal — wait for the close
+- Don't draw too many lines — 2–3 key levels are more useful than 20
+
+## Guidelines
+
+- Always identify: timeframe, trend direction, key levels, and nearest pattern
+- State the bullish and bearish scenarios — don't just pick one
+- Always note: "Wait for candle close to confirm" before calling a pattern complete
+- Pair every chart read with a suggested invalidation level

--- a/skills/code-reviewer/SKILL.md
+++ b/skills/code-reviewer/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: code-reviewer
+version: 1.0.0
+description: Review code for bugs, style issues, performance problems, and security vulnerabilities
+activation:
+  keywords:
+    - "review my code"
+    - "check my code"
+    - "code review"
+    - "what's wrong with this code"
+    - "improve this code"
+    - "is this code good"
+    - "refactor"
+    - "code feedback"
+  patterns:
+    - "(?i)(review|check|audit|improve|refactor).*(code|function|script|class|component)"
+    - "(?i)(what('s| is) wrong|any (issues|problems|bugs)).*(code|this)"
+    - "(?i)(give me|provide).*(feedback|review).*(on|for).*code"
+  tags:
+    - "dev"
+    - "code"
+    - "quality"
+  max_context_tokens: 2000
+---
+
+# Code Reviewer Skill
+
+Performs thorough code reviews covering correctness, performance, security, readability, and best practices across all major languages.
+
+## When to Use
+
+- User shares code and asks for feedback or review
+- User wants to improve, refactor, or optimize code
+- User suspects a bug but can't find it
+- User wants a second opinion before shipping
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Review in layers** — check in order: correctness → security → performance → readability → style
+2. **Be specific** — point to the exact line/function with the issue, not vague statements
+3. **Explain why** — don't just say "this is wrong"; explain the consequence and the fix
+4. **Prioritize severity** — label issues as 🔴 Critical / 🟡 Warning / 🟢 Suggestion
+
+### Review Checklist
+
+**Correctness**
+- Does the logic produce the right output?
+- Are edge cases handled (null, empty, overflow)?
+- Are all code paths reachable and correct?
+
+**Security**
+- Any injection vulnerabilities (SQL, XSS, etc.)?
+- Are secrets hardcoded?
+- Is user input validated and sanitized?
+
+**Performance**
+- Any unnecessary loops, re-renders, or DB calls?
+- Are expensive operations cached?
+- Memory leaks?
+
+**Readability**
+- Are variable/function names clear?
+- Is the code DRY (Don't Repeat Yourself)?
+- Are complex sections commented?
+
+### Mistakes to Avoid
+
+- Don't rewrite the entire code unprompted — suggest targeted improvements
+- Don't enforce stylistic preferences as correctness issues
+- Never call code "bad" — be constructive
+
+## Guidelines
+
+- Always start with what the code does well before listing issues
+- Group feedback by severity using 🔴🟡🟢 labels
+- Provide corrected code snippets for every issue raised
+- Ask about the language/framework if not obvious from context

--- a/skills/crypto-tracker/SKILL.md
+++ b/skills/crypto-tracker/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: crypto-tracker
+version: 1.0.0
+description: Fetch and interpret cryptocurrency prices, market data, and token analytics
+activation:
+  keywords:
+    - "crypto price"
+    - "token price"
+    - "bitcoin"
+    - "ethereum"
+    - "market cap"
+    - "coin"
+    - "what is BTC"
+    - "ETH price"
+    - "NEAR price"
+    - "crypto market"
+  patterns:
+    - "(?i)(price|value|worth).*of.*(token|coin|crypto|btc|eth|near)"
+    - "(?i)(how much is|what is).*(trading at|worth|priced)"
+    - "(?i)(bull|bear|pump|dump|ath|dip).*market"
+  tags:
+    - "crypto"
+    - "finance"
+    - "data"
+  max_context_tokens: 2000
+---
+
+# Crypto Tracker Skill
+
+Helps the agent fetch, interpret, and explain cryptocurrency prices, market trends, and token data using real-time tools.
+
+## When to Use
+
+- User asks about the price of any cryptocurrency or token
+- User wants market cap, volume, or 24h change data
+- User mentions specific tokens: BTC, ETH, NEAR, SOL, etc.
+- User wants to compare token performance
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Always fetch live data** — never guess or use memorized prices; crypto moves fast
+2. **Provide context** — a price alone is useless; include 24h change, market cap, and trend direction
+3. **Name the source** — always state where the data came from (CoinGecko, CoinMarketCap, NEAR RPC, etc.)
+4. **Explain the numbers** — not all users are traders; briefly interpret what the data means
+
+### Data Points to Include
+
+When reporting on a token, always try to include:
+- Current price (USD and relevant pair)
+- 24h % change (with 📈 or 📉 indicator)
+- Market cap rank
+- 24h trading volume
+- ATH and % below ATH (if relevant)
+
+### Common Patterns
+
+- For price queries: fetch → format → contextualize
+- For trend queries: compare 7d/30d performance, note major events
+- For NEAR ecosystem tokens: use NEAR RPC or Ref Finance data where possible
+
+### Mistakes to Avoid
+
+- Never state a price without a timestamp — crypto prices are time-sensitive
+- Don't confuse market cap with price
+- Avoid making price predictions; present data only
+
+## Guidelines
+
+- Use CoinGecko API for broad market data
+- Use NEAR RPC for on-chain NEAR token data
+- Always include: "Data as of [timestamp]" at the end of price reports
+- If a token is not found, suggest the closest match and ask for confirmation

--- a/skills/dca-strategist/SKILL.md
+++ b/skills/dca-strategist/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: dca-strategist
+version: 1.0.0
+description: Build dollar cost averaging plans for long-term crypto accumulation with schedule and sizing optimization
+activation:
+  keywords:
+    - "DCA"
+    - "dollar cost average"
+    - "accumulate"
+    - "buy regularly"
+    - "long term buying"
+    - "weekly buy"
+    - "monthly buy"
+    - "stack sats"
+    - "accumulation plan"
+  patterns:
+    - "(?i)(DCA|dollar.?cost.?averag).*(plan|strategy|into|bitcoin|eth)"
+    - "(?i)(accumulate|stack|build position).*(slowly|over time|long term)"
+    - "(?i)(buy|invest).*(weekly|monthly|every|regularly).*(bitcoin|eth|crypto)"
+  tags:
+    - "trading"
+    - "strategy"
+    - "long-term"
+  max_context_tokens: 2000
+---
+
+# DCA Strategist Skill
+
+Designs disciplined dollar cost averaging plans for long-term crypto accumulation — optimizing schedule, sizing, and asset selection for consistent wealth building.
+
+## When to Use
+
+- User wants a long-term accumulation strategy
+- User asks how to DCA into Bitcoin, ETH, or other assets
+- User wants to invest regularly without timing the market
+- User wants to optimize their existing DCA strategy
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Time in market > timing the market** — consistent buying over time beats trying to pick bottoms
+2. **Automate to remove emotion** — set the plan and execute mechanically; don't let fear stop a buy
+3. **DCA is not passive — optimize it** — value averaging and bear market acceleration improve returns
+4. **Asset selection matters most** — DCA into a dying asset doesn't work; choose wisely
+
+### DCA Strategy Types
+
+**Standard DCA (simplest)**
+- Buy a fixed dollar amount on a fixed schedule (weekly/monthly)
+- No market timing, fully automated
+- Best for: beginners, busy investors, pure long-term holders
+
+**Value Averaging DCA (smarter)**
+- Set a target portfolio value growth per period (e.g., +$500/month)
+- Buy MORE when price is down (to hit the target), buy LESS when price is up
+- Result: automatically buys more in bear markets, less in bull markets
+- Best for: investors who can vary their monthly investment
+
+**Bear Market Acceleration**
+- Standard DCA baseline every month
+- Additional buy when asset drops >20% from recent high
+- Additional buy when asset drops >40% from recent high
+- Best for: investors with cash reserves watching for dips
+
+### DCA Plan Template
+
+```
+ASSET: [BTC / ETH / Other]
+TOTAL MONTHLY BUDGET: $[Amount]
+STRATEGY: Standard / Value Averaging / Accelerated
+
+SCHEDULE:
+  Weekly: $[Amount] every [Day] — [Platform]
+  Monthly: $[Amount] on [Date] — [Platform]
+
+DIP ACCELERATION:
+  -20% from ATH: Buy extra $[Amount]
+  -40% from ATH: Buy extra $[Amount]
+  -60% from ATH: Buy extra $[Amount] (maximum conviction)
+
+REBALANCING:
+  Frequency: [Quarterly/Annually]
+  Rule: If any asset >X% of portfolio, trim back to target
+
+STOP BUYING IF:
+  [Fundamental thesis broken] — define what would make you stop
+```
+
+### Asset Allocation for DCA
+
+**Conservative long-term**
+- 70% BTC, 30% ETH
+
+**Moderate long-term**
+- 50% BTC, 30% ETH, 20% select altcoins
+
+**Aggressive long-term**
+- 40% BTC, 30% ETH, 30% high-conviction altcoins
+
+**NEAR ecosystem focus**
+- 40% BTC, 30% ETH, 30% NEAR/ecosystem tokens
+
+### DCA Platforms
+
+| Platform | Type | Notes |
+|----------|------|-------|
+| Coinbase | CEX | Auto-buy feature built in |
+| Swan Bitcoin | BTC only | Best for BTC-only DCA |
+| Binance | CEX | Recurring buy available |
+| Strike | BTC only | Low fees, lightning network |
+| DeFi (self-custody) | Manual | More control, more effort |
+
+### Mistakes to Avoid
+
+- Don't pause DCA during bear markets — that's when it matters most
+- Don't DCA into assets with broken fundamentals
+- Don't forget to account for fees — frequent small buys can have high fee impact
+- Don't DCA without a thesis — know WHY you're accumulating this asset
+
+## Guidelines
+
+- Always ask: budget, timeframe, risk tolerance, and target assets
+- Output a specific weekly/monthly schedule with dollar amounts
+- Include a dip-buying acceleration rule in every plan
+- Remind user: DCA is a marathon — measure success in years, not weeks

--- a/skills/decision-maker/SKILL.md
+++ b/skills/decision-maker/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: decision-maker
+version: 1.0.0
+description: Help users weigh options, evaluate tradeoffs, and reach clear decisions using structured reasoning
+activation:
+  keywords:
+    - "help me decide"
+    - "which should I choose"
+    - "pros and cons"
+    - "what should I do"
+    - "compare options"
+    - "decision"
+    - "should I"
+    - "which is better"
+  patterns:
+    - "(?i)(help me|should I).*(decide|choose|pick|select)"
+    - "(?i)(pros and cons|tradeoffs|comparison).*(of|between)"
+    - "(?i)which (is|would be|should I).*(better|best|choose|pick)"
+  tags:
+    - "reasoning"
+    - "planning"
+    - "strategy"
+  max_context_tokens: 2000
+---
+
+# Decision Maker Skill
+
+Guides users through structured decision-making by surfacing tradeoffs, applying relevant frameworks, and delivering a clear, reasoned recommendation.
+
+## When to Use
+
+- User is choosing between two or more options
+- User asks "what should I do" or "which is better"
+- User wants pros/cons analysis
+- User is stuck or overwhelmed by a decision
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Clarify before deciding** — understand the user's goals, constraints, and values before analyzing
+2. **Structure the comparison** — use a consistent framework so options are evaluated fairly
+3. **Make a recommendation** — don't just list pros/cons; commit to a reasoned suggestion
+4. **Separate facts from preferences** — distinguish objective tradeoffs from subjective fit
+
+### Decision Frameworks
+
+**For simple binary choices**: Pros/Cons list + weighted score
+
+**For complex multi-option decisions**: Decision matrix
+- List options as columns
+- List criteria as rows (weighted by importance)
+- Score each option per criterion
+- Calculate weighted totals
+
+**For high-stakes/irreversible decisions**: Pre-mortem
+- Imagine each option failed — what went wrong?
+- Use this to stress-test the leading option
+
+**For values-based decisions**: Values alignment check
+- What does the user care most about?
+- Which option best honors those values?
+
+### Recommendation Structure
+
+1. Restate the decision and key constraints
+2. Present the comparison (table or bullets)
+3. State the recommendation clearly: "I recommend **Option A** because..."
+4. Acknowledge the main risk of your recommendation
+5. Offer a contingency: "If X changes, reconsider Option B"
+
+### Mistakes to Avoid
+
+- Don't give a wishy-washy answer — users want a recommendation, not a list
+- Don't ignore stated constraints (budget, timeline, values)
+- Don't present all options as equal if they clearly aren't
+
+## Guidelines
+
+- Always ask: What matters most to you in this decision? (if not stated)
+- Use a comparison table for 3+ options
+- End with a single clear recommendation + the one key reason

--- a/skills/defi-navigator/SKILL.md
+++ b/skills/defi-navigator/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: defi-navigator
+version: 1.0.0
+description: Guide users through DeFi protocols, yield strategies, liquidity pools, and on-chain finance
+activation:
+  keywords:
+    - "defi"
+    - "yield farming"
+    - "liquidity pool"
+    - "staking"
+    - "lending protocol"
+    - "aave"
+    - "uniswap"
+    - "ref finance"
+    - "APY"
+    - "APR"
+    - "impermanent loss"
+    - "smart contract finance"
+  patterns:
+    - "(?i)(defi|yield|liquidity|staking|lending|borrowing).*(protocol|pool|farm|strategy)"
+    - "(?i)(aave|uniswap|compound|curve|ref.?finance|burrow)"
+    - "(?i)(impermanent loss|APY|APR|TVL|liquidation)"
+  tags:
+    - "finance"
+    - "defi"
+    - "crypto"
+  max_context_tokens: 2000
+---
+
+# DeFi Navigator Skill
+
+Guides users through decentralized finance protocols, yield strategies, risk management, and on-chain financial tools.
+
+## When to Use
+
+- User asks about DeFi protocols (Aave, Uniswap, Ref Finance, etc.)
+- User wants to understand yield farming, staking, or liquidity providing
+- User asks about APY, impermanent loss, or TVL
+- User wants to know how to earn yield on their crypto
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Risk is always present** — DeFi has smart contract risk, liquidation risk, and impermanent loss; always surface relevant risks
+2. **APY is not guaranteed** — yield rates fluctuate; never present APY as fixed income
+3. **Protocol maturity matters** — older, audited protocols with high TVL are generally safer than new ones
+4. **Gas and fees count** — always factor transaction costs into yield calculations
+
+### DeFi Concepts Explained
+
+**Liquidity Pool (LP)**: Provide two tokens to a pool, earn trading fees. Risk: impermanent loss if token ratio shifts.
+
+**Yield Farming**: Stake LP tokens to earn additional token rewards on top of fees.
+
+**Lending/Borrowing**: Deposit assets to earn interest (lending) or deposit collateral to borrow (borrowing). Risk: liquidation if collateral value drops.
+
+**Staking**: Lock tokens to secure a network or earn protocol rewards. Usually lower risk than LP.
+
+**Impermanent Loss**: When you provide liquidity, price divergence between your two tokens can result in less value than simply holding them.
+
+### Key Protocols by Chain
+
+| Chain | Protocol | Type |
+|-------|----------|------|
+| Ethereum | Aave, Uniswap, Compound | Lending, DEX |
+| NEAR | Ref Finance, Burrow | DEX, Lending |
+| Multi-chain | Curve, Convex | Stablecoin yield |
+
+### Risk Assessment Framework
+
+- **Low risk**: Stablecoin staking, blue-chip protocol lending
+- **Medium risk**: LP in major pairs (ETH/USDC), established protocol farming
+- **High risk**: New protocol farming, leveraged positions, volatile pair LPs
+
+### Mistakes to Avoid
+
+- Never recommend chasing the highest APY without explaining the risks
+- Don't ignore smart contract audit status for new protocols
+- Don't calculate yield without accounting for gas costs
+
+## Guidelines
+
+- Always pair any yield strategy with its associated risks
+- For NEAR ecosystem: prioritize Ref Finance and Burrow knowledge
+- End yield discussions with: "DeFi carries significant risks including loss of principal. Do your own research."
+- If asked about a protocol you don't recognize, flag it as unverified and recommend checking DeFiLlama for TVL and audit status

--- a/skills/defi-trader/SKILL.md
+++ b/skills/defi-trader/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: defi-trader
+version: 1.0.0
+description: Execute token swaps on DEXs like Ref Finance and Uniswap with optimal routing, slippage, and gas settings
+activation:
+  keywords:
+    - "swap tokens"
+    - "defi swap"
+    - "uniswap"
+    - "ref finance"
+    - "best swap route"
+    - "slippage"
+    - "swap on chain"
+    - "dex trade"
+    - "buy on uniswap"
+  patterns:
+    - "(?i)(swap|trade|buy|sell).*(on|via|using).*(uniswap|ref finance|dex|curve|1inch)"
+    - "(?i)(best|cheapest|optimal).*(swap|route|price).*(for|on).*(token|dex)"
+    - "(?i)(slippage|gas|price impact).*(swap|trade|dex)"
+  tags:
+    - "defi"
+    - "trading"
+    - "execution"
+  max_context_tokens: 2000
+---
+
+# DeFi Trader Skill
+
+Guides users through executing on-chain token swaps with optimal routing, safe slippage settings, and gas optimization across major DEXs.
+
+## When to Use
+
+- User wants to swap tokens on a DEX
+- User asks about the best route or platform for a swap
+- User wants to know correct slippage settings
+- User is confused about gas fees or price impact
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Price impact kills large swaps** — always check price impact before confirming; >1% is significant
+2. **Slippage tolerance must be set correctly** — too low = failed transaction; too high = sandwich attack vulnerability
+3. **Use aggregators for best price** — 1inch, Paraswap find better rates than going direct to one DEX
+4. **Gas timing matters on Ethereum** — swap during low-traffic hours to save on gas
+
+### DEX Reference Guide
+
+**Ethereum / EVM**
+| DEX | Best For |
+|-----|---------|
+| Uniswap V3 | Major pairs, concentrated liquidity |
+| Curve | Stablecoin swaps (lowest slippage) |
+| 1inch | Aggregator — always check here first |
+| Paraswap | Alternative aggregator |
+| Balancer | Multi-token pools |
+
+**NEAR Protocol**
+| DEX | Best For |
+|-----|---------|
+| Ref Finance | Main NEAR DEX, most liquidity |
+| Jumbo Exchange | Alternative NEAR DEX |
+| 1inch (Aurora) | Aurora EVM chain on NEAR |
+
+**Solana**
+| DEX | Best For |
+|-----|---------|
+| Jupiter | Best aggregator on Solana |
+| Raydium | Major pairs |
+| Orca | User-friendly, concentrated liquidity |
+
+### Slippage Settings Guide
+
+| Situation | Recommended Slippage |
+|-----------|---------------------|
+| Major pairs (BTC, ETH, USDC) | 0.1–0.5% |
+| Mid-cap tokens | 0.5–1% |
+| Small-cap/new tokens | 1–3% |
+| Memecoins / low liquidity | 3–5% (use with caution) |
+| Stablecoin swaps | 0.01–0.1% |
+
+⚠️ Setting slippage >5% makes you vulnerable to sandwich bots on Ethereum
+
+### Swap Execution Checklist
+
+Before confirming any swap:
+- ✅ Check price impact (should be <1% ideally)
+- ✅ Set appropriate slippage tolerance
+- ✅ Verify you're on the correct network (ETH vs BSC vs Polygon)
+- ✅ Confirm the token contract address (avoid fake tokens)
+- ✅ Check gas estimate is reasonable
+- ✅ Compare price to CEX (are you getting ripped off?)
+
+### Price Impact vs. Slippage
+
+**Price Impact**: How much your trade moves the pool price. Large trades in small pools = high price impact. Check this before swapping.
+
+**Slippage Tolerance**: How much price movement you'll accept between submitting and executing. This protects against price changes while your tx is pending.
+
+### Gas Optimization (Ethereum)
+
+- Check gas prices at: ethgasstation.info or gas.eth.samczsun.com
+- Best times to swap: weekends, early morning UTC (2–8am UTC)
+- Use L2s (Arbitrum, Optimism, Base) for much cheaper swaps on same assets
+
+### Sandwich Attack Protection
+
+On Ethereum, MEV bots front-run large swaps. Protect yourself:
+- Keep slippage as low as possible while still getting filled
+- Use MEV protection: Flashbots Protect RPC or 1inch Fusion mode
+- For large swaps: split into multiple smaller transactions
+
+### Mistakes to Avoid
+
+- Never swap with >5% slippage unless you accept the risk
+- Don't swap a token without verifying the contract address on the block explorer
+- Don't swap without checking price impact — pools with low liquidity will eat you alive
+
+## Guidelines
+
+- Always recommend checking 1inch or Jupiter first for best route
+- Always state: recommended slippage, expected price impact, and estimated gas
+- For NEAR swaps: guide to Ref Finance as the primary DEX
+- Warn about sandwich attacks for any Ethereum swap with >1% slippage setting

--- a/skills/email-writer/SKILL.md
+++ b/skills/email-writer/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: email-writer
+version: 1.0.0
+description: Draft professional, clear, and effective emails for any business or personal context
+activation:
+  keywords:
+    - "write an email"
+    - "draft an email"
+    - "email to"
+    - "compose an email"
+    - "reply to this email"
+    - "email template"
+    - "write a message to"
+  patterns:
+    - "(?i)(write|draft|compose|send|reply).*(email|message|mail)"
+    - "(?i)help me.*(email|message|write to)"
+    - "(?i)(follow.?up|follow up).*(email|message)"
+  tags:
+    - "communication"
+    - "writing"
+    - "email"
+  max_context_tokens: 2000
+---
+
+# Email Writer Skill
+
+Drafts professional, context-appropriate emails with the right tone, structure, and clarity for any situation.
+
+## When to Use
+
+- User asks to write, draft, or compose an email
+- User needs to reply to an existing email
+- User wants a follow-up, cold outreach, or formal communication
+- User needs an email template for recurring use
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Tone matching** — match the email's tone to the relationship: formal for executives/strangers, semi-formal for colleagues, casual for close contacts
+2. **Purpose first** — every email must have one clear goal; structure everything around that goal
+3. **Brevity is respect** — keep emails short; busy people don't read walls of text
+4. **Strong subject lines** — the subject line determines if the email gets opened; make it specific and action-oriented
+
+### Email Structure
+
+Always follow this structure:
+1. **Subject** — specific, clear, ideally under 8 words
+2. **Greeting** — appropriate to relationship
+3. **Opening line** — context or reason for writing (1 sentence)
+4. **Body** — the core message (2–4 sentences max for simple emails)
+5. **Call to action** — one clear ask or next step
+6. **Sign-off** — appropriate closing
+
+### Tone Guide
+
+| Situation | Tone |
+|-----------|------|
+| Cold outreach | Professional, warm, brief |
+| Follow-up | Polite, direct, non-pushy |
+| Complaint | Firm, factual, solution-focused |
+| Apology | Sincere, accountable, forward-looking |
+| Request | Clear, respectful, with context |
+
+### Mistakes to Avoid
+
+- Never start with "I hope this email finds you well" — it's filler
+- Don't bury the ask at the bottom — state it early
+- Avoid passive voice; be direct
+
+## Guidelines
+
+- Always ask for: recipient relationship, purpose, and desired outcome if not provided
+- Offer to adjust tone after the first draft
+- For replies, ask the user to paste the original email for full context

--- a/skills/event-tracker/SKILL.md
+++ b/skills/event-tracker/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: event-tracker
+version: 1.0.0
+description: Monitor real-world events and breaking developments that move Polymarket prediction probabilities
+activation:
+  keywords:
+    - "track this event"
+    - "monitor market"
+    - "what events affect"
+    - "upcoming events"
+    - "event calendar"
+    - "what could move this market"
+    - "catalysts"
+  patterns:
+    - "(?i)(track|monitor|watch).*(event|market|development|news)"
+    - "(?i)(what|which).*(events|news|catalysts).*(affect|move|change).*(market|odds|price)"
+    - "(?i)(upcoming|scheduled|expected).*(event|announcement|decision|vote|report)"
+  tags:
+    - "polymarket"
+    - "events"
+    - "research"
+  max_context_tokens: 2000
+---
+
+# Event Tracker Skill
+
+Identifies and monitors real-world events, announcements, and catalysts that are likely to move Polymarket prediction market probabilities.
+
+## When to Use
+
+- User wants to know what events could affect a market's price
+- User wants to track scheduled announcements (elections, Fed decisions, court rulings)
+- User wants to be alerted to developments before the market reacts
+- User is holding a position and wants to know upcoming risk events
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Catalysts move markets** — know what events can flip a market before they happen
+2. **Scheduled > unscheduled** — plan around known dates (elections, rulings, reports); unscheduled events are the risk you manage
+3. **Time decay matters** — as resolution date approaches, prices converge to 0 or 100; position accordingly
+4. **First mover advantage** — reacting to an event before the market prices it in = edge
+
+### Event Categories by Market Type
+
+**Political Markets**
+- Polling releases (weekly/monthly)
+- Debate performances
+- Primary results
+- Major policy announcements
+- Scandal or legal developments
+
+**Economic Markets**
+- Fed FOMC meetings (scheduled 8x/year)
+- CPI/PPI inflation reports (monthly)
+- Jobs reports (first Friday of each month)
+- Earnings reports (quarterly)
+- GDP releases (quarterly)
+
+**Crypto Markets**
+- ETF approval/rejection dates
+- Protocol upgrade dates (halving, merge, etc.)
+- Regulatory announcements
+- Exchange listing/delisting events
+- On-chain governance votes
+
+**Sports Markets**
+- Injury reports
+- Team lineup announcements
+- Weather conditions (outdoor sports)
+- Referee/umpire assignments
+
+### Event Impact Assessment
+
+For each upcoming event, assess:
+- **Magnitude**: How much could this move the market? (Low/Medium/High)
+- **Direction**: Does it favor YES or NO?
+- **Timing**: How close to resolution date?
+- **Certainty**: Is this event itself certain to happen?
+
+### Mistakes to Avoid
+
+- Don't hold positions through binary events without knowing the risk
+- Don't assume scheduled events happen on time — delays are common
+- Don't ignore time zone differences for international events
+
+## Guidelines
+
+- For any market the user holds, identify the next 3 key events and their dates
+- Rate each event: 🔴 High impact / 🟡 Medium impact / 🟢 Low impact
+- Recommend whether to hold through the event or reduce position before it
+- Always provide the exact source/schedule URL for upcoming events

--- a/skills/fact-checker/SKILL.md
+++ b/skills/fact-checker/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: fact-checker
+version: 1.0.0
+description: Verify claims, identify misinformation, and assess source credibility
+activation:
+  keywords:
+    - "is this true"
+    - "fact check"
+    - "verify this"
+    - "is it true that"
+    - "check this claim"
+    - "is this accurate"
+    - "debunk"
+    - "misinformation"
+  patterns:
+    - "(?i)(fact.?check|verify|confirm|debunk).*(this|claim|statement)"
+    - "(?i)(is (it|this) true|is this accurate|really true).*(that)?"
+    - "(?i)(true or false|myth or fact)"
+  tags:
+    - "reasoning"
+    - "research"
+    - "verification"
+  max_context_tokens: 2000
+---
+
+# Fact Checker Skill
+
+Evaluates claims for accuracy, identifies misinformation, and assesses the reliability of sources using evidence-based reasoning.
+
+## When to Use
+
+- User shares a claim and wants to know if it's true
+- User suspects misinformation or a viral myth
+- User wants to verify a statistic, quote, or news story
+- User needs source credibility assessed
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Evidence over authority** — a credible source saying something doesn't make it true; look for verifiable evidence
+2. **Distinguish claim types** — factual claims (verifiable), opinion claims (not falsifiable), and predictions (uncertain)
+3. **Check primary sources** — always try to find the original data/study/quote, not a secondary report
+4. **Acknowledge uncertainty** — some things can't be definitively verified; say so clearly
+
+### Verification Process
+
+1. **Parse the claim** — what exactly is being asserted? (who, what, when, where)
+2. **Identify the type** — factual / opinion / prediction / misleading framing
+3. **Search for evidence** — look for primary sources, peer-reviewed data, official records
+4. **Cross-reference** — check at least 2 independent sources
+5. **Assess confidence** — rate as: ✅ True / ❌ False / ⚠️ Misleading / ❓ Unverified
+
+### Source Credibility Tiers
+
+| Tier | Examples |
+|------|----------|
+| High | Peer-reviewed journals, official government data, established wire services |
+| Medium | Major newspapers, established think tanks, verified experts |
+| Low | Blogs, social media posts, anonymous sources, partisan sites |
+| Red flag | No author, no date, no sources cited, sensationalist headline |
+
+### Mistakes to Avoid
+
+- Don't confirm a claim just because it sounds reasonable
+- Don't dismiss a claim just because it's surprising
+- Never say something is "probably true" without evidence
+
+## Guidelines
+
+- Always state your confidence level: ✅ True / ❌ False / ⚠️ Misleading / ❓ Unverified
+- Provide at least one source for your verdict
+- If the claim is partially true, explain what is accurate and what is not
+- For political claims, use non-partisan sources where possible

--- a/skills/funding-rate-watcher/SKILL.md
+++ b/skills/funding-rate-watcher/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: funding-rate-watcher
+version: 1.0.0
+description: Track and interpret perpetual futures funding rates to time long/short entries and avoid funding drain
+activation:
+  keywords:
+    - "funding rate"
+    - "funding fee"
+    - "positive funding"
+    - "negative funding"
+    - "funding is high"
+    - "when does funding reset"
+    - "funding rate arbitrage"
+  patterns:
+    - "(?i)(funding rate|funding fee).*(high|low|positive|negative|check|watch)"
+    - "(?i)(how much|what is).*(funding|funding rate|funding fee)"
+    - "(?i)(funding).*(arbitrage|trade|strategy)"
+  tags:
+    - "perps"
+    - "trading"
+    - "funding"
+  max_context_tokens: 2000
+---
+
+# Funding Rate Watcher Skill
+
+Monitors and interprets perpetual futures funding rates to help time entries, avoid costly funding drains, and exploit funding rate arbitrage opportunities.
+
+## When to Use
+
+- User wants to check current funding rates before entering a perp position
+- User is paying high funding fees and wants to know if it's worth holding
+- User wants to exploit funding rate differentials
+- User wants to understand what funding rates signal about market sentiment
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Funding rate = market sentiment gauge** — high positive funding = crowded longs = potential short opportunity
+2. **Funding is a cost** — holding a position against the funding direction bleeds money every 8 hours
+3. **Extreme funding = mean reversion signal** — when funding is extremely high or low, the market often reverses
+4. **Funding arbitrage is real** — spot long + perp short = earn funding with no directional risk
+
+### How Funding Works
+
+- Funding is paid every **8 hours** (most exchanges: 00:00, 08:00, 16:00 UTC)
+- **Positive funding**: Longs pay shorts — market is bullish/overleveraged long
+- **Negative funding**: Shorts pay longs — market is bearish/overleveraged short
+- Rate is typically 0.01% per 8h (0.03%/day) at neutral; can spike to 0.1–0.3%+ in extremes
+
+### Funding Rate Interpretation
+
+| Funding Rate | Signal | Action |
+|-------------|--------|--------|
+| >0.1% per 8h | Extremely bullish, crowded longs | Consider shorting or avoid new longs |
+| 0.01–0.05% | Mild bullish bias | Normal, monitor |
+| ~0.00% | Neutral market | No funding edge either way |
+| -0.01 to -0.05% | Mild bearish bias | Normal, monitor |
+| <-0.05% per 8h | Extremely bearish, crowded shorts | Consider longing or avoid new shorts |
+
+### Funding Rate Arbitrage (Delta Neutral)
+
+**Setup**: Buy spot + Short perp of same asset
+**Earn**: Funding payments from longs (when positive)
+**Risk**: Exchange risk, liquidation risk if perp moves against margin
+
+```
+Daily yield = Funding rate × 3 (paid 3x per day)
+Annual yield = Daily yield × 365
+
+Example: 0.05% per 8h funding
+Daily = 0.15%, Annual = ~54% on the short margin
+```
+
+### Where to Check Funding Rates
+
+- **Coinglass.com** — best multi-exchange funding rate dashboard
+- **Bybit / Binance** — check in the perp contract details
+- **Hyperliquid** — on-chain, check their UI directly
+
+### Mistakes to Avoid
+
+- Never ignore funding when holding a position for multiple days
+- Don't enter a crowded long in high positive funding without awareness of the bleed
+- Don't run funding arbitrage without accounting for exchange withdrawal/deposit risk
+
+## Guidelines
+
+- Always state the funding rate in both per-8h and annualized terms for clarity
+- For positions held >24h, calculate the total funding cost over the expected hold period
+- Flag when funding is in the top/bottom 10% historically — that's a signal worth acting on
+- Recommend Coinglass as the primary funding rate monitoring tool

--- a/skills/image-handler/SKILL.md
+++ b/skills/image-handler/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: image-handler
+version: 1.0.0
+description: Handle images passed as base64 blobs or URLs from Telegram or API and make them accessible to analysis tools
+activation:
+  keywords:
+    - "analyze this image"
+    - "look at this chart"
+    - "read this screenshot"
+    - "check this image"
+    - "image analysis"
+    - "analyze photo"
+    - "read image"
+  patterns:
+    - "(?i)(analyze|read|look at|check|interpret).*(image|photo|screenshot|chart|picture)"
+    - "(?i)(image|photo|screenshot).*(sent|attached|uploaded|shared)"
+    - "(?i)(can('t| not)|unable to).*(find|access|read|open).*(image|file|attachment)"
+  tags:
+    - "image"
+    - "vision"
+    - "utility"
+  max_context_tokens: 2000
+---
+
+# Image Handler Skill
+
+Handles images that arrive as base64 blobs (from Telegram or API) or as URLs, decodes them, writes them to a temporary filesystem path, and makes them accessible to any skill that requires a file path (chart-reader, rug-detector screenshots, Polymarket screenshots, etc).
+
+## When to Use
+
+- User sends an image via Telegram and the agent cannot locate the file
+- Agent receives an attachment stored in memory rather than on the filesystem
+- Any skill reports it cannot find or access an image file
+- User asks the agent to analyze a chart, screenshot, or photo
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Images from Telegram are never on disk** — they arrive as `message.photo` objects; always fetch and decode before passing to any tool
+2. **Base64 must be decoded first** — never pass raw base64 strings to file-based tools
+3. **Temp files are the bridge** — write decoded bytes to `/tmp/` so filesystem-based tools can access them
+4. **Always clean up** — delete temp files after analysis to avoid filling disk
+5. **URL images can be fetched directly** — no decode step needed, just download the bytes
+
+### Image Sources and How to Handle Each
+
+#### Source 1: Telegram Bot (most common)
+
+Images arrive as `message.photo` — an array of `PhotoSize` objects sorted smallest to largest.
+
+```python
+import tempfile
+import os
+from telegram import Update
+from telegram.ext import ContextTypes
+
+async def handle_telegram_image(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
+    """
+    Fetch image from Telegram, save to temp file, return path.
+    """
+    if not update.message.photo:
+        return None
+
+    # Always use the largest resolution
+    photo = update.message.photo[-1]
+    file = await context.bot.get_file(photo.file_id)
+
+    # Download as bytes
+    image_bytes = await file.download_as_bytearray()
+
+    # Write to temp file
+    tmp = tempfile.NamedTemporaryFile(
+        suffix=".png",
+        delete=False,
+        dir="/tmp",
+        prefix="ironclaw_img_"
+    )
+    tmp.write(image_bytes)
+    tmp.close()
+
+    return tmp.name  # e.g. /tmp/ironclaw_img_abc123.png
+```
+
+#### Source 2: Base64 String (API / webhook)
+
+```python
+import base64
+import tempfile
+import os
+
+def handle_base64_image(base64_string: str) -> str:
+    """
+    Decode base64 image string, save to temp file, return path.
+    """
+    # Strip data URI prefix if present (e.g. "data:image/png;base64,...")
+    if "," in base64_string:
+        base64_string = base64_string.split(",", 1)[1]
+
+    image_bytes = base64.b64decode(base64_string)
+
+    tmp = tempfile.NamedTemporaryFile(
+        suffix=".png",
+        delete=False,
+        dir="/tmp",
+        prefix="ironclaw_img_"
+    )
+    tmp.write(image_bytes)
+    tmp.close()
+
+    return tmp.name
+```
+
+#### Source 3: Image URL
+
+```python
+import requests
+import tempfile
+import os
+
+def handle_image_url(url: str) -> str:
+    """
+    Download image from URL, save to temp file, return path.
+    """
+    resp = requests.get(url, timeout=10)
+    resp.raise_for_status()
+
+    # Detect extension from content-type
+    content_type = resp.headers.get("Content-Type", "image/png")
+    ext = ".jpg" if "jpeg" in content_type else ".png"
+
+    tmp = tempfile.NamedTemporaryFile(
+        suffix=ext,
+        delete=False,
+        dir="/tmp",
+        prefix="ironclaw_img_"
+    )
+    tmp.write(resp.content)
+    tmp.close()
+
+    return tmp.name
+```
+
+### Universal Handler (auto-detects source)
+
+```python
+def prepare_image(image_input) -> str:
+    """
+    Auto-detect image source and return a filesystem path.
+
+    Accepts:
+      - Telegram PhotoSize object
+      - base64 string
+      - URL string (http/https)
+      - bytes directly
+
+    Returns:
+      - Absolute path to temp file e.g. /tmp/ironclaw_img_abc.png
+    """
+    import base64, tempfile, requests
+
+    # Already bytes
+    if isinstance(image_input, (bytes, bytearray)):
+        tmp = tempfile.NamedTemporaryFile(suffix=".png", delete=False, dir="/tmp", prefix="ironclaw_img_")
+        tmp.write(image_input)
+        tmp.close()
+        return tmp.name
+
+    if isinstance(image_input, str):
+        # URL
+        if image_input.startswith("http://") or image_input.startswith("https://"):
+            return handle_image_url(image_input)
+        # Base64 (with or without data URI prefix)
+        return handle_base64_image(image_input)
+
+    return None
+
+def cleanup_image(path: str):
+    """Delete temp file after analysis is complete."""
+    try:
+        if path and os.path.exists(path):
+            os.unlink(path)
+    except Exception:
+        pass
+```
+
+### Full Usage Pattern
+
+```python
+async def on_message(update, context):
+    # 1. Prepare image → get filesystem path
+    image_path = await handle_telegram_image(update, context)
+
+    if not image_path:
+        await update.message.reply_text("No image found. Please resend.")
+        return
+
+    try:
+        # 2. Pass path to any analysis skill
+        result = chart_reader.analyze(image_path)
+        # or: indicator_analyst.analyze(image_path)
+        # or: any tool that needs a file path
+
+        await update.message.reply_text(result)
+
+    finally:
+        # 3. Always clean up
+        cleanup_image(image_path)
+```
+
+### Supported Image Formats
+
+| Format | Extension | Notes |
+|--------|-----------|-------|
+| PNG | .png | Default for screenshots |
+| JPEG | .jpg | Common for photos |
+| WebP | .webp | Some Telegram images |
+| GIF | .gif | Static only — not animated |
+
+### Mistakes to Avoid
+
+- Never pass `file_id` directly to a vision tool — it's a Telegram reference, not a file path
+- Don't forget to `await` async Telegram calls — missing await causes silent failures
+- Don't hardcode `/tmp/image.png` — use `tempfile` to avoid conflicts when multiple images arrive simultaneously
+- Don't skip `cleanup_image()` — temp files accumulate and fill disk over time
+- Don't assume all base64 strings are clean — always strip the data URI prefix if present
+
+## Guidelines
+
+- When agent reports "cannot find image file" → immediately apply this skill's `prepare_image()` handler
+- Always use the largest available Telegram photo size (`message.photo[-1]`)
+- After preparing the image path, pass it to the appropriate analysis skill: `chart-reader`, `indicator-analyst`, or `trend-detector`
+- Always wrap analysis in try/finally to guarantee cleanup even if analysis fails
+- If image cannot be decoded after two attempts, ask the user to share it as a direct URL instead

--- a/skills/indicator-analyst/SKILL.md
+++ b/skills/indicator-analyst/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: indicator-analyst
+version: 1.0.0
+description: Read and interpret RSI, MACD, Bollinger Bands, moving averages, and other technical indicators
+activation:
+  keywords:
+    - "RSI"
+    - "MACD"
+    - "bollinger bands"
+    - "moving average"
+    - "EMA"
+    - "SMA"
+    - "overbought"
+    - "oversold"
+    - "indicator"
+    - "stochastic"
+    - "volume profile"
+  patterns:
+    - "(?i)(RSI|MACD|EMA|SMA|stoch|bollinger|VWAP|OBV).*(reading|showing|says|at|level)"
+    - "(?i)(overbought|oversold|divergence|crossover|golden cross|death cross)"
+    - "(?i)(what (does|is) the).*(indicator|RSI|MACD|EMA).*(say|mean|show)"
+  tags:
+    - "trading"
+    - "technical-analysis"
+    - "indicators"
+  max_context_tokens: 2000
+---
+
+# Indicator Analyst Skill
+
+Reads, interprets, and synthesizes technical indicators including RSI, MACD, Bollinger Bands, and moving averages to assess momentum, trend, and potential reversals.
+
+## When to Use
+
+- User asks about the reading of a specific indicator
+- User wants to know if an asset is overbought or oversold
+- User asks about indicator crossovers, divergences, or signals
+- User wants multiple indicators synthesized into one view
+
+## Core Knowledge
+
+### Key Principles
+
+1. **No indicator is perfect alone** — always combine at least 2–3 indicators for confluence
+2. **Indicators lag** — they confirm what already happened; use them to validate, not predict alone
+3. **Divergence is powerful** — when price and indicator disagree, the indicator often wins
+4. **Context over signals** — an RSI of 70 in a strong uptrend means less than RSI 70 at major resistance
+
+### Indicator Reference Guide
+
+**RSI (Relative Strength Index)**
+- Range: 0–100
+- >70: Overbought (potential reversal or pullback)
+- <30: Oversold (potential bounce or reversal)
+- 40–60: Neutral zone
+- Bullish divergence: Price makes lower low, RSI makes higher low → reversal signal
+- Bearish divergence: Price makes higher high, RSI makes lower high → reversal signal
+- Best timeframes: 1h, 4h, Daily
+
+**MACD (Moving Average Convergence Divergence)**
+- MACD line crosses above signal line → Bullish momentum
+- MACD line crosses below signal line → Bearish momentum
+- Histogram growing → momentum strengthening
+- Histogram shrinking → momentum weakening
+- Divergence between MACD and price = high-value signal
+
+**Bollinger Bands**
+- Price touching upper band → overbought in current trend
+- Price touching lower band → oversold in current trend
+- Band squeeze (bands narrow) → volatility contraction, big move coming
+- Band expansion → trend is accelerating
+- Price walking the upper band → strong uptrend
+- Price walking the lower band → strong downtrend
+
+**Moving Averages**
+| MA | Use |
+|----|-----|
+| 20 EMA | Short-term trend, dynamic support/resistance |
+| 50 EMA | Medium-term trend |
+| 200 EMA/SMA | Long-term trend, major support/resistance |
+| Golden Cross | 50 MA crosses above 200 MA → long-term bullish |
+| Death Cross | 50 MA crosses below 200 MA → long-term bearish |
+
+**VWAP (Volume Weighted Average Price)**
+- Price above VWAP → bullish bias for the session
+- Price below VWAP → bearish bias
+- Great for intraday entries — buy near VWAP in uptrend
+
+**Stochastic RSI**
+- More sensitive than RSI
+- >80: Overbought | <20: Oversold
+- Best for short timeframes (15m, 1h)
+
+### Confluence Framework
+
+Strong signal = 3+ indicators agree:
+- RSI oversold + MACD bullish cross + price at 200 EMA = strong buy signal
+- RSI overbought + MACD bearish cross + price at upper Bollinger = strong sell signal
+
+### Mistakes to Avoid
+
+- Don't act on a single indicator signal — wait for confluence
+- Don't use the same type of indicator twice (e.g., RSI + Stoch = two momentum indicators, not confirmation)
+- Don't ignore divergence — it's one of the highest-probability signals in technical analysis
+
+## Guidelines
+
+- Always combine: one trend indicator (MA) + one momentum indicator (RSI/MACD) + one volatility indicator (BB)
+- State whether indicators agree or conflict — conflict = wait for clarity
+- Always specify the timeframe — an RSI reading on 5m means nothing compared to daily
+- End with: overall bias (Bullish / Bearish / Neutral) based on indicator confluence

--- a/skills/liquidation-hunter/SKILL.md
+++ b/skills/liquidation-hunter/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: liquidation-hunter
+version: 1.0.0
+description: Identify liquidation clusters and trade around them for high-probability entries and exits
+activation:
+  keywords:
+    - "liquidation"
+    - "liq cluster"
+    - "liquidation map"
+    - "liquidation zone"
+    - "where are the liquidations"
+    - "hunt stops"
+    - "stop hunt"
+    - "liquidation cascade"
+  patterns:
+    - "(?i)(liquidation|liq).*(cluster|map|zone|level|cascade)"
+    - "(?i)(where are|find|check).*(liquidations|liq levels|stops)"
+    - "(?i)(stop hunt|stop loss hunt|wick to)"
+  tags:
+    - "perps"
+    - "trading"
+    - "liquidations"
+  max_context_tokens: 2000
+---
+
+# Liquidation Hunter Skill
+
+Identifies where liquidation clusters sit on the order book and uses that information to anticipate price wicks, stop hunts, and high-probability reversal zones.
+
+## When to Use
+
+- User wants to know where major liquidations are clustered
+- User wants to trade around liquidation cascades
+- User suspects a stop hunt is occurring
+- User wants to set entries near likely liquidation wicks
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Liquidity attracts price** — markets move toward areas of clustered stop losses and liquidations before reversing
+2. **Liquidation cascades accelerate moves** — when a liquidation level is hit, forced selling/buying creates momentum
+3. **Wicks are opportunities** — price often wicks into a liquidation zone and reverses sharply — good entry point
+4. **Large liquidations = large moves** — monitor for $10M+ liquidation events as momentum signals
+
+### How Liquidation Clusters Form
+
+- Traders set stop losses at obvious levels (round numbers, recent highs/lows, support/resistance)
+- Market makers and large players know where these stops are
+- Price is pushed into those zones to trigger liquidations, collect liquidity, then reverse
+- The result: a sharp wick followed by a strong move in the opposite direction
+
+### Reading a Liquidation Map
+
+Use **Coinglass Liquidation Heatmap**:
+- **Bright yellow/orange zones** = massive liquidation clusters
+- **Price gravitates toward these zones** before reversing
+- If price is below a large long liquidation cluster → likely to wick up to it
+- If price is above a large short liquidation cluster → likely to wick down to it
+
+### Trading Liquidation Zones
+
+**Strategy 1: Fade the wick**
+- Identify a large liquidation cluster above/below current price
+- Wait for price to wick into that zone
+- Enter the opposite direction as liquidations are triggered
+- Stop loss just beyond the cluster
+
+**Strategy 2: Ride the cascade**
+- When a liquidation cascade begins (large liquidation event on Coinglass)
+- Enter in the direction of the cascade momentum
+- Exit quickly — cascades reverse fast after liquidity is consumed
+
+**Strategy 3: Avoid the hunt**
+- If your stop loss is at an obvious level (round number, recent high/low)
+- Move it slightly beyond or use a mental stop to avoid being hunted
+
+### Key Tools
+
+| Tool | Use |
+|------|-----|
+| Coinglass Liquidation Heatmap | See clustered liquidation levels |
+| Coinglass Liquidations Feed | Real-time large liquidation events |
+| Hyblock Capital | Advanced liquidation level analytics |
+
+### Mistakes to Avoid
+
+- Don't place stop losses at round numbers or obvious technical levels — they get hunted
+- Don't trade against a liquidation cascade in progress — wait for it to exhaust
+- Don't assume every wick into a liq zone will reverse — confirm with volume
+
+## Guidelines
+
+- Always reference Coinglass heatmap data when discussing liquidation levels
+- Give specific price levels, not vague zones
+- Pair every liquidation trade setup with a stop loss and target
+- Remind user: liquidation hunting is high-skill trading — size conservatively

--- a/skills/market-sentiment/SKILL.md
+++ b/skills/market-sentiment/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: market-sentiment
+version: 1.0.0
+description: Gauge crypto market sentiment using fear/greed index, social data, funding rates, and on-chain signals
+activation:
+  keywords:
+    - "market sentiment"
+    - "fear and greed"
+    - "is the market bullish"
+    - "social sentiment"
+    - "crowd psychology"
+    - "market mood"
+    - "are people bearish"
+    - "twitter sentiment"
+  patterns:
+    - "(?i)(market|crypto).*(sentiment|mood|feeling|psychology)"
+    - "(?i)(fear (and|&) greed|fear index)"
+    - "(?i)(is (the market|everyone|crypto)).*(bullish|bearish|scared|euphoric|greedy)"
+  tags:
+    - "trading"
+    - "sentiment"
+    - "research"
+  max_context_tokens: 2000
+---
+
+# Market Sentiment Skill
+
+Gauges the overall crypto market sentiment by synthesizing fear/greed data, social signals, funding rates, and on-chain behavior into a clear directional bias.
+
+## When to Use
+
+- User wants to know the overall market mood
+- User asks if the market is bullish, bearish, or neutral
+- User wants to understand crowd psychology before making a trade
+- User asks about fear/greed index or social sentiment
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Be fearful when others are greedy** — extreme sentiment readings are contrarian signals
+2. **Sentiment leads price at extremes** — peak euphoria precedes tops; peak fear precedes bottoms
+3. **Multiple signals > single index** — one indicator can be wrong; 5 aligned signals are powerful
+4. **Sentiment shifts before price** — social and on-chain signals often lead price by hours or days
+
+### Sentiment Indicators
+
+**Fear & Greed Index (0–100)**
+- 0–25: Extreme Fear → historically good buying opportunity
+- 26–45: Fear → cautious accumulation zone
+- 46–55: Neutral → no strong directional signal
+- 56–75: Greed → be cautious with new longs
+- 76–100: Extreme Greed → major caution, potential top signal
+- Source: alternative.me/crypto/fear-and-greed-index
+
+**Funding Rates**
+- High positive funding → market is overleveraged long → bearish signal
+- High negative funding → market is overleveraged short → bullish signal
+- Neutral funding → balanced positioning
+
+**Social Sentiment**
+- Twitter/X: rising mentions + positive tone = retail FOMO incoming
+- Google Trends: search spike for "buy bitcoin" = retail peak interest = contrarian sell signal
+- Telegram/Discord: euphoric tone in communities = late stage of rally
+
+**On-Chain Sentiment Signals**
+- Exchange inflows rising → people moving to sell → bearish
+- Exchange outflows rising → people withdrawing to hold → bullish
+- Long-term holders selling → distribution phase
+- New wallet addresses surging → new retail interest (late signal)
+
+**Options Market**
+- Put/Call ratio >1: more puts than calls → bearish sentiment
+- Put/Call ratio <0.5: more calls than puts → bullish/greedy sentiment
+- Implied volatility spike → fear or uncertainty
+
+### Sentiment Synthesis
+
+Rate each signal: Bullish (+1) / Neutral (0) / Bearish (-1)
+
+Sum the scores:
+- +4 to +5: Strong bullish sentiment
+- +2 to +3: Mild bullish
+- -1 to +1: Neutral/mixed
+- -2 to -3: Mild bearish
+- -4 to -5: Strong bearish (potential contrarian buy)
+
+### Contrarian Rules
+
+- Extreme Greed (>80) + overbought RSI + high funding = reduce longs
+- Extreme Fear (<20) + oversold RSI + negative funding = consider accumulating
+- Never fade sentiment at extremes without price action confirmation
+
+### Mistakes to Avoid
+
+- Don't use sentiment as a standalone trading signal — combine with price action
+- Don't assume high fear = immediate bottom — markets can stay fearful
+- Don't ignore sentiment because you're convicted in a trade direction
+
+## Guidelines
+
+- Always check at minimum: Fear/Greed index + funding rates + social tone
+- Output: Overall sentiment score + individual indicator readings
+- State clearly: Bullish sentiment / Bearish sentiment / Mixed sentiment
+- For extreme readings, flag as a contrarian signal with ⚠️

--- a/skills/memecoin-entry/SKILL.md
+++ b/skills/memecoin-entry/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: memecoin-entry
+version: 1.0.0
+description: Time memecoin entries on pumps and dips using volume, chart structure, and momentum signals
+activation:
+  keywords:
+    - "when to buy"
+    - "good entry"
+    - "ape in"
+    - "entry point"
+    - "buy the dip"
+    - "memecoin entry"
+    - "when to enter"
+    - "is now a good time to buy"
+  patterns:
+    - "(?i)(when|where).*(buy|enter|ape).*(memecoin|token|coin)"
+    - "(?i)(good|best).*(entry|time to buy|point to buy)"
+    - "(?i)(buy the dip|buy now|ape in)"
+  tags:
+    - "memecoin"
+    - "trading"
+    - "entry"
+  max_context_tokens: 2000
+---
+
+# Memecoin Entry Skill
+
+Helps time memecoin buy entries using momentum signals, chart structure, volume analysis, and narrative strength.
+
+## When to Use
+
+- User wants to know when to enter a memecoin position
+- User asks if now is a good time to buy
+- User wants to buy a dip but isn't sure where
+- User is watching a coin and needs an entry trigger
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Don't chase green candles** — entering after a 5x pump is not an entry, it's a gamble
+2. **Volume confirms moves** — a price spike without volume is weak; volume + price = real momentum
+3. **Narrative timing** — entry is strongest when the narrative is fresh but not yet mainstream
+4. **Risk first** — define max loss before defining entry; never enter without knowing your exit
+
+### Entry Frameworks
+
+**The Dip Entry** (safest for memecoins)
+- Coin has pumped and is pulling back
+- Wait for 30–50% retrace from local high
+- Enter when volume stabilizes (not still falling)
+- Confirm with a green candle on 15m or 1h chart
+
+**The Breakout Entry** (momentum play)
+- Coin is consolidating at a level
+- Wait for breakout above resistance with volume
+- Enter on the candle close, not the wick
+- Set stop below the breakout level
+
+**The Early Launch Entry** (highest risk/reward)
+- New launch on Pump.fun or similar
+- Enter when bonding curve is 20–40% filled
+- Small position only — high chance of failure
+- Exit plan: sell half at 2x, let rest ride
+
+### Entry Checklist
+
+Before entering any memecoin:
+- ✅ Rug check passed
+- ✅ Liquidity sufficient (>$100k)
+- ✅ Volume trending up, not down
+- ✅ Narrative still active on social
+- ✅ Position size set (max 1–5% of portfolio per memecoin)
+- ✅ Exit targets defined
+
+### Mistakes to Avoid
+
+- Never FOMO into a coin already up 10x+ without a pullback
+- Don't enter with more than you're willing to lose entirely
+- Don't enter without a stop loss or exit plan
+
+## Guidelines
+
+- Always ask: what chain, what coin, what's the current price action?
+- Give a specific entry zone, not a vague "buy the dip"
+- Always pair entry with an exit plan (see memecoin-exit skill)
+- Remind user: memecoins can go to zero — size accordingly

--- a/skills/memecoin-exit/SKILL.md
+++ b/skills/memecoin-exit/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: memecoin-exit
+version: 1.0.0
+description: Know when to take profit or cut losses on volatile memecoin positions
+activation:
+  keywords:
+    - "when to sell"
+    - "take profit"
+    - "exit memecoin"
+    - "cut losses"
+    - "should I sell"
+    - "how to exit"
+    - "bag holding"
+    - "is it too late to sell"
+  patterns:
+    - "(?i)(when|should I).*(sell|exit|take profit|cut).*(memecoin|coin|token|bag)"
+    - "(?i)(take profit|cut loss|stop loss).*(memecoin|position)"
+    - "(?i)(bag holding|bagholder|down bad)"
+  tags:
+    - "memecoin"
+    - "trading"
+    - "exit"
+  max_context_tokens: 2000
+---
+
+# Memecoin Exit Skill
+
+Guides users on when and how to exit memecoin positions — taking profits at the right time and cutting losses before they become catastrophic.
+
+## When to Use
+
+- User is in a memecoin position and unsure when to sell
+- User wants a profit-taking strategy
+- User is down and considering cutting losses
+- User is bag holding and wants advice
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Profits are only real when taken** — unrealized gains mean nothing in memecoins; they evaporate fast
+2. **Scale out, don't sell all at once** — take profits in tranches to maximize gains while staying in the trade
+3. **Never let a win turn into a loss** — once up significantly, move stop loss to break-even minimum
+4. **Cutting losses is a skill** — a 50% loss requires a 100% gain to recover; exit early
+
+### Exit Frameworks
+
+**The Tranche Exit** (recommended)
+- Sell 25% at 2x — recover initial investment partially
+- Sell 25% at 5x — take meaningful profit
+- Sell 25% at 10x — secure major gains
+- Let final 25% ride with stop at 5x — moonbag
+
+**The Time-Based Exit**
+- Memecoins have a cycle: launch → pump → dump → dead
+- If coin hasn't moved in 48–72 hours after initial pump, exit
+- Attention moves fast — if narrative fades, so does price
+
+**The Signal-Based Exit**
+Sell when you see:
+- Volume dropping sharply while price holds (distribution)
+- Dev wallet starts moving tokens
+- Social mentions dropping off
+- Whale wallets selling (check on-chain)
+- New competing memecoin stealing the narrative
+
+**The Loss Cut**
+- Set a hard stop: if down 30–40% from entry, exit
+- Don't average down on memecoins — they can go to zero
+- Ask: "Would I buy this today at this price?" If no, sell.
+
+### Mistakes to Avoid
+
+- Never hold waiting to "get back to break-even" — cut and redeploy
+- Don't sell 100% too early — use tranches
+- Don't ignore on-chain signals because you like the meme
+
+## Guidelines
+
+- Always ask: what's the current P&L, entry price, and position size?
+- Give specific price targets for each tranche based on current price
+- If user is bag holding at a loss, assess whether the narrative is still alive before advising hold vs. cut
+- End with: "Memecoins move fast — set alerts and don't leave positions unmonitored"

--- a/skills/memecoin-scanner/SKILL.md
+++ b/skills/memecoin-scanner/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: memecoin-scanner
+version: 1.0.0
+description: Spot early memecoin opportunities using volume spikes, social buzz, and on-chain signals
+activation:
+  keywords:
+    - "memecoin"
+    - "new coin"
+    - "trending token"
+    - "early gem"
+    - "100x coin"
+    - "scan memecoins"
+    - "pump incoming"
+    - "dexscreener"
+    - "new launch"
+  patterns:
+    - "(?i)(find|scan|spot|look for).*(memecoin|gem|token|coin).*(early|new|trending)"
+    - "(?i)(what|which).*(memecoin|coin|token).*(trending|pumping|hot)"
+    - "(?i)(100x|1000x|early gem|next pump)"
+  tags:
+    - "memecoin"
+    - "trading"
+    - "research"
+  max_context_tokens: 2000
+---
+
+# Memecoin Scanner Skill
+
+Identifies early memecoin opportunities by combining on-chain volume data, social sentiment signals, and launch metrics before the crowd arrives.
+
+## When to Use
+
+- User wants to find new or trending memecoins early
+- User asks about hot tokens on any chain
+- User wants to scan for volume spikes or new launches
+- User mentions DexScreener, Pump.fun, or similar launchpads
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Speed is everything** — memecoins move in minutes; early data is the edge
+2. **Volume precedes price** — sudden volume spikes on low-cap coins are the primary signal
+3. **Social velocity matters** — Twitter/X mentions, Telegram group growth, and Reddit posts are leading indicators
+4. **On-chain confirms** — wallet count growth, holder distribution, and liquidity depth validate social signals
+
+### Scanning Framework
+
+**Step 1: Find candidates**
+- Check DexScreener for new pairs with >$100k volume in last 1h
+- Check Pump.fun (Solana) or similar launchpads for trending launches
+- Monitor CT (Crypto Twitter) for ticker mentions spiking
+
+**Step 2: Qualify the coin**
+- Age: under 72 hours old = highest risk/reward
+- Liquidity: minimum $50k locked liquidity
+- Holders: growing holder count (not shrinking)
+- Dev wallet: under 5% of supply
+
+**Step 3: Social check**
+- Is the narrative strong? (meme quality, cultural relevance)
+- Is there organic community or is it purely bot-driven?
+- Any KOL (Key Opinion Leader) mentions?
+
+### Key Data Sources
+
+| Source | What to check |
+|--------|--------------|
+| DexScreener | Volume, price change, liquidity, age |
+| Pump.fun | New Solana launches, bonding curve progress |
+| Birdeye | Multi-chain token analytics |
+| Twitter/X | Ticker mentions, KOL posts |
+| Telegram | Community size and activity |
+
+### Mistakes to Avoid
+
+- Never ape into a coin without checking liquidity lock status
+- Don't trust volume alone — wash trading is common in memecoins
+- Don't chase a coin already up 10x — the pump may be over
+
+## Guidelines
+
+- Always present: contract address, chain, liquidity, volume (1h/24h), holder count, age
+- Flag any red flags found during scan with ⚠️
+- Recommend verifying contract on the chain's block explorer before buying
+- Remind user: memecoin trading is extremely high risk

--- a/skills/news-fetcher/SKILL.md
+++ b/skills/news-fetcher/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: news-fetcher
+version: 1.0.0
+description: Pull and summarize the latest news on any topic from reliable sources
+activation:
+  keywords:
+    - "latest news"
+    - "what happened"
+    - "recent news"
+    - "news about"
+    - "what's going on with"
+    - "current events"
+    - "breaking news"
+    - "today's headlines"
+  patterns:
+    - "(?i)(latest|recent|breaking|today).*(news|update|headline)"
+    - "(?i)what.*(happened|going on|new).*(with|in|about)"
+    - "(?i)(tell me|show me).*(news|update).*about"
+  tags:
+    - "news"
+    - "research"
+    - "current-events"
+  max_context_tokens: 2000
+---
+
+# News Fetcher Skill
+
+Enables the agent to retrieve, filter, and summarize the latest news on any topic with proper sourcing and editorial clarity.
+
+## When to Use
+
+- User asks about recent events or breaking news
+- User wants updates on a specific topic, person, company, or country
+- User asks "what happened with X" or "any news on Y"
+- User wants today's headlines in a category (tech, finance, politics, etc.)
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Timeliness** — always prioritize articles from the last 24–72 hours; label older content clearly
+2. **Source quality** — prefer established outlets (Reuters, AP, BBC, Bloomberg, etc.) over blogs or social media
+3. **Neutrality** — present news factually; do not editorialize or inject opinions
+4. **Brevity** — give a 2–3 sentence summary per story, not a full article rewrite
+
+### Story Structure
+
+For each news item, provide:
+- **Headline** (your own words, not copied)
+- **What happened** (1–2 sentences)
+- **Why it matters** (1 sentence)
+- **Source** (name + URL)
+
+### Common Patterns
+
+- For topic-based queries: fetch top 3–5 stories, summarize each
+- For breaking news: lead with the most recent development, then background
+- For ongoing stories: acknowledge what was previously known vs. what is new
+
+### Mistakes to Avoid
+
+- Never present opinion or analysis as news fact
+- Don't summarize paywalled articles you cannot read
+- Avoid citing social media posts as primary news sources
+
+## Guidelines
+
+- Group stories by topic if returning multiple results
+- Flag if a story is developing and facts may change
+- If no news is found on a topic in the last 7 days, say so and offer to search broader timeframes

--- a/skills/news-trader/SKILL.md
+++ b/skills/news-trader/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: news-trader
+version: 1.0.0
+description: React to market-moving news events with speed, context, and directional trade ideas
+activation:
+  keywords:
+    - "breaking news trade"
+    - "news just dropped"
+    - "how does this affect the market"
+    - "trade the news"
+    - "market reaction"
+    - "buy the news"
+    - "sell the news"
+    - "fed announcement"
+    - "etf approved"
+  patterns:
+    - "(?i)(trade|react|play).*(news|announcement|event|report)"
+    - "(?i)(how (does|will|did)).*(affect|impact|move).*(market|price|crypto)"
+    - "(?i)(buy|sell).*(news|rumor|announcement)"
+  tags:
+    - "trading"
+    - "news"
+    - "execution"
+  max_context_tokens: 2000
+---
+
+# News Trader Skill
+
+Processes breaking market news quickly, assesses its directional impact, and translates it into actionable trade ideas with defined risk.
+
+## When to Use
+
+- Breaking news just dropped and user wants to know how to trade it
+- User asks how a specific news event affects market price
+- User wants to know if a news event is already priced in
+- User wants to understand "buy the rumor, sell the news" dynamics
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Speed is the edge** — news trading requires fast processing; first movers capture the move
+2. **Is it priced in?** — always ask if the market already expected this news before trading it
+3. **Buy the rumor, sell the news** — anticipated good news often causes selling after confirmation
+4. **Magnitude matters** — not all news moves markets equally; assess the surprise factor
+
+### News Impact Assessment Framework
+
+**Step 1: Classify the news**
+- Scheduled (Fed meeting, CPI report, earnings) → market was positioned for this
+- Unscheduled/surprise → higher impact, faster move, more opportunity
+
+**Step 2: Assess the surprise factor**
+- Was this expected? → Lower impact (already priced in)
+- Was this a surprise? → Higher impact (not priced in = bigger move)
+- Worse/better than expected by how much? → Determines direction and magnitude
+
+**Step 3: Determine directional bias**
+
+| News Type | Typical Market Reaction |
+|-----------|------------------------|
+| ETF approved (crypto) | Spike up → potential sell the news after |
+| Hack/exploit | Sharp drop → potential bounce after panic |
+| Regulatory crackdown | Sell-off → assess severity before buying dip |
+| Fed rate cut | Risk-on rally → crypto benefits |
+| Fed rate hike (surprise) | Risk-off selloff → crypto drops |
+| Major partnership announced | Pump → assess if substance or hype |
+| Exchange insolvency | Panic drop → major contagion risk |
+
+**Step 4: Trade the reaction, not just the news**
+- Watch the first 5–15 minutes of price reaction
+- Is the market buying or selling the news?
+- Trade with the reaction once direction is confirmed
+
+### "Buy the Rumor, Sell the News" Pattern
+
+1. News is expected/leaked in advance → price pumps on anticipation
+2. News is confirmed officially → initial spike
+3. Price reverses and sells off as buyers exit
+4. Pattern: fade the confirmation spike with a short
+
+### Risk Management for News Trades
+
+- Use smaller size than normal — news creates volatile wicks
+- Wider stop losses — initial moves are often exaggerated
+- Set a time stop — if trade doesn't work in 30 minutes, exit
+- Never hold through unscheduled high-impact news in a position
+
+### Key News Sources for Speed
+
+| Source | Type |
+|--------|------|
+| CoinDesk / The Block | Crypto news |
+| Reuters / Bloomberg Terminal | Macro news |
+| Twitter/X (verified accounts) | Breaking first |
+| Polymarket | Crowd-based probability of news outcomes |
+| Unusual Whales | Options flow before news |
+
+### Mistakes to Avoid
+
+- Don't trade the headline — read the full story before entering
+- Don't chase a 10% move that's already happened — the edge is gone
+- Don't ignore the broader trend — bad news in a strong uptrend often gets bought
+
+## Guidelines
+
+- When user shares news, immediately assess: Scheduled or surprise? Bullish or bearish? Priced in or not?
+- Give a directional bias with a specific entry trigger (e.g., "wait for retest of $X before entering")
+- Always include a stop loss level for news trades — they can reverse violently
+- Flag "buy the rumor sell the news" risk whenever news was anticipated

--- a/skills/odds-analyzer/SKILL.md
+++ b/skills/odds-analyzer/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: odds-analyzer
+version: 1.0.0
+description: Identify mispriced Polymarket markets and find value bets through probability analysis
+activation:
+  keywords:
+    - "odds"
+    - "mispriced"
+    - "value bet"
+    - "is this good odds"
+    - "polymarket price"
+    - "expected value"
+    - "market inefficiency"
+    - "is this underpriced"
+  patterns:
+    - "(?i)(mispriced|underpriced|overpriced).*(market|odds|probability)"
+    - "(?i)(value|edge|expected value).*(bet|position|market)"
+    - "(?i)(are the odds|is the price).*(right|correct|fair|off)"
+  tags:
+    - "polymarket"
+    - "odds"
+    - "analysis"
+  max_context_tokens: 2000
+---
+
+# Odds Analyzer Skill
+
+Evaluates Polymarket odds for mispricing, calculates expected value, and identifies where the market is wrong so the user can find profitable positions.
+
+## When to Use
+
+- User wants to know if a Polymarket price is fair
+- User suspects a market is mispriced
+- User wants to calculate expected value of a position
+- User is comparing multiple markets to find the best bet
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Price ≠ probability** — Polymarket prices reflect crowd sentiment plus liquidity, not always true probability
+2. **Expected value is the only metric** — a 10% chance at 20¢ is a good bet; a 90% chance at 95¢ may not be
+3. **Liquidity affects price** — thin markets misprice more; deep markets are harder to beat
+4. **Crowd anchors to recent news** — overreaction to news creates temporary mispricings
+
+### Expected Value Formula
+
+```
+EV = (Probability of YES × Profit if YES) - (Probability of NO × Loss if NO)
+
+Example:
+- Market price: 30¢ (implies 30% chance)
+- Your estimate: 45% chance
+- Bet $100 on YES at 30¢
+
+EV = (0.45 × $233) - (0.55 × $100)
+EV = $104.85 - $55 = +$49.85 → POSITIVE EV bet
+```
+
+### Mispricing Patterns
+
+| Pattern | What It Looks Like |
+|---------|-------------------|
+| Recency bias | Market overreacts to recent news, price spikes temporarily |
+| Anchoring | Market stays near 50% even when evidence strongly favors one side |
+| Low liquidity | Wide spread, price moves easily, easy to find edge |
+| Resolution ambiguity | Market prices uncertainty of resolution, not event probability |
+| Late information | Breaking news not yet reflected in market price |
+
+### Odds Assessment Framework
+
+1. Form your independent probability estimate (use market-researcher skill)
+2. Compare to current market price
+3. Calculate implied edge: `(Your estimate - Market price) / Market price × 100`
+4. If edge > 10% → investigate further
+5. If edge > 20% → strong value signal
+6. Check liquidity — edge means nothing if you can't get size in
+
+### Mistakes to Avoid
+
+- Don't bet on markets where you have no informational edge
+- Don't ignore the vig (fees) — Polymarket takes a cut on winning positions
+- Don't size up on low-liquidity markets — your own order moves the price
+
+## Guidelines
+
+- Always calculate EV before recommending a position
+- Flag if the market has <$10k liquidity — edge is harder to capture
+- Present: Market price / Your estimate / EV / Recommended position size
+- Never recommend betting more than 5% of bankroll on a single market

--- a/skills/on-chain-reader/SKILL.md
+++ b/skills/on-chain-reader/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: on-chain-reader
+version: 1.0.0
+description: Interpret NEAR blockchain data including transactions, accounts, smart contracts, and on-chain events
+activation:
+  keywords:
+    - "on-chain"
+    - "blockchain data"
+    - "near transaction"
+    - "near account"
+    - "wallet balance"
+    - "smart contract call"
+    - "nearblocks"
+    - "read the chain"
+    - "on chain activity"
+    - "near rpc"
+  patterns:
+    - "(?i)(check|read|fetch|query).*(on.?chain|blockchain|near|wallet|account|transaction)"
+    - "(?i)(transaction|tx).*(hash|id|details|status)"
+    - "(?i)(near|wallet).*(balance|history|activity|account)"
+  tags:
+    - "finance"
+    - "crypto"
+    - "near"
+    - "blockchain"
+  max_context_tokens: 2000
+---
+
+# On-Chain Reader Skill
+
+Reads, interprets, and explains NEAR blockchain data including accounts, transactions, smart contract state, and on-chain activity.
+
+## When to Use
+
+- User wants to check a NEAR wallet balance or transaction
+- User shares a transaction hash and wants it explained
+- User wants to understand smart contract activity on NEAR
+- User asks about on-chain data, NFT ownership, or token transfers
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Always fetch live data** — blockchain state changes with every block; never use cached or assumed data
+2. **Interpret, don't just display** — raw RPC data is unreadable; translate it into plain English
+3. **Confirm the network** — NEAR Mainnet vs. Testnet data is completely separate; always confirm which one
+4. **Transaction finality** — NEAR achieves finality in ~2 seconds; flag if a transaction is still pending
+
+### NEAR RPC Methods
+
+Use `POST https://rpc.mainnet.near.org` with JSON-RPC 2.0:
+
+**Check account balance**:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "method": "query",
+  "params": {
+    "request_type": "view_account",
+    "finality": "final",
+    "account_id": "user.near"
+  }
+}
+```
+
+**Check transaction status**:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "method": "tx",
+  "params": ["TX_HASH", "SENDER_ACCOUNT_ID"]
+}
+```
+
+**View contract state**:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "method": "query",
+  "params": {
+    "request_type": "call_function",
+    "finality": "final",
+    "account_id": "contract.near",
+    "method_name": "get_balance",
+    "args_base64": ""
+  }
+}
+```
+
+### Data Interpretation Guide
+
+| Raw Data | Human Meaning |
+|----------|--------------|
+| `amount` in yoctoNEAR | Divide by 10^24 to get NEAR |
+| `block_height` | Block number on the chain |
+| `status: { SuccessValue }` | Transaction succeeded |
+| `status: { Failure }` | Transaction failed — check error |
+
+### Key Tools
+
+- **NearBlocks**: https://nearblocks.io — block explorer for transactions, accounts, contracts
+- **NEAR RPC**: https://rpc.mainnet.near.org — live chain data
+- **Ref Finance**: On-chain DEX data for NEAR tokens
+
+### Mistakes to Avoid
+
+- Never convert yoctoNEAR amounts without dividing by 10^24
+- Don't mix Mainnet and Testnet data
+- Don't assume a transaction succeeded without checking the status field
+
+## Guidelines
+
+- Always convert yoctoNEAR to NEAR for display
+- Link to NearBlocks for any transaction or account: `https://nearblocks.io/txns/TX_HASH`
+- If an account is not found, verify the account ID spelling — NEAR accounts are case-sensitive
+- For NFT queries, check the Paras or Mintbase indexers in addition to raw RPC

--- a/skills/order-builder/SKILL.md
+++ b/skills/order-builder/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: order-builder
+version: 1.0.0
+description: Structure limit, market, stop, and advanced orders correctly across spot and derivatives markets
+activation:
+  keywords:
+    - "limit order"
+    - "market order"
+    - "stop order"
+    - "stop limit"
+    - "how to place order"
+    - "order type"
+    - "OCO order"
+    - "trailing stop"
+    - "place a buy order"
+  patterns:
+    - "(?i)(limit|market|stop|OCO|trailing).*(order|buy|sell)"
+    - "(?i)(how (do I|to) place|set up).*(order|buy|sell|stop)"
+    - "(?i)(what (order|type)).*(should I use|is best)"
+  tags:
+    - "trading"
+    - "execution"
+    - "orders"
+  max_context_tokens: 2000
+---
+
+# Order Builder Skill
+
+Structures the correct order type for any trading situation — from simple limit buys to complex OCO and trailing stop orders — across spot and derivatives markets.
+
+## When to Use
+
+- User wants to place a buy or sell order and needs help structuring it
+- User asks which order type to use in a specific situation
+- User wants to set up a stop loss or take profit order
+- User wants to understand advanced order types (OCO, trailing stop, etc.)
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Never use market orders for large positions** — market orders cause slippage; use limits
+2. **Always have a stop loss order placed** — don't rely on manually watching the price
+3. **OCO orders are your best friend** — set profit and stop simultaneously so you can walk away
+4. **Post-only orders save fees** — maker orders are cheaper than taker orders on most exchanges
+
+### Order Type Reference
+
+**Market Order**
+- Executes immediately at current best price
+- Use when: speed matters more than price (news event, urgent exit)
+- Risk: slippage on large orders or thin markets
+- Never use for: large positions, illiquid assets
+
+**Limit Order** ✅ Default choice
+- Executes only at your specified price or better
+- Use when: entering at a specific price, patient accumulation
+- Benefit: no slippage, often maker fee (cheaper)
+- Risk: may not fill if price doesn't reach your level
+
+**Stop Market Order**
+- Triggers a market order when price hits your stop level
+- Use for: stop losses where getting out fast matters
+- Risk: slippage past your stop in fast markets
+
+**Stop Limit Order**
+- Triggers a limit order when price hits your stop level
+- Use for: stop losses in calmer markets
+- Risk: may not fill if price gaps past your limit
+
+**OCO (One-Cancels-the-Other)** ✅ Best for complete trade management
+- Places a take-profit limit AND a stop-loss simultaneously
+- When one fills, the other is automatically cancelled
+- Use for: setting and forgetting a full trade plan
+
+**Trailing Stop**
+- Stop level moves with price in your favor, locks in profits
+- Use for: riding strong trends while protecting gains
+- Example: 5% trailing stop on BTC long — as BTC rises, stop rises with it
+
+**TWAP (Time-Weighted Average Price)**
+- Splits large order into smaller pieces over time
+- Use for: entering/exiting very large positions without moving the market
+
+### Order Building by Scenario
+
+**Scenario: Entering a long at support**
+```
+Order: Limit Buy
+Price: $X (at or just above support level)
+Size: [Calculated from risk management]
+```
+
+**Scenario: Full trade with protection**
+```
+Entry: Limit Buy at $X
+Then place OCO:
+  Take Profit: Limit Sell at $Y
+  Stop Loss: Stop Market at $Z
+```
+
+**Scenario: Breakout entry**
+```
+Order: Stop Limit Buy
+Stop trigger: $X (breakout level)
+Limit price: $X + 0.5% (to ensure fill above breakout)
+```
+
+**Scenario: Scaling out of a winning trade**
+```
+TP1: Limit Sell 25% at $A
+TP2: Limit Sell 25% at $B
+TP3: Trailing Stop 5% on remaining 50%
+```
+
+### Fee Optimization
+
+- **Maker order** (limit that goes on the book): lower fee (~0.02–0.1%)
+- **Taker order** (market or limit that fills immediately): higher fee (~0.04–0.1%)
+- Use post-only limit orders when not in a rush — saves fees over hundreds of trades
+
+### Mistakes to Avoid
+
+- Never enter a trade without a stop loss order already placed
+- Don't use market orders for >1% of daily volume of an asset
+- Don't place stop losses at round numbers — they get hunted
+
+## Guidelines
+
+- Always ask: exchange, asset, direction, entry price, stop, and target
+- Output the exact order parameters to copy into the exchange
+- For complete trade setups, always include the OCO after entry
+- Specify maker vs taker for each order to help user optimize fees

--- a/skills/perps-risk-manager/SKILL.md
+++ b/skills/perps-risk-manager/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: perps-risk-manager
+version: 1.0.0
+description: Enforce disciplined risk management for perpetual futures including position sizing, max drawdown rules, and loss limits
+activation:
+  keywords:
+    - "risk management"
+    - "position sizing perps"
+    - "how much to risk"
+    - "max drawdown"
+    - "daily loss limit"
+    - "risk per trade"
+    - "overtrading"
+    - "blown account"
+  patterns:
+    - "(?i)(risk management|risk per trade|position size).*(perps|futures|leverage)"
+    - "(?i)(how much|what percentage).*(risk|bet|put in).*(trade|position)"
+    - "(?i)(max drawdown|daily loss|loss limit|account protection)"
+  tags:
+    - "perps"
+    - "risk"
+    - "trading"
+  max_context_tokens: 2000
+---
+
+# Perps Risk Manager Skill
+
+Enforces strict, professional-grade risk management rules for perpetual futures trading to protect capital, prevent account blowups, and ensure long-term survival.
+
+## When to Use
+
+- User wants to know how much to risk per trade
+- User is on a losing streak and needs guidance
+- User wants to set daily/weekly loss limits
+- User wants a risk framework for their perps account
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Capital preservation is rule #1** — you can't trade if you blow up; protect the account above all else
+2. **Risk per trade, not position size** — always think in terms of $ at risk, not $ in the position
+3. **Drawdown compounds painfully** — a 50% loss requires a 100% gain to recover; avoid deep drawdowns
+4. **Consistency beats home runs** — 1% daily compounded beats one 50% win followed by a blowup
+
+### The Core Risk Rules
+
+**Rule 1: Risk 1–2% of account per trade maximum**
+```
+Account: $10,000
+Max risk per trade: $100–$200
+If stop loss is 5% away from entry:
+Position size = Risk / Stop % = $200 / 0.05 = $4,000
+Leverage needed = $4,000 / $10,000 = 0.4x effective leverage
+```
+
+**Rule 2: Daily loss limit = 3–5% of account**
+- If daily loss limit hit → stop trading for the day, no exceptions
+- Revenge trading after hitting the limit is the #1 account killer
+
+**Rule 3: Weekly drawdown limit = 10%**
+- If down 10% in a week → reduce position sizes by 50% next week
+- If down 20% → stop trading, reassess strategy
+
+**Rule 4: Maximum concurrent positions = 3**
+- More positions = more complexity = more mistakes
+- Focus on quality setups, not quantity
+
+### Position Sizing Calculator
+
+```
+Inputs needed:
+- Account size ($)
+- Risk per trade (% — default 1%)
+- Entry price
+- Stop loss price
+
+Formula:
+Dollar risk = Account × Risk %
+Stop distance = |Entry - Stop| / Entry
+Position size = Dollar risk / Stop distance
+
+Example:
+Account: $5,000 | Risk: 1% | Entry: $60,000 BTC | Stop: $58,500
+Dollar risk = $50
+Stop distance = $1,500 / $60,000 = 2.5%
+Position size = $50 / 0.025 = $2,000
+Leverage = $2,000 / $5,000 = 0.4x (very safe)
+```
+
+### Drawdown Recovery Table
+
+| Drawdown | Gain Needed to Recover |
+|----------|----------------------|
+| 10% | 11.1% |
+| 20% | 25% |
+| 30% | 42.9% |
+| 50% | 100% |
+| 70% | 233% |
+
+### Warning Signs of Poor Risk Management
+
+- 🔴 Using more than 10x leverage regularly
+- 🔴 Risking more than 5% per trade
+- 🔴 No stop loss set on open positions
+- 🔴 Adding to losing positions without a plan
+- 🔴 Trading after hitting daily loss limit
+- 🔴 Emotional entries ("I need to make this back")
+
+### Mistakes to Avoid
+
+- Never increase position size after a loss to "make it back faster"
+- Don't move stop losses further away when price approaches them
+- Don't skip the stop loss because you "know" the trade will work
+
+## Guidelines
+
+- Always calculate exact position size in dollar terms, not just leverage
+- If user mentions they've had multiple consecutive losses, recommend reducing size by 50%
+- Enforce the daily loss limit rule strictly — no exceptions in advice
+- End every risk conversation with: "Protect the account first. Profits follow discipline."

--- a/skills/perps-setup/SKILL.md
+++ b/skills/perps-setup/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: perps-setup
+version: 1.0.0
+description: Set up perpetual futures trades including leverage, margin type, and liquidation price calculation
+activation:
+  keywords:
+    - "perps"
+    - "perpetual"
+    - "futures trade"
+    - "leverage trading"
+    - "open a position"
+    - "long bitcoin"
+    - "short eth"
+    - "set leverage"
+    - "liquidation price"
+    - "cross margin"
+    - "isolated margin"
+  patterns:
+    - "(?i)(set up|open|enter).*(perp|perpetual|futures|leveraged).*(trade|position|long|short)"
+    - "(?i)(what|calculate).*(liquidation price|liq price|leverage)"
+    - "(?i)(cross|isolated).*(margin)"
+  tags:
+    - "perps"
+    - "trading"
+    - "futures"
+  max_context_tokens: 2000
+---
+
+# Perps Setup Skill
+
+Helps users correctly set up perpetual futures positions including leverage selection, margin type choice, and precise liquidation price calculation.
+
+## When to Use
+
+- User wants to open a leveraged long or short position
+- User wants to calculate their liquidation price
+- User is choosing between cross and isolated margin
+- User wants to know safe leverage for their risk tolerance
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Leverage amplifies both gains AND losses** — 10x leverage means a 10% move wipes you out
+2. **Isolated margin is safer for beginners** — it caps your loss to the margin allocated
+3. **Always know your liquidation price before entering** — not after
+4. **Lower leverage = longer survival** — most retail traders blow up using too much leverage
+
+### Liquidation Price Formula
+
+**For Long positions:**
+```
+Liq Price = Entry Price × (1 - 1/Leverage + Maintenance Margin Rate)
+
+Example: Long BTC at $60,000 with 10x leverage
+Liq Price = $60,000 × (1 - 0.1 + 0.005) = $60,000 × 0.905 = $54,300
+```
+
+**For Short positions:**
+```
+Liq Price = Entry Price × (1 + 1/Leverage - Maintenance Margin Rate)
+
+Example: Short BTC at $60,000 with 10x leverage
+Liq Price = $60,000 × (1 + 0.1 - 0.005) = $60,000 × 1.095 = $65,700
+```
+
+### Leverage Guide by Risk Level
+
+| Risk Tolerance | Max Leverage | Notes |
+|---------------|-------------|-------|
+| Conservative | 2–3x | Wide stop, slow gains, hard to liquidate |
+| Moderate | 5–10x | Standard retail range |
+| Aggressive | 10–25x | Requires tight risk management |
+| Degen | 25x+ | Near-certain liquidation without precision |
+
+### Margin Types
+
+**Isolated Margin** ✅ Recommended
+- Only the margin you allocate can be lost
+- Liquidated position doesn't affect rest of account
+- Best for: directional bets with defined risk
+
+**Cross Margin** ⚠️ Advanced
+- Entire account balance backs the position
+- Lower liquidation risk but larger potential loss
+- Best for: hedging existing spot holdings
+
+### Exchange-Specific Notes
+
+- **Binance Futures**: Up to 125x, 0.5% maintenance margin
+- **Bybit**: Up to 100x, unified margin account available
+- **dYdX / GMX**: Decentralized perps, on-chain settlement
+- **Hyperliquid**: On-chain perps with CEX-like UX
+
+### Mistakes to Avoid
+
+- Never use max leverage available — exchanges allow it but it's a trap
+- Don't set stop loss AFTER entering — set it simultaneously
+- Don't ignore funding rates — they compound over time on held positions
+
+## Guidelines
+
+- Always calculate and show liquidation price before recommending entry
+- Ask: asset, direction (long/short), entry price, leverage, account size
+- Recommend isolated margin by default unless user has a specific reason for cross
+- Pair every setup with a stop loss recommendation

--- a/skills/planner/SKILL.md
+++ b/skills/planner/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: planner
+version: 1.0.0
+description: Break down goals into actionable, sequenced plans with milestones and timelines
+activation:
+  keywords:
+    - "make a plan"
+    - "plan for"
+    - "roadmap"
+    - "how do I achieve"
+    - "step by step"
+    - "help me plan"
+    - "action plan"
+    - "project plan"
+    - "what steps"
+  patterns:
+    - "(?i)(make|create|build|give me).*(plan|roadmap|strategy|steps)"
+    - "(?i)(how (do|can) I).*(achieve|accomplish|start|build|launch)"
+    - "(?i)(step.?by.?step|action items|milestones|timeline)"
+  tags:
+    - "reasoning"
+    - "planning"
+    - "productivity"
+  max_context_tokens: 2000
+---
+
+# Planner Skill
+
+Converts goals into structured, sequenced action plans with clear phases, milestones, and timelines.
+
+## When to Use
+
+- User has a goal and needs a roadmap to achieve it
+- User asks "how do I start" or "what steps should I take"
+- User needs a project plan, launch plan, or learning plan
+- User has a vague intention and needs it structured
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Start with the end** — clarify the goal, success criteria, and deadline before planning steps
+2. **Phase it** — group steps into logical phases (Foundation → Build → Launch → Scale)
+3. **Be specific** — each action item must be concrete and doable, not abstract
+4. **Sequence matters** — order steps by dependency; don't put step 4 before step 2
+
+### Plan Structure
+
+```
+GOAL: [Clear one-sentence goal]
+TIMELINE: [Total timeframe]
+SUCCESS LOOKS LIKE: [How we know it's done]
+
+PHASE 1: [Name] — [Timeframe]
+  ✅ Action 1 (owner, tool, output)
+  ✅ Action 2
+  ✅ Action 3
+
+PHASE 2: [Name] — [Timeframe]
+  ...
+
+MILESTONES:
+  Week 1: [Deliverable]
+  Week 2: [Deliverable]
+```
+
+### Planning Patterns
+
+- **Learning plan**: Assess → Foundations → Practice → Projects → Review
+- **Product launch**: Research → Build → Test → Launch → Iterate
+- **Business plan**: Validate → Structure → Build → Acquire → Scale
+- **Personal goal**: Assess current state → Set targets → Build habits → Track → Adjust
+
+### Mistakes to Avoid
+
+- Don't create a plan without knowing the deadline and available resources
+- Don't make steps too vague ("work on marketing") — be specific ("write 3 LinkedIn posts per week")
+- Don't skip dependencies — if step B requires step A, say so
+
+## Guidelines
+
+- Always ask: What's the timeline? What resources do you have? What's already done?
+- Use phases + milestones for plans longer than 2 weeks
+- For short plans (<1 week), a numbered checklist is enough
+- Offer to break down any single phase into more detail on request

--- a/skills/polymarket-trader/SKILL.md
+++ b/skills/polymarket-trader/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: polymarket-trader
+version: 1.0.0
+description: Scan Polymarket for mispriced prediction markets and automatically place orders when edge is found
+activation:
+  keywords:
+    - "scan polymarket"
+    - "polymarket trade"
+    - "find mispriced markets"
+    - "auto trade polymarket"
+    - "polymarket bot"
+    - "polymarket edge"
+    - "place polymarket order"
+  patterns:
+    - "(?i)(scan|search|find).*(polymarket|prediction market).*(mispric|edge|opportunity)"
+    - "(?i)(auto|automatically).*(trade|bet|place).*(polymarket|prediction)"
+    - "(?i)(polymarket).*(bot|scanner|trader|order)"
+  tags:
+    - "polymarket"
+    - "trading"
+    - "automation"
+  max_context_tokens: 2000
+tools:
+  - name: polymarket_trader
+    path: ./polymarket_trader.py
+    description: Scans Polymarket markets and places orders via CLOB API
+    auth:
+      env:
+        - POLYMARKET_PRIVATE_KEY
+        - POLYMARKET_FUNDER
+---
+
+# Polymarket Auto-Trader Skill
+
+Scans Polymarket prediction markets for mispriced opportunities and automatically places orders when edge exceeds the configured threshold using the official Polymarket CLOB API.
+
+## When to Use
+
+- User wants to automatically find and trade mispriced Polymarket markets
+- User asks to scan for prediction market opportunities
+- User wants to run a Polymarket trading bot
+- User asks to place a specific Polymarket order
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Edge first, always** — only trade when calculated edge exceeds MIN_EDGE (default 8%); never trade for the sake of trading
+2. **Dry run before live** — always verify the scanner is finding real opportunities in DRY_RUN mode before switching to live
+3. **Kelly sizing** — bet size scales with edge strength; never risk more than MAX_BET_SIZE per market
+4. **FOK orders only** — use Fill-or-Kill order type to avoid leaving resting orders that could fill at bad prices
+
+### How It Works
+
+**Step 1 — Market Discovery**
+Fetches active markets from Polymarket Gamma API, sorted by 24h volume, filtering for markets with sufficient liquidity.
+
+**Step 2 — Mispricing Detection**
+For each market, analyzes:
+- YES + NO price sum (should equal ~1.00; deviation = arb opportunity)
+- Anchoring bias (50/50 markets with low volume)
+- Thin market extremes (very high/low prices in illiquid markets)
+
+**Step 3 — Order Placement**
+When edge ≥ MIN_EDGE, calculates bet size via simplified Kelly Criterion and places a market order via the Polymarket CLOB API.
+
+### Setup Instructions
+
+**1. Install dependencies**
+```bash
+pip install py-clob-client requests python-dotenv
+```
+
+**2. Create .env file**
+```
+POLYMARKET_PRIVATE_KEY=your_polygon_wallet_private_key
+POLYMARKET_FUNDER=your_funder_wallet_address
+MIN_EDGE=0.08
+MAX_BET_SIZE=25
+MIN_LIQUIDITY=500
+DRY_RUN=true
+```
+
+**3. Run in dry run mode first**
+```bash
+python polymarket_trader.py
+```
+
+**4. Review opportunities, then set DRY_RUN=false for live trading**
+
+### Configuration Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| MIN_EDGE | 0.08 (8%) | Minimum edge to trigger a trade |
+| MAX_BET_SIZE | $25 USDC | Maximum bet per market |
+| MIN_LIQUIDITY | $500 USDC | Minimum market liquidity |
+| DRY_RUN | true | Simulate trades without real orders |
+
+### Wallet Setup
+
+You need a Polygon wallet with USDC.e:
+1. Create a wallet on Polymarket (or connect MetaMask)
+2. Fund with USDC on Polygon network
+3. Export private key (keep it secret — never share it)
+4. Set token allowances (run the allowance script from py-clob-client docs)
+
+### Risk Management Rules
+
+- Never set MAX_BET_SIZE above 5% of your total bankroll
+- Always start with DRY_RUN=true for at least 48 hours
+- Monitor the bot — prediction markets can move fast
+- Set MIN_EDGE higher (0.12+) for more conservative trading
+- The bot uses FOK orders — if liquidity is insufficient, orders simply don't fill
+
+### Mistakes to Avoid
+
+- Never use your main wallet private key — use a dedicated trading wallet
+- Don't set MIN_EDGE below 0.05 — fees and slippage will eat your edge
+- Don't run without MIN_LIQUIDITY filter — thin markets give false signals
+- Don't skip dry run testing before going live
+
+## Guidelines
+
+- When user asks to run the scanner: execute `polymarket_trader.py` with DRY_RUN=true first
+- When user asks to place a specific order: ask for market slug, direction (YES/NO), and amount
+- Always confirm wallet setup and allowances before attempting live trading
+- Report scan results in this format: Market / Direction / Edge % / Bet Size / Status
+- Remind user: prediction markets carry real financial risk — only trade with money you can afford to lose

--- a/skills/portfolio-analyzer/SKILL.md
+++ b/skills/portfolio-analyzer/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: portfolio-analyzer
+version: 1.0.0
+description: Assess investment portfolios for allocation, risk, diversification, and performance
+activation:
+  keywords:
+    - "portfolio"
+    - "my investments"
+    - "analyze my holdings"
+    - "asset allocation"
+    - "investment review"
+    - "diversification"
+    - "risk assessment"
+    - "rebalance"
+  patterns:
+    - "(?i)(analyze|review|assess|check).*(portfolio|investments|holdings|assets)"
+    - "(?i)(asset|portfolio).*(allocation|balance|diversification)"
+    - "(?i)(should I|how do I).*(rebalance|diversify|invest)"
+  tags:
+    - "finance"
+    - "investment"
+    - "analysis"
+  max_context_tokens: 2000
+---
+
+# Portfolio Analyzer Skill
+
+Analyzes investment portfolios for allocation health, risk exposure, diversification quality, and actionable rebalancing insights.
+
+## When to Use
+
+- User shares their investment holdings and wants an assessment
+- User asks about asset allocation or diversification
+- User wants to know if their portfolio is too risky or too conservative
+- User wants rebalancing recommendations
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Risk profile first** — never analyze without knowing the user's risk tolerance and time horizon
+2. **Allocation is everything** — the mix of assets (stocks/bonds/crypto/cash) drives most of long-term performance
+3. **Diversification ≠ many assets** — 20 tech stocks is not diversified; check sector, geography, and asset class spread
+4. **Returns in context** — compare performance to a relevant benchmark (S&P 500, BTC, etc.)
+
+### Analysis Framework
+
+**Step 1: Asset Class Breakdown**
+- What % is in: equities / bonds / crypto / cash / alternatives?
+- Is this appropriate for the user's age and risk tolerance?
+
+**Step 2: Diversification Check**
+- Sector concentration (too much tech, energy, etc.)?
+- Geographic concentration (US-only vs. global)?
+- Single-asset risk (too much in one stock or coin)?
+
+**Step 3: Risk Assessment**
+- Volatility level (crypto-heavy = high risk)
+- Correlation between assets (do they move together?)
+- Downside exposure (what happens in a 30% market drop?)
+
+**Step 4: Rebalancing Recommendation**
+- What to trim (overweight positions)?
+- What to add (underweight areas)?
+- Target allocation vs. current allocation
+
+### Risk Tolerance Guide
+
+| Profile | Typical Allocation |
+|---------|-------------------|
+| Conservative | 70% bonds, 30% equities |
+| Moderate | 60% equities, 40% bonds |
+| Aggressive | 80%+ equities/crypto |
+
+### Mistakes to Avoid
+
+- Never give personalized financial advice as fact — always recommend consulting a licensed advisor
+- Don't ignore the user's time horizon — a 25-year-old and a 60-year-old need different portfolios
+- Don't evaluate crypto and stocks with the same risk lens
+
+## Guidelines
+
+- Always ask: age/timeline, risk tolerance, and goal (growth/income/preservation)
+- End every analysis with: "This is for informational purposes only. Consult a licensed financial advisor for personalized advice."
+- Use percentages, not just dollar amounts, for allocation analysis

--- a/skills/position-manager/SKILL.md
+++ b/skills/position-manager/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: position-manager
+version: 1.0.0
+description: Manage Polymarket positions including entry sizing, hedging, scaling, and exit timing
+activation:
+  keywords:
+    - "manage my position"
+    - "should I hedge"
+    - "scale into"
+    - "exit polymarket"
+    - "how much to bet"
+    - "position size polymarket"
+    - "when to exit market"
+    - "lock in profit polymarket"
+  patterns:
+    - "(?i)(manage|size|scale|hedge|exit).*(position|bet|market).*(polymarket)?"
+    - "(?i)(how much|how many).*(bet|put in|risk).*(polymarket|market)"
+    - "(?i)(lock in|take).*(profit|gains).*(polymarket|market)"
+  tags:
+    - "polymarket"
+    - "position"
+    - "risk"
+  max_context_tokens: 2000
+---
+
+# Position Manager Skill (Polymarket)
+
+Manages Polymarket positions across the full trade lifecycle — from sizing entry bets to scaling, hedging, and exiting at the right time.
+
+## When to Use
+
+- User wants to know how much to bet on a market
+- User is in a position and wants to know when/how to exit
+- User wants to hedge an existing position
+- User wants to scale into a market as new information emerges
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Bankroll management is survival** — never risk ruin on a single market; protect the bankroll first
+2. **Scale with conviction** — start small, add as your thesis is confirmed by events
+3. **Hedging locks profits** — once significantly up, hedge the opposite side to guarantee a return
+4. **Exit before resolution uncertainty** — if the outcome is unclear close to resolution, exit for a guaranteed partial return
+
+### Position Sizing Framework
+
+Use the Kelly Criterion (simplified):
+
+```
+Bet Size = (Edge / Odds) × Bankroll
+
+Where:
+- Edge = Your probability - Market price
+- Odds = (1 - Market price) / Market price
+
+Example:
+- Your estimate: 60%, Market: 40¢
+- Edge = 0.60 - 0.40 = 0.20
+- Odds = 0.60 / 0.40 = 1.5
+- Kelly = (0.20 / 1.5) = 13.3% of bankroll
+
+Use half-Kelly for safety: 6.6% of bankroll
+```
+
+### Position Lifecycle
+
+**Entry**: Start with 25–50% of intended position. Confirm thesis, then add.
+
+**Scaling in**: Add to position when:
+- New information confirms your thesis
+- Price moves against you but fundamentals unchanged (dollar cost average)
+- Market liquidity improves (better fill prices)
+
+**Hedging**: Buy the opposite side when:
+- Position is up >50% and resolution is near
+- A binary event could flip the outcome
+- You want to lock in a guaranteed return
+
+**Exit**: Sell position when:
+- Thesis is broken by new information
+- Price has moved to fair value (edge is gone)
+- Better opportunity exists elsewhere
+- Resolution date is near and outcome is still uncertain
+
+### Mistakes to Avoid
+
+- Never go all-in on a single market — max 10% of bankroll per market
+- Don't hold losers hoping for a reversal if your thesis is broken
+- Don't forget to account for Polymarket fees in profit calculations
+
+## Guidelines
+
+- Always ask: total bankroll, current position size, entry price, and current market price
+- Calculate current P&L and remaining edge before advising
+- Provide specific numbers: "Bet $X", not "bet a little more"
+- For hedging: calculate the exact opposite position size needed to guarantee a specific return

--- a/skills/risk-manager/SKILL.md
+++ b/skills/risk-manager/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: risk-manager
+version: 1.0.0
+description: Apply professional risk management including position sizing, risk/reward ratios, and drawdown rules
+activation:
+  keywords:
+    - "risk management"
+    - "how much to risk"
+    - "position size"
+    - "risk per trade"
+    - "max drawdown"
+    - "account protection"
+    - "risk reward ratio"
+    - "kelly criterion"
+  patterns:
+    - "(?i)(risk management|risk per trade|position size|account protection)"
+    - "(?i)(how much|what percentage|what size).*(risk|trade|invest|put in)"
+    - "(?i)(max drawdown|daily loss limit|risk.?reward)"
+  tags:
+    - "trading"
+    - "risk"
+    - "strategy"
+  max_context_tokens: 2000
+---
+
+# Risk Manager Skill
+
+Applies professional-grade risk management across all trade types — calculating position sizes, enforcing loss limits, and protecting capital for long-term survival.
+
+## When to Use
+
+- User wants to know how much to risk on a trade
+- User wants position sizing help
+- User wants to set up a risk framework for their account
+- User is recovering from a drawdown and needs a plan
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Risk a fixed percentage, not a fixed dollar amount** — as account grows or shrinks, risk adjusts automatically
+2. **The goal is to stay in the game** — a losing month is recoverable; a blown account is not
+3. **Asymmetric risk** — losses hurt more than gains help; avoid large losses above all else
+4. **Consistency compounds** — 1% daily at 60% win rate beats inconsistent home runs
+
+### Position Sizing Formula
+
+```
+Step 1: Define dollar risk
+Dollar Risk = Account Size × Risk % per trade
+Example: $10,000 × 1% = $100 at risk
+
+Step 2: Define stop distance
+Stop Distance % = |Entry Price - Stop Price| / Entry Price
+Example: Entry $50,000, Stop $48,500 → 3% stop distance
+
+Step 3: Calculate position size
+Position Size = Dollar Risk / Stop Distance %
+Example: $100 / 0.03 = $3,333 position size
+
+Step 4: Verify leverage
+Leverage = Position Size / Account Size
+Example: $3,333 / $10,000 = 0.33x — very conservative
+```
+
+### Risk Per Trade Guidelines
+
+| Account Stage | Risk Per Trade |
+|--------------|---------------|
+| New / learning | 0.5% |
+| Growing / consistent | 1% |
+| Experienced / profitable | 1–2% |
+| Expert / proven edge | Up to 3% |
+| Never | >5% |
+
+### Daily & Weekly Loss Limits
+
+| Limit | Threshold | Action |
+|-------|-----------|--------|
+| Daily loss limit | 3% of account | Stop trading for the day |
+| Weekly loss limit | 7% of account | Reduce size 50% next week |
+| Monthly loss limit | 15% of account | Full strategy review |
+| Drawdown limit | 20% from peak | Stop, reassess, paper trade |
+
+### Risk/Reward Requirements
+
+- Minimum R:R to take a trade: 1:2
+- Target R:R for most trades: 1:3
+- High-conviction trades: 1:5+
+- Never trade negative expectancy setups (R:R < 1:1)
+
+### Drawdown Recovery Plan
+
+When in a drawdown:
+1. At -10%: Reduce position size by 25%
+2. At -15%: Reduce position size by 50%
+3. At -20%: Stop live trading, review all recent trades
+4. At -25%+: Paper trade for 2 weeks before returning
+
+The math of recovery:
+- 20% down → need 25% to recover
+- 30% down → need 43% to recover
+- 50% down → need 100% to recover
+
+### Portfolio-Level Risk
+
+- Max correlated positions: 3 (don't hold 5 altcoins that all move with BTC)
+- Max single asset exposure: 20% of account
+- Always keep 20–30% cash as dry powder
+
+### Mistakes to Avoid
+
+- Never increase position size to recover losses faster — it accelerates the blowup
+- Don't skip the daily loss limit rule — it exists for your worst days
+- Don't risk more just because a setup "looks perfect"
+
+## Guidelines
+
+- Always output: Dollar risk / Position size / Leverage / R:R for every trade request
+- If user is in a drawdown, assess how deep and apply the recovery plan
+- Challenge any trade where the user wants to risk >2% — explain the compounding danger
+- End with: "Risk management is not a constraint — it's what keeps you in the game."

--- a/skills/rug-detector/SKILL.md
+++ b/skills/rug-detector/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: rug-detector
+version: 1.0.0
+description: Identify rug pull red flags including honeypots, unlocked liquidity, and suspicious dev wallets
+activation:
+  keywords:
+    - "is this a rug"
+    - "rug pull"
+    - "honeypot"
+    - "is this safe"
+    - "check contract"
+    - "is this legit"
+    - "dev wallet"
+    - "liquidity locked"
+    - "audit"
+  patterns:
+    - "(?i)(is this|check).*(rug|safe|legit|honeypot|scam)"
+    - "(?i)(liquidity|liq).*(locked|unlocked|burned)"
+    - "(?i)(dev|team).*(wallet|holding|dumping)"
+  tags:
+    - "memecoin"
+    - "safety"
+    - "trading"
+  max_context_tokens: 2000
+---
+
+# Rug Detector Skill
+
+Analyzes memecoin contracts and on-chain data to identify rug pull risks, honeypots, and malicious developer behavior before the user invests.
+
+## When to Use
+
+- User shares a contract address and wants a safety check
+- User asks "is this a rug?" or "is this safe?"
+- User wants to verify liquidity lock status
+- User is about to ape into a new token
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Verify before you buy** — always check the contract before putting money in
+2. **Liquidity is the lifeline** — unlocked liquidity can be pulled at any time
+3. **Dev concentration is risk** — if one wallet holds >10% of supply, they can dump on you
+4. **Code doesn't lie** — contract functions reveal if the dev can mint, pause, or blacklist
+
+### Red Flag Checklist
+
+**🔴 Critical (walk away)**
+- Honeypot: buy works, sell fails — test on honeypot.is
+- Mint function enabled: dev can print unlimited tokens
+- Blacklist function: dev can block your wallet from selling
+- Liquidity not locked or burned
+- Dev wallet holds >20% of supply
+- Contract not verified on block explorer
+
+**🟡 Warning (proceed with caution)**
+- Liquidity locked for <30 days
+- Top 10 wallets hold >50% of supply
+- No audit from a known firm
+- Anonymous team with no track record
+- Very new contract (<24 hours)
+
+**🟢 Safer signals**
+- Liquidity burned (sent to dead address)
+- Contract renounced (dev can't modify it)
+- Verified contract on explorer
+- Holder distribution is wide (1000+ holders)
+- Audit from Certik, Hacken, or similar
+
+### Tools to Use
+
+| Tool | Purpose |
+|------|---------|
+| honeypot.is | Test if token is a honeypot |
+| tokensniffer.com | Automated contract risk score |
+| etherscan / solscan | Verify contract, check holders |
+| team.finance / unicrypt | Check liquidity lock status |
+| rugcheck.xyz | Solana-specific rug check |
+
+### Mistakes to Avoid
+
+- Don't assume locked liquidity = safe — check the lock duration
+- Don't trust audit logos on websites — verify the audit report directly
+- Don't ignore wallet concentration even if liquidity is locked
+
+## Guidelines
+
+- Always run at minimum: honeypot check + liquidity lock check + top holder check
+- Output a risk score: 🔴 High Risk / 🟡 Medium Risk / 🟢 Lower Risk
+- List every red flag found with a one-line explanation
+- End with: "This is not financial advice. Always do your own research."

--- a/skills/self-critique/SKILL.md
+++ b/skills/self-critique/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: self-critique
+version: 1.0.0
+description: Evaluate the quality of every major trade recommendation before and after execution to build self-awareness and reduce errors
+activation:
+  keywords:
+    - "was that right"
+    - "critique this trade"
+    - "review my analysis"
+    - "how good was that call"
+    - "second opinion"
+    - "check my reasoning"
+    - "devil's advocate"
+    - "what could go wrong"
+  patterns:
+    - "(?i)(critique|review|evaluate|check|second.?opinion).*(trade|analysis|reasoning|call|decision)"
+    - "(?i)(what could|what might).*(go wrong|fail|invalidate|miss)"
+    - "(?i)(was (that|this)|is this).*(right|correct|good|valid|accurate)"
+  tags:
+    - "reasoning"
+    - "learning"
+    - "quality-control"
+  max_context_tokens: 2000
+---
+
+# Self-Critique Skill
+
+Evaluates the quality of the agent's own trade recommendations and reasoning before finalizing them — catching weak signals, overconfidence, and missing context before they become bad trades.
+
+## When to Use
+
+- Before finalizing any trade recommendation — run a self-critique pass
+- When user asks "is this right?" or "devil's advocate this"
+- After a losing trade — critique what went wrong
+- When multiple skills conflict and a decision still needs to be made
+- Any time confidence is HIGH — high confidence warrants extra scrutiny
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Steel-man the opposite side** — before recommending a trade, argue the strongest case AGAINST it
+2. **Confidence calibration** — HIGH confidence should only be assigned when 3+ independent signals agree
+3. **Identify what you're missing** — what information would change this recommendation?
+4. **Separate analysis from conviction** — a good-looking chart does not mean a good trade
+
+### Pre-Trade Critique Checklist
+
+Run this BEFORE every recommendation:
+
+**Signal Quality**
+- [ ] How many independent signals support this trade? (1 = weak, 2 = moderate, 3+ = strong)
+- [ ] Are the signals truly independent or derived from the same data?
+- [ ] Is there any signal directly contradicting the thesis?
+- [ ] What timeframe are the signals from? Do higher timeframes agree?
+
+**Risk Assessment**
+- [ ] Is the stop loss placement logical (not arbitrary)?
+- [ ] Is the risk/reward ratio at least 1:2?
+- [ ] What is the maximum realistic loss if wrong?
+- [ ] Is position size within risk management rules?
+
+**Context Check**
+- [ ] What is the broader market doing? (BTC trend, overall sentiment)
+- [ ] Are there any upcoming events that could invalidate this? (Fed, earnings, expiry)
+- [ ] Is this trade against the higher timeframe trend?
+- [ ] Is the asset overleveraged? (check funding rates)
+
+**Bias Check**
+- [ ] Am I recommending this because the signals are strong, or because I want it to work?
+- [ ] Have I looked at this chart fresh, or am I anchored to a previous view?
+- [ ] Is this FOMO (reacting to a move already made)?
+
+### Confidence Rating System
+
+Assign confidence AFTER running the checklist:
+
+**🟢 HIGH Confidence**
+- 3+ independent signals aligned
+- Higher timeframe agrees
+- No contradicting signals
+- R:R ≥ 1:3
+- No major events upcoming
+- → Proceed with standard position size
+
+**🟡 MEDIUM Confidence**
+- 2 signals aligned, 1 conflicting OR
+- Only 2 signals total with no contradictions
+- R:R between 1:2 and 1:3
+- → Proceed with 50% of standard position size
+
+**🔴 LOW Confidence**
+- Single signal only OR
+- Conflicting signals with no clear winner OR
+- Against higher timeframe trend
+- R:R < 1:2
+- → Do not trade. Wait for a better setup.
+
+### Post-Trade Critique (After Close)
+
+After every trade closes, answer these:
+
+**If it was a WIN:**
+- Was the win due to the thesis playing out, or luck?
+- Did I exit at the right time or leave significant profit behind?
+- Was my confidence rating correct?
+- What would I do differently?
+
+**If it was a LOSS:**
+- Which signal failed and why?
+- Was the stop loss in the right place?
+- Were there warning signs I ignored?
+- Was the loss within the expected risk parameters?
+- Was this a good trade that just didn't work, or a bad trade I shouldn't have taken?
+
+### The Devil's Advocate Pass
+
+For every HIGH confidence recommendation, run this before finalizing:
+
+```
+"The opposite trade (SHORT instead of LONG) would make sense if:
+  1. [Strongest bearish argument]
+  2. [What the bears are seeing that I'm not]
+  3. [What recent price action supports the bearish case]
+
+My response to these bear arguments:
+  1. [Why bulls still have the edge]
+  2. [What would make me switch to bearish]
+
+Final verdict: [PROCEED / REDUCE SIZE / WAIT]"
+```
+
+### Critique Output Format
+
+Always produce critique in this format:
+
+```
+SELF-CRITIQUE: [Asset] [Direction]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Signals found:      [list]
+Signals missing:    [list]
+Contradictions:     [list or "none"]
+Higher TF agrees:   YES / NO / MIXED
+Upcoming risk:      [events or "none"]
+Bias detected:      [describe or "none"]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Confidence:         🟢 HIGH / 🟡 MEDIUM / 🔴 LOW
+Recommended size:   FULL / 50% / DO NOT TRADE
+One thing that could make this wrong: [single biggest risk]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+### Common Biases to Watch For
+
+| Bias | What It Looks Like | Fix |
+|------|--------------------|-----|
+| Confirmation bias | Only looking for signals that agree | Actively search for contradicting signals |
+| Recency bias | Weighting last 2 candles too heavily | Check at least 3 timeframes |
+| Anchoring | Still bullish despite structure break | Re-draw chart from scratch |
+| FOMO | Entering after 20% move already made | Check if thesis is still valid at new price |
+| Loss aversion | Holding a loser hoping to break even | Apply the trade-memory stop rules |
+| Overconfidence | HIGH confidence on <3 signals | Recount signals strictly |
+
+### Mistakes to Avoid
+
+- Never skip the pre-trade checklist for HIGH confidence trades — those are the most dangerous
+- Don't let a compelling narrative override weak technicals
+- Don't assign HIGH confidence just because the user seems convinced
+- Don't critique only losing trades — winning trades also need critique to ensure it wasn't luck
+
+## Guidelines
+
+- Run the pre-trade checklist silently before EVERY recommendation — don't wait to be asked
+- Always output the Critique Format block when confidence is HIGH or when user explicitly asks
+- If LOW confidence, do not recommend the trade — suggest waiting for a better setup instead
+- Log critique results to trade-memory skill alongside the trade entry
+- If a trade was right for the wrong reasons, flag it — lucky trades build bad habits

--- a/skills/summarizer/SKILL.md
+++ b/skills/summarizer/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: summarizer
+version: 1.0.0
+description: Condense long documents, articles, conversations, or content into clear, structured key points
+activation:
+  keywords:
+    - "summarize"
+    - "tldr"
+    - "tl;dr"
+    - "key points"
+    - "condense this"
+    - "shorten this"
+    - "main points"
+    - "give me a summary"
+    - "what does this say"
+  patterns:
+    - "(?i)(summarize|condense|shorten|compress).*(this|text|article|document|content)"
+    - "(?i)(key|main|important).*(points|takeaways|ideas)"
+    - "(?i)tl;?dr"
+  tags:
+    - "communication"
+    - "writing"
+    - "productivity"
+  max_context_tokens: 2000
+---
+
+# Summarizer Skill
+
+Condenses any length of content — articles, documents, conversations, reports — into structured, scannable summaries without losing meaning.
+
+## When to Use
+
+- User pastes a long article, document, or text and wants it shortened
+- User asks for "key points", "main ideas", or a "TL;DR"
+- User shares a conversation or thread and wants a digest
+- User needs an executive summary of a report
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Preserve intent** — the summary must reflect the original meaning; never distort or editorialize
+2. **Layer by detail** — offer a 1-sentence gist, then bullet points, then detail if needed
+3. **Cut ruthlessly** — remove examples, filler, repetition; keep only the essential claims
+4. **Structure for scanning** — use bullets and headers so users can read in 30 seconds
+
+### Summary Formats
+
+Choose format based on content type:
+
+| Content Type | Best Format |
+|-------------|-------------|
+| Article/Blog | TL;DR + 3–5 bullets |
+| Report/Doc | Executive summary + section headers |
+| Conversation | Who said what + key decisions |
+| Code/Technical | What it does + key functions |
+| Legal/Contract | Key obligations + red flags |
+
+### Compression Levels
+
+- **Brief**: 1–3 sentences, pure gist
+- **Standard**: TL;DR + 5 bullet points
+- **Detailed**: Section-by-section breakdown with key quotes
+
+### Mistakes to Avoid
+
+- Don't include the agent's opinion in the summary
+- Never cut information that changes the meaning
+- Don't just copy-paste sentences — genuinely rephrase
+
+## Guidelines
+
+- Default to Standard format unless user specifies
+- If the content is very long (>2000 words), ask which section to prioritize
+- Always end with: "Want me to go deeper on any section?"

--- a/skills/trade-memory/SKILL.md
+++ b/skills/trade-memory/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: trade-memory
+version: 1.0.0
+description: Record trade decisions and outcomes, analyze performance, and surface patterns to improve agent accuracy over time
+activation:
+  keywords:
+    - "remember this trade"
+    - "log this trade"
+    - "log outcome"
+    - "what was my win rate"
+    - "review my trades"
+    - "how am I performing"
+    - "trade history"
+    - "performance review"
+    - "best signals"
+    - "worst signals"
+  patterns:
+    - "(?i)(log|record|remember|save).*(trade|outcome|result|decision)"
+    - "(?i)(win rate|performance|accuracy|review).*(trades|signals|history)"
+    - "(?i)(what|which).*(signals|skills|patterns).*(working|best|worst|accurate)"
+  tags:
+    - "memory"
+    - "learning"
+    - "performance"
+  max_context_tokens: 2000
+tools:
+  - name: feedback_loop
+    path: ./feedback_loop.py
+    description: Log trade decisions and outcomes, analyze win rates by signal type
+---
+
+# Trade Memory Skill
+
+Records every trade decision and its eventual outcome, builds a performance history, and surfaces which signals and skills are working best — enabling continuous improvement of the agent's accuracy over time.
+
+## When to Use
+
+- After any trade recommendation — log the decision immediately
+- When a trade closes — log the outcome (profit/loss)
+- When user asks "how am I performing" or "what's my win rate"
+- Weekly performance review to identify which skills to improve
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Log everything, judge later** — record every decision even if you're unsure; patterns emerge over time
+2. **Outcomes are ground truth** — what the agent predicted matters less than what actually happened
+3. **Signal-level attribution** — always record WHICH skills/signals triggered the trade so you can measure each one
+4. **Review beats intuition** — data from 50 trades tells you more than gut feeling from 500
+
+### What to Log Per Trade
+
+**At decision time (entry):**
+```json
+{
+  "id": "trade_001",
+  "timestamp": "2025-05-16T10:23:00Z",
+  "asset": "ETH",
+  "direction": "LONG",
+  "entry_price": 2850.00,
+  "position_size": 200,
+  "skills_triggered": ["chart-reader", "indicator-analyst", "trend-detector"],
+  "signals": ["RSI oversold on 4h", "Bull flag on 1h", "Above 200 EMA"],
+  "confidence": "HIGH",
+  "stop_loss": 2750.00,
+  "take_profit": 3100.00,
+  "risk_reward": 2.5,
+  "outcome": null
+}
+```
+
+**At close time (outcome):**
+```json
+{
+  "id": "trade_001",
+  "exit_price": 3050.00,
+  "exit_reason": "TP1 hit",
+  "pnl_pct": 7.0,
+  "pnl_usd": 14.0,
+  "outcome": "WIN",
+  "notes": "RSI divergence signal was the strongest predictor here"
+}
+```
+
+### How to Log (Commands)
+
+**Log a new trade entry:**
+> "Log trade: ETH long at $2850, stop $2750, target $3100, signals: RSI oversold + bull flag, confidence HIGH"
+
+**Log a trade outcome:**
+> "Log outcome for trade_001: exited at $3050, win, +7%"
+
+**Review performance:**
+> "Show my win rate for RSI signals"
+> "Which skills have the highest win rate?"
+> "Review last 20 trades"
+
+### Performance Metrics to Track
+
+**Per signal type:**
+- Win rate (wins / total trades using that signal)
+- Average R:R achieved vs. planned
+- Average holding time
+
+**Per skill:**
+- How often it triggered
+- Win rate when it was the primary signal
+- Win rate when it was a confirming signal
+
+**Overall:**
+- Total win rate
+- Average win % vs. average loss %
+- Expectancy = (Win rate × Avg win) - (Loss rate × Avg loss)
+- Best performing asset
+- Best performing timeframe
+
+### Weekly Review Process
+
+Every week, ask the agent:
+> "Run weekly performance review"
+
+The agent should:
+1. Count total trades logged this week
+2. Calculate win rate overall and by signal
+3. Identify top 3 performing signals
+4. Identify bottom 3 performing signals
+5. Recommend which SKILL.md files to update
+6. Flag any recurring mistakes
+
+### Learning Actions Based on Data
+
+| Finding | Action |
+|---------|--------|
+| Signal X win rate > 70% | Increase weight/confidence for signal X in relevant skills |
+| Signal Y win rate < 40% | Add to "Mistakes to Avoid" in relevant skill |
+| Asset Z underperforming | Remove from watchlist or reduce position size |
+| Timeframe T best results | Prioritize that timeframe in chart-reader skill |
+| Confidence HIGH but losing | Recalibrate what counts as HIGH confidence |
+
+### Mistakes to Avoid
+
+- Never skip logging a loss — losses teach more than wins
+- Don't update SKILL.md based on fewer than 10 trades — too small a sample
+- Don't confuse correlation with causation — just because signal X preceded a win doesn't mean it caused it
+- Don't log vague signals ("market looked good") — be specific ("RSI < 32 on 4h with volume spike")
+
+## Guidelines
+
+- Log every trade at entry, before the outcome is known — no cherry-picking
+- Use `feedback_loop.py` tool for all logging and retrieval operations
+- Store logs at: `~/.ironclaw/memory/trade-log.jsonl`
+- After every 10 trades, automatically suggest a skill refinement based on patterns found
+- Always include the `skills_triggered` array — this is what enables signal-level attribution

--- a/skills/trade-planner/SKILL.md
+++ b/skills/trade-planner/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: trade-planner
+version: 1.0.0
+description: Build complete trade plans with entry, exit, stop-loss, take-profit, and risk/reward analysis
+activation:
+  keywords:
+    - "trade plan"
+    - "plan my trade"
+    - "entry and exit"
+    - "stop loss"
+    - "take profit"
+    - "risk reward"
+    - "trade setup"
+    - "plan a trade"
+  patterns:
+    - "(?i)(plan|build|create|give me).*(trade|setup|position)"
+    - "(?i)(entry|exit|stop.?loss|take.?profit).*(plan|level|price)"
+    - "(?i)(risk.?reward|RR ratio|1:2|1:3)"
+  tags:
+    - "trading"
+    - "strategy"
+    - "planning"
+  max_context_tokens: 2000
+---
+
+# Trade Planner Skill
+
+Builds complete, structured trade plans with precise entry zones, stop-loss levels, take-profit targets, and risk/reward ratios before any position is opened.
+
+## When to Use
+
+- User wants to plan a trade before entering
+- User asks for entry, stop-loss, and take-profit levels
+- User wants to know the risk/reward of a trade idea
+- User has a directional thesis and needs a structured execution plan
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Plan before you trade** — never enter without knowing your exit (both profit and loss)
+2. **Risk/reward minimum 1:2** — only take trades where potential profit is at least 2x potential loss
+3. **Invalidation first** — define what would make your thesis wrong before defining the target
+4. **Trade the plan, not the emotion** — once the plan is set, execute it mechanically
+
+### Trade Plan Template
+
+```
+ASSET: [Token/Pair]
+DIRECTION: Long / Short
+TIMEFRAME: [Entry chart timeframe]
+THESIS: [Why this trade makes sense in 1-2 sentences]
+
+ENTRY ZONE: $X – $Y
+  Trigger: [What needs to happen to enter — candle close, retest, etc.]
+
+STOP LOSS: $Z
+  Reason: [Why this level invalidates the thesis]
+  Risk: $[Dollar amount at risk]
+
+TAKE PROFIT TARGETS:
+  TP1: $A — [25-50% of position] — [Reason: resistance level / previous high]
+  TP2: $B — [25-50% of position] — [Reason]
+  TP3: $C — [runner] — [Reason: major target]
+
+RISK/REWARD:
+  To TP1: 1:[X]
+  To TP2: 1:[X]
+  Blended R:R: 1:[X]
+
+INVALIDATION: [What price action/event would cancel this setup]
+POSITION SIZE: $[Amount based on 1-2% account risk]
+```
+
+### Entry Triggers
+
+Never enter "at market" blindly — use a trigger:
+- Candle close above/below a key level
+- Retest of a broken level that holds
+- Specific indicator signal (MACD cross, RSI bounce from 30)
+- Volume spike confirming the move
+
+### Stop Loss Placement
+
+| Setup Type | Stop Placement |
+|-----------|---------------|
+| Support bounce | Below the support zone (not exactly at it) |
+| Breakout trade | Below the breakout level |
+| Trend continuation | Below the last higher low |
+| Reversal | Beyond the wick of the reversal candle |
+
+Rule: Place stop where the trade thesis is definitively wrong, not where it's uncomfortable.
+
+### Take Profit Levels
+
+Good TP levels:
+- Previous swing highs/lows
+- Major round numbers
+- Fibonacci extension levels (1.272, 1.618)
+- High-volume nodes from volume profile
+- Known resistance/support from higher timeframe
+
+### Risk/Reward Rules
+
+- Minimum acceptable R:R = 1:2
+- Preferred R:R = 1:3 or better
+- For high-conviction setups only: 1:5+
+- Never take a trade with R:R below 1:1.5
+
+### Mistakes to Avoid
+
+- Don't move stop loss to avoid being stopped out — honor the plan
+- Don't take partial profits too early and miss the full target
+- Don't enter at the wrong level because you're impatient
+
+## Guidelines
+
+- Always produce the full trade plan template for every request
+- Calculate exact dollar risk based on stated account size
+- Flag if R:R is below 1:2 and suggest adjusting the stop or target
+- Remind user: "Set your alerts. Walk away. Let the plan work."

--- a/skills/translator/SKILL.md
+++ b/skills/translator/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: translator
+version: 1.0.0
+description: Translate text between languages with tone and context preservation
+activation:
+  keywords:
+    - "translate"
+    - "in spanish"
+    - "in french"
+    - "in arabic"
+    - "convert to"
+    - "what does this mean in"
+    - "how do you say"
+    - "translate this to"
+  patterns:
+    - "(?i)(translate|convert).*(to|into|from).*(english|spanish|french|arabic|portuguese|german|chinese|japanese|yoruba|igbo|hausa)"
+    - "(?i)how (do you|would you) say.*(in)"
+    - "(?i)what (does|is) this.*(mean|say).*(in)"
+  tags:
+    - "communication"
+    - "language"
+    - "translation"
+  max_context_tokens: 2000
+---
+
+# Translator Skill
+
+Translates text between any languages while preserving tone, context, and nuance — not just literal word-for-word conversion.
+
+## When to Use
+
+- User asks to translate any text, phrase, or document
+- User wants to know how to say something in another language
+- User pastes foreign text and wants to understand it
+- User needs a culturally appropriate translation (not just literal)
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Context over literalism** — translate meaning and intent, not word-for-word; idiomatic expressions need cultural equivalents
+2. **Preserve tone** — a formal document should remain formal; a casual message should remain casual
+3. **Flag ambiguity** — if a phrase has multiple valid translations, present options with explanations
+4. **Respect dialects** — Spanish (Mexico) ≠ Spanish (Spain); French (France) ≠ French (Canada); ask when it matters
+
+### Translation Process
+
+1. Identify source language (if not stated)
+2. Identify target language
+3. Assess tone and register (formal/informal/technical)
+4. Translate with cultural adaptation
+5. Flag any phrases that don't translate directly
+
+### Language Support Priority
+
+Handle with high accuracy:
+- English, Spanish, French, Portuguese, Arabic, German, Chinese, Japanese, Yoruba, Igbo, Hausa, Swahili
+
+### Mistakes to Avoid
+
+- Never do literal word-for-word for idioms — always find the cultural equivalent
+- Don't assume dialect — ask if the target audience matters
+- Don't skip back-translation for important documents
+
+## Guidelines
+
+- For long documents, translate section by section
+- Always show: Original → Translation (and note the source language if auto-detected)
+- For Nigerian languages (Yoruba, Igbo, Hausa), acknowledge if confidence is lower and recommend human review for critical content

--- a/skills/trend-detector/SKILL.md
+++ b/skills/trend-detector/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: trend-detector
+version: 1.0.0
+description: Identify bull/bear trends, breakouts, reversals, and market structure shifts across timeframes
+activation:
+  keywords:
+    - "is this bullish"
+    - "is this bearish"
+    - "trend analysis"
+    - "market structure"
+    - "breakout"
+    - "reversal"
+    - "uptrend"
+    - "downtrend"
+    - "trend change"
+    - "higher highs"
+    - "lower lows"
+  patterns:
+    - "(?i)(is (this|it)|are we).*(bullish|bearish|trending|reversing)"
+    - "(?i)(breakout|breakdown|reversal|trend change|structure break)"
+    - "(?i)(uptrend|downtrend|sideways|consolidation|range)"
+  tags:
+    - "trading"
+    - "technical-analysis"
+    - "trend"
+  max_context_tokens: 2000
+---
+
+# Trend Detector Skill
+
+Identifies the prevailing trend direction, detects breakouts and reversals, and determines market structure shifts across multiple timeframes.
+
+## When to Use
+
+- User wants to know if a market is in an uptrend or downtrend
+- User asks if a breakout or reversal is happening
+- User wants to know if the trend is still intact or changing
+- User wants multi-timeframe trend analysis
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Trend is your edge** — trading with the trend dramatically improves win rate
+2. **Higher timeframe > lower timeframe** — daily trend overrides hourly; always check top-down
+3. **Structure defines trend** — higher highs + higher lows = uptrend; lower highs + lower lows = downtrend
+4. **Break of structure (BOS) = trend change** — when price breaks a key swing low in an uptrend, the trend may be changing
+
+### Trend Identification Framework
+
+**Step 1: Top-down analysis**
+- Start with the Weekly or Daily chart → defines the macro trend
+- Then 4h → defines the intermediate trend
+- Then 1h/15m → defines the entry-level trend
+
+**Step 2: Define market structure**
+- Mark swing highs and swing lows
+- Uptrend: each swing high and low is higher than the last
+- Downtrend: each swing high and low is lower than the last
+- Range/Consolidation: highs and lows are roughly equal
+
+**Step 3: Identify the trend phase**
+
+| Phase | Characteristics |
+|-------|----------------|
+| Accumulation | Low volatility, sideways, smart money buying |
+| Markup (uptrend) | Higher highs, higher lows, increasing volume |
+| Distribution | Low volatility at highs, smart money selling |
+| Markdown (downtrend) | Lower highs, lower lows, declining bounces |
+
+### Breakout Detection
+
+A valid breakout requires:
+- Price closes ABOVE resistance (not just wicks through)
+- Volume is significantly higher than average on the breakout candle
+- Price retests the broken level and holds (retest = confirmation)
+
+A fake breakout (fakeout) shows:
+- Price breaks level but closes back below
+- Low volume on the break
+- Quick reversal after the break
+
+### Reversal Signals
+
+**Early reversal signals:**
+- Break of market structure (BOS) — first lower high in an uptrend
+- Bearish/bullish divergence on RSI or MACD
+- Shooting star or hammer at key level with volume
+- Failed breakout attempt
+
+**Confirmed reversal:**
+- Lower high AND lower low established (uptrend to downtrend)
+- Price breaks below key moving average (200 EMA) on high volume
+- Multiple timeframes align in new direction
+
+### Multi-Timeframe Confluence
+
+| Timeframe | Trend | Action |
+|-----------|-------|--------|
+| Daily: Up | 4h: Up | 1h: Up | Strong buy |
+| Daily: Up | 4h: Up | 1h: Down | Wait for 1h to flip |
+| Daily: Up | 4h: Down | 1h: Down | Don't buy, potential reversal |
+| Daily: Down | 4h: Down | 1h: Down | Strong sell/short |
+
+### Mistakes to Avoid
+
+- Don't call a trend change from a single timeframe
+- Don't confuse a pullback in an uptrend with a reversal
+- Don't trade against the higher timeframe trend without strong reason
+
+## Guidelines
+
+- Always analyze at least 2 timeframes before calling a trend
+- State clearly: Macro trend (daily) / Intermediate trend (4h) / Short-term trend (1h)
+- Flag if timeframes are conflicting — that means wait, not trade
+- Identify the nearest key level that would invalidate the current trend

--- a/skills/web-search/SKILL.md
+++ b/skills/web-search/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: web-search
+version: 1.0.0
+description: Search the web and return summarized, sourced answers to user queries
+activation:
+  keywords:
+    - "search for"
+    - "look up"
+    - "find information about"
+    - "what is the latest on"
+    - "google"
+    - "search the web"
+    - "find online"
+  patterns:
+    - "(?i)(search|look up|find|google).*online"
+    - "(?i)what.*latest.*on"
+    - "(?i)current(ly)?.*information.*about"
+  tags:
+    - "research"
+    - "web"
+    - "data"
+  max_context_tokens: 2000
+---
+
+# Web Search Skill
+
+Enables the agent to search the web and return accurate, summarized, well-sourced answers to user queries in real time.
+
+## When to Use
+
+- User asks for current or recent information
+- User explicitly says "search", "look up", "google", or "find online"
+- The topic requires up-to-date data (news, prices, events, people)
+- Internal knowledge may be outdated or insufficient
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Recency first** — always prefer the most recent, authoritative sources; flag if results are older than 6 months
+2. **Summarize, don't dump** — extract the key insight from results; do not paste raw search output
+3. **Cite your sources** — always include the source name and URL for every major claim
+4. **Acknowledge uncertainty** — if results are conflicting or sparse, say so explicitly
+
+### Search Strategy
+
+- Break complex queries into 2–3 focused sub-queries
+- Prefer official sites, reputable news outlets, and peer-reviewed sources
+- Cross-reference at least 2 sources before presenting a fact as confirmed
+- For ambiguous queries, clarify intent before searching
+
+### Mistakes to Avoid
+
+- Never fabricate URLs or source names — only cite real results
+- Don't present a single source as consensus
+- Avoid summarizing opinion pieces as facts
+
+## Guidelines
+
+- Always end with: "Sources: [name](url)" for each reference used
+- If search returns no useful results, tell the user clearly and suggest alternative queries
+- Keep summaries under 200 words unless the user asks for detail


### PR DESCRIPTION
## Summary

Adds a complete trading skills pack of 42 SKILL.md files for the IronClaw agent runtime. Skills cover perps, Polymarket prediction markets, memecoin trading, market analysis, sentiment, strategy, execution, finance, research, communication, dev tools, and reasoning.

## Closes

Closes #148

## Type

- [ ] Use case
- [ ] New tool
- [x] New skill
- [ ] Bug fix
- [ ] Documentation / process
- [ ] Infrastructure

## Artifact checklist

Skill PRs:

- [x] Adds or updates `skills/<skill-name>/SKILL.md`
- [x] Documents required tool dependencies
- [x] Includes activation behavior in `SKILL.md`
- [x] Tests at least one prompt that should activate the skill

## Testing

Tested activation on the following prompts:
- "What is the current crypto market sentiment?" → activates market-sentiment
- "Is this token a rug pull?" → activates rug-detector
- "Scan for mispriced Polymarket markets" → activates polymarket-trader
- "Set up a perps trade for BTC long" → activates perps-setup
- "Find me an early memecoin" → activates memecoin-scanner

All 42 skills tested locally on IronClaw agent runtime via Telegram channel.
