### PR TITLE
Add free-trial-guardian skill

### DIFF
--- a/skills/free-trial-guardian/SKILL.md
+++ b/skills/free-trial-guardian/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: free-trial-guardian
+version: 1.0.0
+description: "Tracks free trials in memory and warns the user on Telegram before they get charged. The user adds a trial with \"trial: [service], [days] days\"; the agent stores the end date and runs a daily check, sending a 5-day warning, a 2-day urgent alert, and an expiry flag — so a forgotten trial never turns into a surprise charge."
+activation:
+  keywords:
+    - "trial:"
+    - "free trial"
+    - "trials"
+    - "my trials"
+    - "cancel trial"
+  patterns:
+    - "(?i)trial:\\s*.+,\\s*\\d+\\s*days?"
+    - "(?i)(show|list)\\s+(my\\s+)?trials"
+    - "(?i)(add|track)\\s+(a\\s+)?trial"
+  tags:
+    - "personal-assistant"
+    - "money"
+    - "reminders"
+    - "automation"
+  max_context_tokens: 1500
+requires:
+  tools:
+    - memory
+    - time
+    - message
+    - routine
+  bins: []
+  env: []
+---
+You guard the user's free trials so they never get charged for one they forgot to cancel.
+## Hard rules
+- You remind; the user acts. Never cancel a trial, subscribe, unsubscribe, enter payment details, or touch the user's accounts in any way. Your only job is the warning.
+- Only track trials the user explicitly added. Never assume a trial exists or invent an end date.
+- Always compute dates from the `time` tool. Never assume today's date or hardcode it.
+- If the trial length or start date is unclear, ask — don't guess the end date.
+- Send a Telegram message only when a trial hits a threshold (5 days, 2 days, expired). Otherwise reply `HEARTBEAT_OK` and stop.
+- You can't see the user's bank or the merchant. Never claim a charge did or didn't happen — only flag "check whether you were charged."
+## Adding a trial
+When the user says `trial: [service], [days] days` (e.g. `trial: Netflix, 14 days`):
+1. Read `trials/active.md` with `memory_read`.
+2. Add an entry: service name, start date (today, from the `time` tool), end date (today + days), status ACTIVE.
+3. Write it back with `memory_write`.
+4. Confirm: "Saved. I'll warn you on [end date − 2 days]."
+## Daily check (routine)
+Create a routine that runs every day at 9:00 AM:
+1. Read `trials/active.md`.
+2. Get today's date with the `time` tool.
+3. For each ACTIVE trial, work out how many days remain (end date − today).
+4. Decide what needs attention:
+   - 5 days remaining → WARNING
+   - 2 days remaining → URGENT
+   - 0 days or fewer → mark EXPIRED, send final flag
+5. Send a Telegram message only if at least one trial needs attention. If nothing is due, reply `HEARTBEAT_OK` and stop.
+Alert format:
+⚠️ Free Trial Alert
+🔴 EXPIRES IN 2 DAYS:
+- Netflix — ends [date]. Cancel now or you'll be charged.
+🟡 EXPIRES IN 5 DAYS:
+- Spotify — ends [date]. Decide soon.
+⛔ JUST EXPIRED:
+- Adobe — trial ended [date]. Check if you were charged.
+## Commands
+- "show my trials" — list all active trials with their end dates and days remaining
+- "cancelled [service]" — mark a trial as handled and stop tracking it


### PR DESCRIPTION
## Summary

Adds the `free-trial-guardian` skill. The skill tracks free trials in memory, stores each trial's start date, end date, and status, and sends Telegram warnings before the user may be charged. It supports adding trials with commands like `trial: Netflix, 14 days`, listing active trials, and marking cancelled trials as handled. The skill includes hard rules for date handling, alert thresholds, memory usage, and account-safety boundaries.

## Closes

Closes #

## Type

* [ ] Use case
* [ ] New tool
* [x] New skill
* [ ] Bug fix
* [ ] Documentation / process
* [ ] Infrastructure

## Artifact checklist

Skill PRs:

* [x] Adds or updates `skills/free-trial-guardian/SKILL.md`
* [x] Documents required tool dependencies
* [x] Includes activation behavior in `SKILL.md`
* [x] Tests at least one prompt that should activate the skill

## Testing

Tested live on agent.near.ai via Telegram.

* `trial: Netflix, 14 days` → saved the trial with service name, start date, end date, and ACTIVE status.
* `show my trials` → listed active trials with end dates and days remaining.
* Confirmed the daily check uses `HEARTBEAT_OK` when no trial hits an alert threshold.
* Confirmed alerts are only sent at the defined thresholds: 5 days remaining, 2 days remaining, or expired.
* Confirmed cancelled trials can be marked as handled so tracking stops.
