### PR TITLE
Add token-unlock-warning skill

### DIFF
--- a/skills/token-unlock-warning/SKILL.md
+++ b/skills/token-unlock-warning/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: token-unlock-warning
+version: 1.0.0
+description: "Gives the user a 24-hour Telegram warning before any token unlock hits the market. The user pastes an unlock schedule (copied from a source like DeFiLlama, Messari, or Tokenomist); the agent saves every event to memory with date, amount, USD value, and category, then runs a daily check that pings the day before any unlock with the amount, percentage of supply, and a short price-impact note. It stays silent when nothing is due and holds the full schedule across the whole vesting period."
+activation:
+  keywords:
+    - "token unlock"
+    - "unlock schedule"
+    - "unlock warning"
+    - "vesting"
+    - "my unlocks"
+  patterns:
+    - "(?i)token\\s+unlock"
+    - "(?i)unlock\\s+(schedule|warning|alert)"
+    - "(?i)(show|list)\\s+(my\\s+)?unlocks"
+  tags:
+    - "crypto"
+    - "tokenomics"
+    - "monitoring"
+    - "automation"
+  max_context_tokens: 2000
+requires:
+  tools:
+    - memory
+    - time
+    - message
+    - routine
+  bins: []
+  env: []
+---
+You warn the user 24 hours before any token unlock they're tracking hits the market.
+
+## Hard rules
+- Always read `unlocks/schedule.md` with `memory_read` before any change, then write the full file back with `memory_write`. Never overwrite from scratch and never drop earlier unlock events.
+- Always get today's date from the `time` tool. Never guess it. Hours-until-unlock comes from comparing the stored unlock date to today.
+- If an unlock event has only a calendar date and no exact time, treat the daily check on the day before the unlock date as the 24-hour warning. Do not invent an unlock time.
+- Judge which unlocks are due by reading the dates in plain language. Never write or run code to do it.
+- In the daily routine, send a warning only for unlocks that are due (the day before the unlock date, or within the next 24 hours if a time is given) and not already flagged as alerted. If none are due, reply `HEARTBEAT_OK` and stop — send no message.
+- Each unlock fires its warning once. After warning, mark it ALERTED so it never re-sends.
+- Save and report only unlock events the user actually pasted. Never invent an unlock, an amount, or a date.
+- The price-impact note is interpretation, not a prediction — frame it as a rough read (a larger % of supply tends to mean more pressure), never as advice to buy or sell.
+- Installing this skill does not create the routine by itself. After install, you must explicitly call the routine/mission creation tool yourself to register it — never assume the routine exists just because this file describes one. Confirm it was created (e.g. list active routines) before telling the user it's running.
+
+## Adding an unlock schedule
+When the user pastes an unlock schedule (e.g. lines like `June 9, 2026 — 1,670,000 AVAX — ~$11.34M — 0.23% of total supply — Team/Investor vesting`):
+1. Read `unlocks/schedule.md` with `memory_read`.
+2. Save each event: token, date, amount, USD value, % of total supply, category, status PENDING.
+3. Write the full file back with `memory_write`.
+4. Confirm with a clean table of saved events and a one-line price-impact read per event.
+
+Each event is stored in `unlocks/schedule.md` like this:
+```
+[TOKEN] unlocks
+- [date] | [amount] | [~$USD] | [% of supply] | [category] | status: PENDING | ALERTED: no
+```
+
+## Daily check (routine)
+Create a routine that runs every day at 9:00 AM UTC. The routine goal must contain these full steps as a self-contained prompt, because a routine does not keep any context from this conversation when it runs:
+1. Read `unlocks/schedule.md` with `memory_read`.
+2. Get today's date from the `time` tool.
+3. For each PENDING unlock, see whether it is due. If the event has only a calendar date, it is due when today is the day before that date. If it has an exact time, it is due when the unlock is within the next 24 hours.
+4. For any due unlock that is not yet ALERTED, send the warning (format below) and mark it ALERTED.
+5. If nothing is due, reply `HEARTBEAT_OK` and stop.
+
+Warning format:
+```
+🔓 Token Unlock in ~24h — [TOKEN]
+Date: [date]
+Amount: [amount] ([% of supply] of total supply)
+Value: ~$[USD]
+Category: [category]
+💡 Likely impact: [rough read — e.g. "0.23% of supply is small, limited pressure" / "large unlock relative to supply, watch for selling"]
+```
+
+## Commands
+- `show my unlocks` — list all tracked unlocks with dates, amounts, and days remaining
+- `delete [token] unlocks` — remove a token's schedule from memory


### PR DESCRIPTION
## Summary

Adds the `token-unlock-warning` skill. The skill lets the user paste a token unlock schedule, stores each unlock event in memory with date, amount, USD value, supply percentage, category, and alert status, then runs a daily check to warn the user before an unlock is due. It sends a Telegram warning only for pending unlocks that are within the warning window and have not already been alerted, marks them as alerted after sending, and returns `HEARTBEAT_OK` when nothing is due. The skill is a tokenomics reminder and risk-awareness tool, not trading advice.

## Closes

Closes #

## Type

* [ ] Use case
* [ ] New tool
* [x] New skill
* [ ] Bug fix
* [ ] Documentation / process
* [ ] Infrastructure

## Artifact checklist

Skill PRs:

* [x] Adds or updates `skills/token-unlock-warning/SKILL.md`
* [x] Documents required tool dependencies
* [x] Includes activation behavior in `SKILL.md`
* [x] Tests at least one prompt that should activate the skill

## Testing

Manual checks planned before merge.

* Paste an unlock schedule line like `June 9, 2026 — 1,670,000 AVAX — ~$11.34M — 0.23% of total supply — Team/Investor vesting` → save the unlock event to `unlocks/schedule.md` with status `PENDING` and `ALERTED: no`.
* `show my unlocks` → list tracked unlocks with token, date, amount, USD value, supply percentage, category, and days remaining.
* Confirm the daily routine reads `unlocks/schedule.md`, checks dates using the `time` tool, and sends a warning only for unlocks in the warning window.
* Confirm each unlock alert fires only once and is marked `ALERTED` after sending.
* Confirm runs with no due unlocks return `HEARTBEAT_OK` and send no Telegram message.
* Confirm the skill does not invent unlock dates, amounts, USD values, or price-impact claims.