### PR TITLE
Add crypto-trade-journal skill

### DIFF
--- a/crypto-trade-journal/SKILL.md
+++ b/crypto-trade-journal/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: crypto-trade-journal
+version: 1.0.0
+description: "Logs the trades the user tells it about and gives live P&L on demand. The user says something like \"bought 500 NEAR at $3.20\" or \"sold 200 SOL at $145\"; the agent appends it to a persistent journal in memory. On \"show P&L\" it reconstructs each open position, works out the size-weighted average entry, fetches current prices from CoinGecko, and shows cost basis, current value, and profit/loss per token and overall. The journal survives restarts."
+activation:
+  keywords:
+    - "trade journal"
+    - "show my trades"
+    - "show p&l"
+    - "bought"
+    - "sold"
+    - "my pnl"
+  patterns:
+    - "(?i)(bought|sold)\\s+[\\d.]+\\s+\\w+\\s+(at|@)\\s*\\$?[\\d.]+"
+    - "(?i)show\\s+(my\\s+)?(trades|p&l|pnl|history)"
+    - "(?i)how\\s+am\\s+i\\s+doing"
+  tags:
+    - "crypto"
+    - "trading"
+    - "journaling"
+    - "automation"
+  max_context_tokens: 2200
+requires:
+  tools:
+    - http
+    - memory
+    - time
+  bins: []
+  env: []
+---
+You keep a running journal of the user's trades and give them live P&L whenever they ask.
+
+## Hard rules
+- Always read `trades/journal.md` with `memory_read` before writing, then append the new entry with `memory_write`. Never overwrite the journal from scratch and never drop earlier trades. If the file does not exist, create it with a header line and add the entry.
+- Work out positions, average entry, and P&L by reasoning over the journal in plain language. Never write or run code to do the math.
+- For the average entry price, weight by position size, not a simple average of prices.
+- A sell reduces the open position — don't just log it and ignore it.
+- Get the date from the `time` tool when logging. Get prices from CoinGecko with the `http` tool when showing P&L. Never guess a price or a date.
+- Report only trades that are actually in the journal and prices you actually fetched. If a token isn't on CoinGecko, log the trade but mark its price "unavailable" rather than inventing one.
+- This is a record-keeper, not an advisor. Never tell the user to buy or sell.
+
+## Logging a trade
+When the user says something like `bought 500 NEAR at $3.20` or `sold 200 SOL at $145`:
+1. Get the current date/time from the `time` tool.
+2. Read `trades/journal.md` with `memory_read`.
+3. Append one line in this exact format: `[date] | BUY/SELL | [amount] [TOKEN] | @ $[price] | Total: $[amount × price]`.
+4. Write it back with `memory_write`.
+5. Confirm: `Logged: bought 500 NEAR @ $3.20 on [date]`.
+
+Journal entries live in `trades/journal.md`:
+```
+# Trade Journal
+[date] | BUY | 500 NEAR | @ $3.20 | Total: $1600
+[date] | SELL | 200 SOL | @ $145 | Total: $29000
+```
+
+## Showing P&L
+When the user says `show P&L` / `how am I doing`:
+1. Read `trades/journal.md` with `memory_read`.
+2. For each token still held (more bought than sold), determine the size-weighted average entry and the open size.
+3. Fetch current prices with the `http` tool: `https://api.coingecko.com/api/v3/simple/price?ids=[ids]&vs_currencies=usd` (map symbols to CoinGecko ids yourself — NEAR=near, SOL=solana, BTC=bitcoin, ETH=ethereum, etc.).
+4. Show the table (format below).
+
+P&L format:
+```
+📊 Live P&L
+Token | Avg Entry | Current | Size | Cost Basis | Value | P&L
+NEAR | $[X] | $[X] | [X] | $[X] | $[X] | [+/-X]% 
+...
+Total invested: $[X] | Current value: $[X] | Total P&L: $[X] ([+/-X]%)
+```
+
+## Commands
+- `bought [amount] [token] at $[price]` / `sold [amount] [token] at $[price]` — log a trade
+- `show my trades` — show the full journal as a clean table
+- `show P&L` / `how am I doing` — live P&L across all open positions
+- `show P&L for [token]` — P&L for one token plus its individual trade entries


### PR DESCRIPTION
## Summary

Adds the `crypto-trade-journal` skill. The skill lets the user log crypto trades in memory with natural commands like `bought 500 NEAR at $3.20` or `sold 200 SOL at $145`, then reconstructs open positions on demand to show live P&L. It reads the persistent trade journal from memory, calculates open size and size-weighted average entry, fetches current prices from CoinGecko, and reports cost basis, current value, and profit/loss per token and overall. It is a record-keeping tool, not trading advice.

## Closes

Closes #

## Type

* [ ] Use case
* [ ] New tool
* [x] New skill
* [ ] Bug fix
* [ ] Documentation / process
* [ ] Infrastructure

## Artifact checklist

Skill PRs:

* [x] Adds or updates `skills/crypto-trade-journal/SKILL.md`
* [x] Documents required tool dependencies
* [x] Includes activation behavior in `SKILL.md`
* [x] Tests at least one prompt that should activate the skill

## Testing

Manual checks planned before merge.

* `bought 500 NEAR at $3.20` → create or read `trades/journal.md`, append a BUY entry with date, amount, token, price, and total.
* `sold 200 SOL at $145` → append a SELL entry and confirm it reduces the open position when calculating P&L.
* `show my trades` → display the full journal as a clean table.
* `show P&L` → reconstruct open positions from the journal, fetch current prices from CoinGecko, and show average entry, current value, cost basis, and P&L.
* `show P&L for NEAR` → show token-specific P&L and individual trade entries.
* Confirm the skill never invents prices or dates and marks unavailable prices clearly if a token cannot be found on CoinGecko.
