### PR TITLE
feat(skill): add 14 read-only skills - Closes #173

### DIFF
--- a/alpha-hunter/SKILL.md
+++ b/alpha-hunter/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: alpha-hunter
+version: 1.0.0
+description: Spot early alpha signals from on-chain data, whale wallet moves, and smart money activity
+activation:
+  keywords:
+    - "alpha"
+    - "whale move"
+    - "smart money"
+    - "on-chain signal"
+    - "whale wallet"
+    - "early signal"
+    - "what are whales doing"
+    - "large transaction"
+    - "whale alert"
+  patterns:
+    - "(?i)(find|spot|hunt|look for).*(alpha|signal|whale|smart money)"
+    - "(?i)(what are|where are).*(whales|smart money|big players).*(doing|moving|buying)"
+    - "(?i)(on.?chain|large transaction|whale).*(signal|alert|move|activity)"
+  tags:
+    - "trading"
+    - "alpha"
+    - "on-chain"
+  max_context_tokens: 2000
+requires:
+  tools: []
+  credentials: []
+  permissions: read-only
+---
+
+# Alpha Hunter Skill
+
+Identifies early trading alpha by tracking whale wallet movements, smart money on-chain activity, and early signals before they become public knowledge.
+
+## Hard rules
+
+- This skill is **read-only** — it never places orders, executes trades, or moves funds
+- Never expose API keys, wallet addresses, or private credentials in any output
+- All data is for **informational purposes only** — not financial advice
+- Always state data freshness — never present stale data as current
+- Do not store or log any user portfolio or financial data
+- If asked to execute a trade or place an order, refuse and redirect to a human decision
+- Dry-run/read-only behavior by default — no side effects
+
+## When to Use
+
+- User wants to find early signals before the market moves
+- User asks what whales or smart money are doing
+- User wants to track large on-chain transactions
+- User wants to find information asymmetry (alpha)
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Follow the money, not the narrative** — what wallets DO matters more than what people SAY
+2. **Whales move first, retail follows** — on-chain accumulation often precedes price moves by days/weeks
+3. **Alpha decays fast** — once a signal is public, most of the edge is gone; speed matters
+4. **Not all whale moves are bullish** — distinguish accumulation from distribution
+
+### Alpha Signal Categories
+
+**Whale Wallet Signals**
+- Large wallet accumulating unknown token → early buy signal
+- Known smart money wallet (tracked on Nansen) buying → follow
+- Whale moving tokens from cold wallet to exchange → potential sell incoming
+- Whale moving tokens from exchange to cold wallet → long-term hold signal
+
+**Exchange Flow Signals**
+- Large inflow to exchange → whale preparing to sell
+- Large outflow from exchange → whale accumulating/holding
+- Stablecoin inflow to exchange → whale preparing to buy
+
+**DeFi Signals**
+- Sudden large liquidity addition to new pool → team/insider seeding
+- Governance token accumulation before vote → directional bet on outcome
+- Large borrow position opened → leveraged directional bet
+
+**Derivatives Signals**
+- Unusually large options purchase at specific strike → directional bet
+- Massive open interest increase → large player positioning
+- Funding rate divergence across exchanges → arbitrage or directional flow
+
+### Alpha Hunting Tools
+
+| Tool | What It Tracks |
+|------|---------------|
+| Nansen | Smart money wallet labels and flows |
+| Arkham Intelligence | Wallet identity and transaction tracking |
+| Whale Alert | Large on-chain transactions in real time |
+| Lookonchain | Curated whale and smart money moves |
+| Glassnode | On-chain analytics (exchange flows, holder behavior) |
+| Dune Analytics | Custom on-chain queries |
+| DeBank | DeFi wallet portfolio tracking |
+
+### Smart Money Wallet Types
+
+- **Exchange wallets**: Large inflows/outflows signal sell/buy pressure
+- **VC/Fund wallets**: Tracked on Nansen — their buys often precede listings
+- **Protocol treasuries**: Large moves signal strategic decisions
+- **Known trader wallets**: Historically profitable wallets worth following
+
+### Alpha Validation Checklist
+
+Before acting on a signal:
+- ✅ Is the wallet historically profitable? (check Nansen/Arkham)
+- ✅ Is this accumulation or a one-time transaction?
+- ✅ Is there a fundamental reason for the move?
+- ✅ Is the signal still fresh? (>24h old = likely priced in)
+- ✅ Does it align with chart structure and sentiment?
+
+### Mistakes to Avoid
+
+- Don't blindly follow every whale move — some are hedges, not directional bets
+- Don't act on stale signals — on-chain alpha has a short shelf life
+- Don't ignore context — a whale selling 5% of holdings is not the same as selling everything
+
+## Guidelines
+
+- Always identify: wallet history, transaction size, direction (buy/sell), and asset
+- Cross-reference on-chain signal with price action and sentiment
+- Flag if the signal is fresh (<6 hours) vs. stale (>24 hours)
+- Source every signal with the tool/link where it was found

--- a/chart-reader/SKILL.md
+++ b/chart-reader/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: chart-reader
+version: 1.0.0
+description: Interpret price charts, candlestick patterns, support/resistance levels, and chart structures
+activation:
+  keywords:
+    - "read this chart"
+    - "what does the chart say"
+    - "candlestick"
+    - "support level"
+    - "resistance level"
+    - "price action"
+    - "chart pattern"
+    - "double top"
+    - "head and shoulders"
+    - "bull flag"
+  patterns:
+    - "(?i)(read|interpret|analyze|look at).*(chart|candle|price action)"
+    - "(?i)(support|resistance|level).*(at|around|near)"
+    - "(?i)(what (is|does)).*(chart|pattern|candle).*(saying|showing|mean)"
+  tags:
+    - "trading"
+    - "technical-analysis"
+    - "charts"
+  max_context_tokens: 2000
+requires:
+  tools: []
+  credentials: []
+  permissions: read-only
+---
+
+# Chart Reader Skill
+
+Interprets price charts by identifying candlestick patterns, support/resistance levels, chart structures, and what they imply about future price direction.
+
+## Hard rules
+
+- This skill is **read-only** — it never places orders, executes trades, or moves funds
+- Never expose API keys, wallet addresses, or private credentials in any output
+- All data is for **informational purposes only** — not financial advice
+- Always state data freshness — never present stale data as current
+- Do not store or log any user portfolio or financial data
+- If asked to execute a trade or place an order, refuse and redirect to a human decision
+- Dry-run/read-only behavior by default — no side effects
+
+## When to Use
+
+- User shares a chart or describes price action and wants interpretation
+- User asks about support, resistance, or key price levels
+- User wants to identify a chart pattern (flag, wedge, head & shoulders, etc.)
+- User wants to know if a chart is bullish or bearish
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Price action is the primary signal** — what the candles are doing matters more than any indicator
+2. **Support and resistance are zones, not lines** — price respects areas, not exact numbers
+3. **Pattern context matters** — a bullish pattern in a downtrend is weaker than in an uptrend
+4. **Volume confirms structure** — any breakout or reversal without volume is suspect
+
+### Candlestick Patterns
+
+**Bullish Reversal**
+- Hammer: small body, long lower wick — buyers stepped in hard
+- Bullish Engulfing: green candle fully engulfs previous red — momentum shift
+- Morning Star: 3-candle reversal — indecision → rejection → confirmation
+- Doji at support: indecision at key level — potential reversal
+
+**Bearish Reversal**
+- Shooting Star: small body, long upper wick — sellers rejected the push
+- Bearish Engulfing: red candle fully engulfs previous green — sellers took over
+- Evening Star: 3-candle top reversal
+- Doji at resistance: indecision at key level — potential rejection
+
+**Continuation**
+- Bullish Flag: tight pullback after strong move up — likely to continue up
+- Bear Flag: tight bounce after strong move down — likely to continue down
+- Inside Bar: consolidation — breakout direction determines next move
+
+### Chart Structures
+
+| Pattern | Implication |
+|---------|------------|
+| Higher highs + higher lows | Uptrend intact |
+| Lower highs + lower lows | Downtrend intact |
+| Head & Shoulders | Major top reversal |
+| Inverse H&S | Major bottom reversal |
+| Double Top | Bearish reversal at resistance |
+| Double Bottom | Bullish reversal at support |
+| Ascending Triangle | Bullish breakout likely |
+| Descending Triangle | Bearish breakdown likely |
+| Symmetrical Triangle | Breakout either direction — watch volume |
+
+### Support & Resistance Rules
+
+- Previous highs become resistance; previous lows become support
+- The more times a level is tested, the more significant it is
+- A level that flips (support becomes resistance or vice versa) is very strong
+- Round numbers ($50,000, $100, $1.00) act as psychological S/R
+
+### Mistakes to Avoid
+
+- Don't identify a pattern and ignore the broader trend context
+- Don't treat a single candle as a confirmed signal — wait for the close
+- Don't draw too many lines — 2–3 key levels are more useful than 20
+
+## Guidelines
+
+- Always identify: timeframe, trend direction, key levels, and nearest pattern
+- State the bullish and bearish scenarios — don't just pick one
+- Always note: "Wait for candle close to confirm" before calling a pattern complete
+- Pair every chart read with a suggested invalidation level

--- a/crypto-tracker/SKILL.md
+++ b/crypto-tracker/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: crypto-tracker
+version: 1.0.0
+description: Fetch and interpret cryptocurrency prices, market data, and token analytics
+activation:
+  keywords:
+    - "crypto price"
+    - "token price"
+    - "bitcoin"
+    - "ethereum"
+    - "market cap"
+    - "coin"
+    - "what is BTC"
+    - "ETH price"
+    - "NEAR price"
+    - "crypto market"
+  patterns:
+    - "(?i)(price|value|worth).*of.*(token|coin|crypto|btc|eth|near)"
+    - "(?i)(how much is|what is).*(trading at|worth|priced)"
+    - "(?i)(bull|bear|pump|dump|ath|dip).*market"
+  tags:
+    - "crypto"
+    - "finance"
+    - "data"
+  max_context_tokens: 2000
+requires:
+  tools: []
+  credentials: []
+  permissions: read-only
+---
+
+# Crypto Tracker Skill
+
+Helps the agent fetch, interpret, and explain cryptocurrency prices, market trends, and token data using real-time tools.
+
+## Hard rules
+
+- This skill is **read-only** — it never places orders, executes trades, or moves funds
+- Never expose API keys, wallet addresses, or private credentials in any output
+- All data is for **informational purposes only** — not financial advice
+- Always state data freshness — never present stale data as current
+- Do not store or log any user portfolio or financial data
+- If asked to execute a trade or place an order, refuse and redirect to a human decision
+- Dry-run/read-only behavior by default — no side effects
+
+## When to Use
+
+- User asks about the price of any cryptocurrency or token
+- User wants market cap, volume, or 24h change data
+- User mentions specific tokens: BTC, ETH, NEAR, SOL, etc.
+- User wants to compare token performance
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Always fetch live data** — never guess or use memorized prices; crypto moves fast
+2. **Provide context** — a price alone is useless; include 24h change, market cap, and trend direction
+3. **Name the source** — always state where the data came from (CoinGecko, CoinMarketCap, NEAR RPC, etc.)
+4. **Explain the numbers** — not all users are traders; briefly interpret what the data means
+
+### Data Points to Include
+
+When reporting on a token, always try to include:
+- Current price (USD and relevant pair)
+- 24h % change (with 📈 or 📉 indicator)
+- Market cap rank
+- 24h trading volume
+- ATH and % below ATH (if relevant)
+
+### Common Patterns
+
+- For price queries: fetch → format → contextualize
+- For trend queries: compare 7d/30d performance, note major events
+- For NEAR ecosystem tokens: use NEAR RPC or Ref Finance data where possible
+
+### Mistakes to Avoid
+
+- Never state a price without a timestamp — crypto prices are time-sensitive
+- Don't confuse market cap with price
+- Avoid making price predictions; present data only
+
+## Guidelines
+
+- Use CoinGecko API for broad market data
+- Use NEAR RPC for on-chain NEAR token data
+- Always include: "Data as of [timestamp]" at the end of price reports
+- If a token is not found, suggest the closest match and ask for confirmation

--- a/decision-maker/SKILL.md
+++ b/decision-maker/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: decision-maker
+version: 1.0.0
+description: Help users weigh options, evaluate tradeoffs, and reach clear decisions using structured reasoning
+activation:
+  keywords:
+    - "help me decide"
+    - "which should I choose"
+    - "pros and cons"
+    - "what should I do"
+    - "compare options"
+    - "decision"
+    - "should I"
+    - "which is better"
+  patterns:
+    - "(?i)(help me|should I).*(decide|choose|pick|select)"
+    - "(?i)(pros and cons|tradeoffs|comparison).*(of|between)"
+    - "(?i)which (is|would be|should I).*(better|best|choose|pick)"
+  tags:
+    - "reasoning"
+    - "planning"
+    - "strategy"
+  max_context_tokens: 2000
+requires:
+  tools: []
+  credentials: []
+  permissions: read-only
+---
+
+# Decision Maker Skill
+
+Guides users through structured decision-making by surfacing tradeoffs, applying relevant frameworks, and delivering a clear, reasoned recommendation.
+
+## Hard rules
+
+- This skill is **read-only** — it never places orders, executes trades, or moves funds
+- Never expose API keys, wallet addresses, or private credentials in any output
+- All data is for **informational purposes only** — not financial advice
+- Always state data freshness — never present stale data as current
+- Do not store or log any user portfolio or financial data
+- If asked to execute a trade or place an order, refuse and redirect to a human decision
+- Dry-run/read-only behavior by default — no side effects
+
+## When to Use
+
+- User is choosing between two or more options
+- User asks "what should I do" or "which is better"
+- User wants pros/cons analysis
+- User is stuck or overwhelmed by a decision
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Clarify before deciding** — understand the user's goals, constraints, and values before analyzing
+2. **Structure the comparison** — use a consistent framework so options are evaluated fairly
+3. **Make a recommendation** — don't just list pros/cons; commit to a reasoned suggestion
+4. **Separate facts from preferences** — distinguish objective tradeoffs from subjective fit
+
+### Decision Frameworks
+
+**For simple binary choices**: Pros/Cons list + weighted score
+
+**For complex multi-option decisions**: Decision matrix
+- List options as columns
+- List criteria as rows (weighted by importance)
+- Score each option per criterion
+- Calculate weighted totals
+
+**For high-stakes/irreversible decisions**: Pre-mortem
+- Imagine each option failed — what went wrong?
+- Use this to stress-test the leading option
+
+**For values-based decisions**: Values alignment check
+- What does the user care most about?
+- Which option best honors those values?
+
+### Recommendation Structure
+
+1. Restate the decision and key constraints
+2. Present the comparison (table or bullets)
+3. State the recommendation clearly: "I recommend **Option A** because..."
+4. Acknowledge the main risk of your recommendation
+5. Offer a contingency: "If X changes, reconsider Option B"
+
+### Mistakes to Avoid
+
+- Don't give a wishy-washy answer — users want a recommendation, not a list
+- Don't ignore stated constraints (budget, timeline, values)
+- Don't present all options as equal if they clearly aren't
+
+## Guidelines
+
+- Always ask: What matters most to you in this decision? (if not stated)
+- Use a comparison table for 3+ options
+- End with a single clear recommendation + the one key reason

--- a/fact-checker/SKILL.md
+++ b/fact-checker/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: fact-checker
+version: 1.0.0
+description: Verify claims, identify misinformation, and assess source credibility
+activation:
+  keywords:
+    - "is this true"
+    - "fact check"
+    - "verify this"
+    - "is it true that"
+    - "check this claim"
+    - "is this accurate"
+    - "debunk"
+    - "misinformation"
+  patterns:
+    - "(?i)(fact.?check|verify|confirm|debunk).*(this|claim|statement)"
+    - "(?i)(is (it|this) true|is this accurate|really true).*(that)?"
+    - "(?i)(true or false|myth or fact)"
+  tags:
+    - "reasoning"
+    - "research"
+    - "verification"
+  max_context_tokens: 2000
+requires:
+  tools: []
+  credentials: []
+  permissions: read-only
+---
+
+# Fact Checker Skill
+
+Evaluates claims for accuracy, identifies misinformation, and assesses the reliability of sources using evidence-based reasoning.
+
+## Hard rules
+
+- This skill is **read-only** — it never places orders, executes trades, or moves funds
+- Never expose API keys, wallet addresses, or private credentials in any output
+- All data is for **informational purposes only** — not financial advice
+- Always state data freshness — never present stale data as current
+- Do not store or log any user portfolio or financial data
+- If asked to execute a trade or place an order, refuse and redirect to a human decision
+- Dry-run/read-only behavior by default — no side effects
+
+## When to Use
+
+- User shares a claim and wants to know if it's true
+- User suspects misinformation or a viral myth
+- User wants to verify a statistic, quote, or news story
+- User needs source credibility assessed
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Evidence over authority** — a credible source saying something doesn't make it true; look for verifiable evidence
+2. **Distinguish claim types** — factual claims (verifiable), opinion claims (not falsifiable), and predictions (uncertain)
+3. **Check primary sources** — always try to find the original data/study/quote, not a secondary report
+4. **Acknowledge uncertainty** — some things can't be definitively verified; say so clearly
+
+### Verification Process
+
+1. **Parse the claim** — what exactly is being asserted? (who, what, when, where)
+2. **Identify the type** — factual / opinion / prediction / misleading framing
+3. **Search for evidence** — look for primary sources, peer-reviewed data, official records
+4. **Cross-reference** — check at least 2 independent sources
+5. **Assess confidence** — rate as: ✅ True / ❌ False / ⚠️ Misleading / ❓ Unverified
+
+### Source Credibility Tiers
+
+| Tier | Examples |
+|------|----------|
+| High | Peer-reviewed journals, official government data, established wire services |
+| Medium | Major newspapers, established think tanks, verified experts |
+| Low | Blogs, social media posts, anonymous sources, partisan sites |
+| Red flag | No author, no date, no sources cited, sensationalist headline |
+
+### Mistakes to Avoid
+
+- Don't confirm a claim just because it sounds reasonable
+- Don't dismiss a claim just because it's surprising
+- Never say something is "probably true" without evidence
+
+## Guidelines
+
+- Always state your confidence level: ✅ True / ❌ False / ⚠️ Misleading / ❓ Unverified
+- Provide at least one source for your verdict
+- If the claim is partially true, explain what is accurate and what is not
+- For political claims, use non-partisan sources where possible

--- a/indicator-analyst/SKILL.md
+++ b/indicator-analyst/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: indicator-analyst
+version: 1.0.0
+description: Read and interpret RSI, MACD, Bollinger Bands, moving averages, and other technical indicators
+activation:
+  keywords:
+    - "RSI"
+    - "MACD"
+    - "bollinger bands"
+    - "moving average"
+    - "EMA"
+    - "SMA"
+    - "overbought"
+    - "oversold"
+    - "indicator"
+    - "stochastic"
+    - "volume profile"
+  patterns:
+    - "(?i)(RSI|MACD|EMA|SMA|stoch|bollinger|VWAP|OBV).*(reading|showing|says|at|level)"
+    - "(?i)(overbought|oversold|divergence|crossover|golden cross|death cross)"
+    - "(?i)(what (does|is) the).*(indicator|RSI|MACD|EMA).*(say|mean|show)"
+  tags:
+    - "trading"
+    - "technical-analysis"
+    - "indicators"
+  max_context_tokens: 2000
+requires:
+  tools: []
+  credentials: []
+  permissions: read-only
+---
+
+# Indicator Analyst Skill
+
+Reads, interprets, and synthesizes technical indicators including RSI, MACD, Bollinger Bands, and moving averages to assess momentum, trend, and potential reversals.
+
+## Hard rules
+
+- This skill is **read-only** — it never places orders, executes trades, or moves funds
+- Never expose API keys, wallet addresses, or private credentials in any output
+- All data is for **informational purposes only** — not financial advice
+- Always state data freshness — never present stale data as current
+- Do not store or log any user portfolio or financial data
+- If asked to execute a trade or place an order, refuse and redirect to a human decision
+- Dry-run/read-only behavior by default — no side effects
+
+## When to Use
+
+- User asks about the reading of a specific indicator
+- User wants to know if an asset is overbought or oversold
+- User asks about indicator crossovers, divergences, or signals
+- User wants multiple indicators synthesized into one view
+
+## Core Knowledge
+
+### Key Principles
+
+1. **No indicator is perfect alone** — always combine at least 2–3 indicators for confluence
+2. **Indicators lag** — they confirm what already happened; use them to validate, not predict alone
+3. **Divergence is powerful** — when price and indicator disagree, the indicator often wins
+4. **Context over signals** — an RSI of 70 in a strong uptrend means less than RSI 70 at major resistance
+
+### Indicator Reference Guide
+
+**RSI (Relative Strength Index)**
+- Range: 0–100
+- >70: Overbought (potential reversal or pullback)
+- <30: Oversold (potential bounce or reversal)
+- 40–60: Neutral zone
+- Bullish divergence: Price makes lower low, RSI makes higher low → reversal signal
+- Bearish divergence: Price makes higher high, RSI makes lower high → reversal signal
+- Best timeframes: 1h, 4h, Daily
+
+**MACD (Moving Average Convergence Divergence)**
+- MACD line crosses above signal line → Bullish momentum
+- MACD line crosses below signal line → Bearish momentum
+- Histogram growing → momentum strengthening
+- Histogram shrinking → momentum weakening
+- Divergence between MACD and price = high-value signal
+
+**Bollinger Bands**
+- Price touching upper band → overbought in current trend
+- Price touching lower band → oversold in current trend
+- Band squeeze (bands narrow) → volatility contraction, big move coming
+- Band expansion → trend is accelerating
+- Price walking the upper band → strong uptrend
+- Price walking the lower band → strong downtrend
+
+**Moving Averages**
+| MA | Use |
+|----|-----|
+| 20 EMA | Short-term trend, dynamic support/resistance |
+| 50 EMA | Medium-term trend |
+| 200 EMA/SMA | Long-term trend, major support/resistance |
+| Golden Cross | 50 MA crosses above 200 MA → long-term bullish |
+| Death Cross | 50 MA crosses below 200 MA → long-term bearish |
+
+**VWAP (Volume Weighted Average Price)**
+- Price above VWAP → bullish bias for the session
+- Price below VWAP → bearish bias
+- Great for intraday entries — buy near VWAP in uptrend
+
+**Stochastic RSI**
+- More sensitive than RSI
+- >80: Overbought | <20: Oversold
+- Best for short timeframes (15m, 1h)
+
+### Confluence Framework
+
+Strong signal = 3+ indicators agree:
+- RSI oversold + MACD bullish cross + price at 200 EMA = strong buy signal
+- RSI overbought + MACD bearish cross + price at upper Bollinger = strong sell signal
+
+### Mistakes to Avoid
+
+- Don't act on a single indicator signal — wait for confluence
+- Don't use the same type of indicator twice (e.g., RSI + Stoch = two momentum indicators, not confirmation)
+- Don't ignore divergence — it's one of the highest-probability signals in technical analysis
+
+## Guidelines
+
+- Always combine: one trend indicator (MA) + one momentum indicator (RSI/MACD) + one volatility indicator (BB)
+- State whether indicators agree or conflict — conflict = wait for clarity
+- Always specify the timeframe — an RSI reading on 5m means nothing compared to daily
+- End with: overall bias (Bullish / Bearish / Neutral) based on indicator confluence

--- a/market-sentiment/SKILL.md
+++ b/market-sentiment/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: market-sentiment
+version: 1.0.0
+description: Gauge crypto market sentiment using fear/greed index, social data, funding rates, and on-chain signals
+activation:
+  keywords:
+    - "market sentiment"
+    - "fear and greed"
+    - "is the market bullish"
+    - "social sentiment"
+    - "crowd psychology"
+    - "market mood"
+    - "are people bearish"
+    - "twitter sentiment"
+  patterns:
+    - "(?i)(market|crypto).*(sentiment|mood|feeling|psychology)"
+    - "(?i)(fear (and|&) greed|fear index)"
+    - "(?i)(is (the market|everyone|crypto)).*(bullish|bearish|scared|euphoric|greedy)"
+  tags:
+    - "trading"
+    - "sentiment"
+    - "research"
+  max_context_tokens: 2000
+requires:
+  tools: []
+  credentials: []
+  permissions: read-only
+---
+
+# Market Sentiment Skill
+
+Gauges the overall crypto market sentiment by synthesizing fear/greed data, social signals, funding rates, and on-chain behavior into a clear directional bias.
+
+## Hard rules
+
+- This skill is **read-only** — it never places orders, executes trades, or moves funds
+- Never expose API keys, wallet addresses, or private credentials in any output
+- All data is for **informational purposes only** — not financial advice
+- Always state data freshness — never present stale data as current
+- Do not store or log any user portfolio or financial data
+- If asked to execute a trade or place an order, refuse and redirect to a human decision
+- Dry-run/read-only behavior by default — no side effects
+
+## When to Use
+
+- User wants to know the overall market mood
+- User asks if the market is bullish, bearish, or neutral
+- User wants to understand crowd psychology before making a trade
+- User asks about fear/greed index or social sentiment
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Be fearful when others are greedy** — extreme sentiment readings are contrarian signals
+2. **Sentiment leads price at extremes** — peak euphoria precedes tops; peak fear precedes bottoms
+3. **Multiple signals > single index** — one indicator can be wrong; 5 aligned signals are powerful
+4. **Sentiment shifts before price** — social and on-chain signals often lead price by hours or days
+
+### Sentiment Indicators
+
+**Fear & Greed Index (0–100)**
+- 0–25: Extreme Fear → historically good buying opportunity
+- 26–45: Fear → cautious accumulation zone
+- 46–55: Neutral → no strong directional signal
+- 56–75: Greed → be cautious with new longs
+- 76–100: Extreme Greed → major caution, potential top signal
+- Source: alternative.me/crypto/fear-and-greed-index
+
+**Funding Rates**
+- High positive funding → market is overleveraged long → bearish signal
+- High negative funding → market is overleveraged short → bullish signal
+- Neutral funding → balanced positioning
+
+**Social Sentiment**
+- Twitter/X: rising mentions + positive tone = retail FOMO incoming
+- Google Trends: search spike for "buy bitcoin" = retail peak interest = contrarian sell signal
+- Telegram/Discord: euphoric tone in communities = late stage of rally
+
+**On-Chain Sentiment Signals**
+- Exchange inflows rising → people moving to sell → bearish
+- Exchange outflows rising → people withdrawing to hold → bullish
+- Long-term holders selling → distribution phase
+- New wallet addresses surging → new retail interest (late signal)
+
+**Options Market**
+- Put/Call ratio >1: more puts than calls → bearish sentiment
+- Put/Call ratio <0.5: more calls than puts → bullish/greedy sentiment
+- Implied volatility spike → fear or uncertainty
+
+### Sentiment Synthesis
+
+Rate each signal: Bullish (+1) / Neutral (0) / Bearish (-1)
+
+Sum the scores:
+- +4 to +5: Strong bullish sentiment
+- +2 to +3: Mild bullish
+- -1 to +1: Neutral/mixed
+- -2 to -3: Mild bearish
+- -4 to -5: Strong bearish (potential contrarian buy)
+
+### Contrarian Rules
+
+- Extreme Greed (>80) + overbought RSI + high funding = reduce longs
+- Extreme Fear (<20) + oversold RSI + negative funding = consider accumulating
+- Never fade sentiment at extremes without price action confirmation
+
+### Mistakes to Avoid
+
+- Don't use sentiment as a standalone trading signal — combine with price action
+- Don't assume high fear = immediate bottom — markets can stay fearful
+- Don't ignore sentiment because you're convicted in a trade direction
+
+## Guidelines
+
+- Always check at minimum: Fear/Greed index + funding rates + social tone
+- Output: Overall sentiment score + individual indicator readings
+- State clearly: Bullish sentiment / Bearish sentiment / Mixed sentiment
+- For extreme readings, flag as a contrarian signal with ⚠️

--- a/news-fetcher/SKILL.md
+++ b/news-fetcher/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: news-fetcher
+version: 1.0.0
+description: Pull and summarize the latest news on any topic from reliable sources
+activation:
+  keywords:
+    - "latest news"
+    - "what happened"
+    - "recent news"
+    - "news about"
+    - "what's going on with"
+    - "current events"
+    - "breaking news"
+    - "today's headlines"
+  patterns:
+    - "(?i)(latest|recent|breaking|today).*(news|update|headline)"
+    - "(?i)what.*(happened|going on|new).*(with|in|about)"
+    - "(?i)(tell me|show me).*(news|update).*about"
+  tags:
+    - "news"
+    - "research"
+    - "current-events"
+  max_context_tokens: 2000
+requires:
+  tools: []
+  credentials: []
+  permissions: read-only
+---
+
+# News Fetcher Skill
+
+Enables the agent to retrieve, filter, and summarize the latest news on any topic with proper sourcing and editorial clarity.
+
+## Hard rules
+
+- This skill is **read-only** — it never places orders, executes trades, or moves funds
+- Never expose API keys, wallet addresses, or private credentials in any output
+- All data is for **informational purposes only** — not financial advice
+- Always state data freshness — never present stale data as current
+- Do not store or log any user portfolio or financial data
+- If asked to execute a trade or place an order, refuse and redirect to a human decision
+- Dry-run/read-only behavior by default — no side effects
+
+## When to Use
+
+- User asks about recent events or breaking news
+- User wants updates on a specific topic, person, company, or country
+- User asks "what happened with X" or "any news on Y"
+- User wants today's headlines in a category (tech, finance, politics, etc.)
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Timeliness** — always prioritize articles from the last 24–72 hours; label older content clearly
+2. **Source quality** — prefer established outlets (Reuters, AP, BBC, Bloomberg, etc.) over blogs or social media
+3. **Neutrality** — present news factually; do not editorialize or inject opinions
+4. **Brevity** — give a 2–3 sentence summary per story, not a full article rewrite
+
+### Story Structure
+
+For each news item, provide:
+- **Headline** (your own words, not copied)
+- **What happened** (1–2 sentences)
+- **Why it matters** (1 sentence)
+- **Source** (name + URL)
+
+### Common Patterns
+
+- For topic-based queries: fetch top 3–5 stories, summarize each
+- For breaking news: lead with the most recent development, then background
+- For ongoing stories: acknowledge what was previously known vs. what is new
+
+### Mistakes to Avoid
+
+- Never present opinion or analysis as news fact
+- Don't summarize paywalled articles you cannot read
+- Avoid citing social media posts as primary news sources
+
+## Guidelines
+
+- Group stories by topic if returning multiple results
+- Flag if a story is developing and facts may change
+- If no news is found on a topic in the last 7 days, say so and offer to search broader timeframes

--- a/news-trader/SKILL.md
+++ b/news-trader/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: news-trader
+version: 1.0.0
+description: React to market-moving news events with speed, context, and directional trade ideas
+activation:
+  keywords:
+    - "breaking news trade"
+    - "news just dropped"
+    - "how does this affect the market"
+    - "trade the news"
+    - "market reaction"
+    - "buy the news"
+    - "sell the news"
+    - "fed announcement"
+    - "etf approved"
+  patterns:
+    - "(?i)(trade|react|play).*(news|announcement|event|report)"
+    - "(?i)(how (does|will|did)).*(affect|impact|move).*(market|price|crypto)"
+    - "(?i)(buy|sell).*(news|rumor|announcement)"
+  tags:
+    - "trading"
+    - "news"
+    - "execution"
+  max_context_tokens: 2000
+requires:
+  tools: []
+  credentials: []
+  permissions: read-only
+---
+
+# News Trader Skill
+
+Processes breaking market news quickly, assesses its directional impact, and translates it into actionable trade ideas with defined risk.
+
+## Hard rules
+
+- This skill is **read-only** — it never places orders, executes trades, or moves funds
+- Never expose API keys, wallet addresses, or private credentials in any output
+- All data is for **informational purposes only** — not financial advice
+- Always state data freshness — never present stale data as current
+- Do not store or log any user portfolio or financial data
+- If asked to execute a trade or place an order, refuse and redirect to a human decision
+- Dry-run/read-only behavior by default — no side effects
+
+## When to Use
+
+- Breaking news just dropped and user wants to know how to trade it
+- User asks how a specific news event affects market price
+- User wants to know if a news event is already priced in
+- User wants to understand "buy the rumor, sell the news" dynamics
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Speed is the edge** — news trading requires fast processing; first movers capture the move
+2. **Is it priced in?** — always ask if the market already expected this news before trading it
+3. **Buy the rumor, sell the news** — anticipated good news often causes selling after confirmation
+4. **Magnitude matters** — not all news moves markets equally; assess the surprise factor
+
+### News Impact Assessment Framework
+
+**Step 1: Classify the news**
+- Scheduled (Fed meeting, CPI report, earnings) → market was positioned for this
+- Unscheduled/surprise → higher impact, faster move, more opportunity
+
+**Step 2: Assess the surprise factor**
+- Was this expected? → Lower impact (already priced in)
+- Was this a surprise? → Higher impact (not priced in = bigger move)
+- Worse/better than expected by how much? → Determines direction and magnitude
+
+**Step 3: Determine directional bias**
+
+| News Type | Typical Market Reaction |
+|-----------|------------------------|
+| ETF approved (crypto) | Spike up → potential sell the news after |
+| Hack/exploit | Sharp drop → potential bounce after panic |
+| Regulatory crackdown | Sell-off → assess severity before buying dip |
+| Fed rate cut | Risk-on rally → crypto benefits |
+| Fed rate hike (surprise) | Risk-off selloff → crypto drops |
+| Major partnership announced | Pump → assess if substance or hype |
+| Exchange insolvency | Panic drop → major contagion risk |
+
+**Step 4: Trade the reaction, not just the news**
+- Watch the first 5–15 minutes of price reaction
+- Is the market buying or selling the news?
+- Trade with the reaction once direction is confirmed
+
+### "Buy the Rumor, Sell the News" Pattern
+
+1. News is expected/leaked in advance → price pumps on anticipation
+2. News is confirmed officially → initial spike
+3. Price reverses and sells off as buyers exit
+4. Pattern: fade the confirmation spike with a short
+
+### Risk Management for News Trades
+
+- Use smaller size than normal — news creates volatile wicks
+- Wider stop losses — initial moves are often exaggerated
+- Set a time stop — if trade doesn't work in 30 minutes, exit
+- Never hold through unscheduled high-impact news in a position
+
+### Key News Sources for Speed
+
+| Source | Type |
+|--------|------|
+| CoinDesk / The Block | Crypto news |
+| Reuters / Bloomberg Terminal | Macro news |
+| Twitter/X (verified accounts) | Breaking first |
+| Polymarket | Crowd-based probability of news outcomes |
+| Unusual Whales | Options flow before news |
+
+### Mistakes to Avoid
+
+- Don't trade the headline — read the full story before entering
+- Don't chase a 10% move that's already happened — the edge is gone
+- Don't ignore the broader trend — bad news in a strong uptrend often gets bought
+
+## Guidelines
+
+- When user shares news, immediately assess: Scheduled or surprise? Bullish or bearish? Priced in or not?
+- Give a directional bias with a specific entry trigger (e.g., "wait for retest of $X before entering")
+- Always include a stop loss level for news trades — they can reverse violently
+- Flag "buy the rumor sell the news" risk whenever news was anticipated

--- a/planner/SKILL.md
+++ b/planner/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: planner
+version: 1.0.0
+description: Break down goals into actionable, sequenced plans with milestones and timelines
+activation:
+  keywords:
+    - "make a plan"
+    - "plan for"
+    - "roadmap"
+    - "how do I achieve"
+    - "step by step"
+    - "help me plan"
+    - "action plan"
+    - "project plan"
+    - "what steps"
+  patterns:
+    - "(?i)(make|create|build|give me).*(plan|roadmap|strategy|steps)"
+    - "(?i)(how (do|can) I).*(achieve|accomplish|start|build|launch)"
+    - "(?i)(step.?by.?step|action items|milestones|timeline)"
+  tags:
+    - "reasoning"
+    - "planning"
+    - "productivity"
+  max_context_tokens: 2000
+requires:
+  tools: []
+  credentials: []
+  permissions: read-only
+---
+
+# Planner Skill
+
+Converts goals into structured, sequenced action plans with clear phases, milestones, and timelines.
+
+## Hard rules
+
+- This skill is **read-only** — it never places orders, executes trades, or moves funds
+- Never expose API keys, wallet addresses, or private credentials in any output
+- All data is for **informational purposes only** — not financial advice
+- Always state data freshness — never present stale data as current
+- Do not store or log any user portfolio or financial data
+- If asked to execute a trade or place an order, refuse and redirect to a human decision
+- Dry-run/read-only behavior by default — no side effects
+
+## When to Use
+
+- User has a goal and needs a roadmap to achieve it
+- User asks "how do I start" or "what steps should I take"
+- User needs a project plan, launch plan, or learning plan
+- User has a vague intention and needs it structured
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Start with the end** — clarify the goal, success criteria, and deadline before planning steps
+2. **Phase it** — group steps into logical phases (Foundation → Build → Launch → Scale)
+3. **Be specific** — each action item must be concrete and doable, not abstract
+4. **Sequence matters** — order steps by dependency; don't put step 4 before step 2
+
+### Plan Structure
+
+```
+GOAL: [Clear one-sentence goal]
+TIMELINE: [Total timeframe]
+SUCCESS LOOKS LIKE: [How we know it's done]
+
+PHASE 1: [Name] — [Timeframe]
+  ✅ Action 1 (owner, tool, output)
+  ✅ Action 2
+  ✅ Action 3
+
+PHASE 2: [Name] — [Timeframe]
+  ...
+
+MILESTONES:
+  Week 1: [Deliverable]
+  Week 2: [Deliverable]
+```
+
+### Planning Patterns
+
+- **Learning plan**: Assess → Foundations → Practice → Projects → Review
+- **Product launch**: Research → Build → Test → Launch → Iterate
+- **Business plan**: Validate → Structure → Build → Acquire → Scale
+- **Personal goal**: Assess current state → Set targets → Build habits → Track → Adjust
+
+### Mistakes to Avoid
+
+- Don't create a plan without knowing the deadline and available resources
+- Don't make steps too vague ("work on marketing") — be specific ("write 3 LinkedIn posts per week")
+- Don't skip dependencies — if step B requires step A, say so
+
+## Guidelines
+
+- Always ask: What's the timeline? What resources do you have? What's already done?
+- Use phases + milestones for plans longer than 2 weeks
+- For short plans (<1 week), a numbered checklist is enough
+- Offer to break down any single phase into more detail on request

--- a/summarizer/SKILL.md
+++ b/summarizer/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: summarizer
+version: 1.0.0
+description: Condense long documents, articles, conversations, or content into clear, structured key points
+activation:
+  keywords:
+    - "summarize"
+    - "tldr"
+    - "tl;dr"
+    - "key points"
+    - "condense this"
+    - "shorten this"
+    - "main points"
+    - "give me a summary"
+    - "what does this say"
+  patterns:
+    - "(?i)(summarize|condense|shorten|compress).*(this|text|article|document|content)"
+    - "(?i)(key|main|important).*(points|takeaways|ideas)"
+    - "(?i)tl;?dr"
+  tags:
+    - "communication"
+    - "writing"
+    - "productivity"
+  max_context_tokens: 2000
+requires:
+  tools: []
+  credentials: []
+  permissions: read-only
+---
+
+# Summarizer Skill
+
+Condenses any length of content — articles, documents, conversations, reports — into structured, scannable summaries without losing meaning.
+
+## Hard rules
+
+- This skill is **read-only** — it never places orders, executes trades, or moves funds
+- Never expose API keys, wallet addresses, or private credentials in any output
+- All data is for **informational purposes only** — not financial advice
+- Always state data freshness — never present stale data as current
+- Do not store or log any user portfolio or financial data
+- If asked to execute a trade or place an order, refuse and redirect to a human decision
+- Dry-run/read-only behavior by default — no side effects
+
+## When to Use
+
+- User pastes a long article, document, or text and wants it shortened
+- User asks for "key points", "main ideas", or a "TL;DR"
+- User shares a conversation or thread and wants a digest
+- User needs an executive summary of a report
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Preserve intent** — the summary must reflect the original meaning; never distort or editorialize
+2. **Layer by detail** — offer a 1-sentence gist, then bullet points, then detail if needed
+3. **Cut ruthlessly** — remove examples, filler, repetition; keep only the essential claims
+4. **Structure for scanning** — use bullets and headers so users can read in 30 seconds
+
+### Summary Formats
+
+Choose format based on content type:
+
+| Content Type | Best Format |
+|-------------|-------------|
+| Article/Blog | TL;DR + 3–5 bullets |
+| Report/Doc | Executive summary + section headers |
+| Conversation | Who said what + key decisions |
+| Code/Technical | What it does + key functions |
+| Legal/Contract | Key obligations + red flags |
+
+### Compression Levels
+
+- **Brief**: 1–3 sentences, pure gist
+- **Standard**: TL;DR + 5 bullet points
+- **Detailed**: Section-by-section breakdown with key quotes
+
+### Mistakes to Avoid
+
+- Don't include the agent's opinion in the summary
+- Never cut information that changes the meaning
+- Don't just copy-paste sentences — genuinely rephrase
+
+## Guidelines
+
+- Default to Standard format unless user specifies
+- If the content is very long (>2000 words), ask which section to prioritize
+- Always end with: "Want me to go deeper on any section?"

--- a/translator/SKILL.md
+++ b/translator/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: translator
+version: 1.0.0
+description: Translate text between languages with tone and context preservation
+activation:
+  keywords:
+    - "translate"
+    - "in spanish"
+    - "in french"
+    - "in arabic"
+    - "convert to"
+    - "what does this mean in"
+    - "how do you say"
+    - "translate this to"
+  patterns:
+    - "(?i)(translate|convert).*(to|into|from).*(english|spanish|french|arabic|portuguese|german|chinese|japanese|yoruba|igbo|hausa)"
+    - "(?i)how (do you|would you) say.*(in)"
+    - "(?i)what (does|is) this.*(mean|say).*(in)"
+  tags:
+    - "communication"
+    - "language"
+    - "translation"
+  max_context_tokens: 2000
+requires:
+  tools: []
+  credentials: []
+  permissions: read-only
+---
+
+# Translator Skill
+
+Translates text between any languages while preserving tone, context, and nuance — not just literal word-for-word conversion.
+
+## Hard rules
+
+- This skill is **read-only** — it never places orders, executes trades, or moves funds
+- Never expose API keys, wallet addresses, or private credentials in any output
+- All data is for **informational purposes only** — not financial advice
+- Always state data freshness — never present stale data as current
+- Do not store or log any user portfolio or financial data
+- If asked to execute a trade or place an order, refuse and redirect to a human decision
+- Dry-run/read-only behavior by default — no side effects
+
+## When to Use
+
+- User asks to translate any text, phrase, or document
+- User wants to know how to say something in another language
+- User pastes foreign text and wants to understand it
+- User needs a culturally appropriate translation (not just literal)
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Context over literalism** — translate meaning and intent, not word-for-word; idiomatic expressions need cultural equivalents
+2. **Preserve tone** — a formal document should remain formal; a casual message should remain casual
+3. **Flag ambiguity** — if a phrase has multiple valid translations, present options with explanations
+4. **Respect dialects** — Spanish (Mexico) ≠ Spanish (Spain); French (France) ≠ French (Canada); ask when it matters
+
+### Translation Process
+
+1. Identify source language (if not stated)
+2. Identify target language
+3. Assess tone and register (formal/informal/technical)
+4. Translate with cultural adaptation
+5. Flag any phrases that don't translate directly
+
+### Language Support Priority
+
+Handle with high accuracy:
+- English, Spanish, French, Portuguese, Arabic, German, Chinese, Japanese, Yoruba, Igbo, Hausa, Swahili
+
+### Mistakes to Avoid
+
+- Never do literal word-for-word for idioms — always find the cultural equivalent
+- Don't assume dialect — ask if the target audience matters
+- Don't skip back-translation for important documents
+
+## Guidelines
+
+- For long documents, translate section by section
+- Always show: Original → Translation (and note the source language if auto-detected)
+- For Nigerian languages (Yoruba, Igbo, Hausa), acknowledge if confidence is lower and recommend human review for critical content

--- a/trend-detector/SKILL.md
+++ b/trend-detector/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: trend-detector
+version: 1.0.0
+description: Identify bull/bear trends, breakouts, reversals, and market structure shifts across timeframes
+activation:
+  keywords:
+    - "is this bullish"
+    - "is this bearish"
+    - "trend analysis"
+    - "market structure"
+    - "breakout"
+    - "reversal"
+    - "uptrend"
+    - "downtrend"
+    - "trend change"
+    - "higher highs"
+    - "lower lows"
+  patterns:
+    - "(?i)(is (this|it)|are we).*(bullish|bearish|trending|reversing)"
+    - "(?i)(breakout|breakdown|reversal|trend change|structure break)"
+    - "(?i)(uptrend|downtrend|sideways|consolidation|range)"
+  tags:
+    - "trading"
+    - "technical-analysis"
+    - "trend"
+  max_context_tokens: 2000
+requires:
+  tools: []
+  credentials: []
+  permissions: read-only
+---
+
+# Trend Detector Skill
+
+Identifies the prevailing trend direction, detects breakouts and reversals, and determines market structure shifts across multiple timeframes.
+
+## Hard rules
+
+- This skill is **read-only** — it never places orders, executes trades, or moves funds
+- Never expose API keys, wallet addresses, or private credentials in any output
+- All data is for **informational purposes only** — not financial advice
+- Always state data freshness — never present stale data as current
+- Do not store or log any user portfolio or financial data
+- If asked to execute a trade or place an order, refuse and redirect to a human decision
+- Dry-run/read-only behavior by default — no side effects
+
+## When to Use
+
+- User wants to know if a market is in an uptrend or downtrend
+- User asks if a breakout or reversal is happening
+- User wants to know if the trend is still intact or changing
+- User wants multi-timeframe trend analysis
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Trend is your edge** — trading with the trend dramatically improves win rate
+2. **Higher timeframe > lower timeframe** — daily trend overrides hourly; always check top-down
+3. **Structure defines trend** — higher highs + higher lows = uptrend; lower highs + lower lows = downtrend
+4. **Break of structure (BOS) = trend change** — when price breaks a key swing low in an uptrend, the trend may be changing
+
+### Trend Identification Framework
+
+**Step 1: Top-down analysis**
+- Start with the Weekly or Daily chart → defines the macro trend
+- Then 4h → defines the intermediate trend
+- Then 1h/15m → defines the entry-level trend
+
+**Step 2: Define market structure**
+- Mark swing highs and swing lows
+- Uptrend: each swing high and low is higher than the last
+- Downtrend: each swing high and low is lower than the last
+- Range/Consolidation: highs and lows are roughly equal
+
+**Step 3: Identify the trend phase**
+
+| Phase | Characteristics |
+|-------|----------------|
+| Accumulation | Low volatility, sideways, smart money buying |
+| Markup (uptrend) | Higher highs, higher lows, increasing volume |
+| Distribution | Low volatility at highs, smart money selling |
+| Markdown (downtrend) | Lower highs, lower lows, declining bounces |
+
+### Breakout Detection
+
+A valid breakout requires:
+- Price closes ABOVE resistance (not just wicks through)
+- Volume is significantly higher than average on the breakout candle
+- Price retests the broken level and holds (retest = confirmation)
+
+A fake breakout (fakeout) shows:
+- Price breaks level but closes back below
+- Low volume on the break
+- Quick reversal after the break
+
+### Reversal Signals
+
+**Early reversal signals:**
+- Break of market structure (BOS) — first lower high in an uptrend
+- Bearish/bullish divergence on RSI or MACD
+- Shooting star or hammer at key level with volume
+- Failed breakout attempt
+
+**Confirmed reversal:**
+- Lower high AND lower low established (uptrend to downtrend)
+- Price breaks below key moving average (200 EMA) on high volume
+- Multiple timeframes align in new direction
+
+### Multi-Timeframe Confluence
+
+| Timeframe | Trend | Action |
+|-----------|-------|--------|
+| Daily: Up | 4h: Up | 1h: Up | Strong buy |
+| Daily: Up | 4h: Up | 1h: Down | Wait for 1h to flip |
+| Daily: Up | 4h: Down | 1h: Down | Don't buy, potential reversal |
+| Daily: Down | 4h: Down | 1h: Down | Strong sell/short |
+
+### Mistakes to Avoid
+
+- Don't call a trend change from a single timeframe
+- Don't confuse a pullback in an uptrend with a reversal
+- Don't trade against the higher timeframe trend without strong reason
+
+## Guidelines
+
+- Always analyze at least 2 timeframes before calling a trend
+- State clearly: Macro trend (daily) / Intermediate trend (4h) / Short-term trend (1h)
+- Flag if timeframes are conflicting — that means wait, not trade
+- Identify the nearest key level that would invalidate the current trend

--- a/web-search/SKILL.md
+++ b/web-search/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: web-search
+version: 1.0.0
+description: Search the web and return summarized, sourced answers to user queries
+activation:
+  keywords:
+    - "search for"
+    - "look up"
+    - "find information about"
+    - "what is the latest on"
+    - "google"
+    - "search the web"
+    - "find online"
+  patterns:
+    - "(?i)(search|look up|find|google).*online"
+    - "(?i)what.*latest.*on"
+    - "(?i)current(ly)?.*information.*about"
+  tags:
+    - "research"
+    - "web"
+    - "data"
+  max_context_tokens: 2000
+requires:
+  tools: []
+  credentials: []
+  permissions: read-only
+---
+
+# Web Search Skill
+
+Enables the agent to search the web and return accurate, summarized, well-sourced answers to user queries in real time.
+
+## Hard rules
+
+- This skill is **read-only** — it never places orders, executes trades, or moves funds
+- Never expose API keys, wallet addresses, or private credentials in any output
+- All data is for **informational purposes only** — not financial advice
+- Always state data freshness — never present stale data as current
+- Do not store or log any user portfolio or financial data
+- If asked to execute a trade or place an order, refuse and redirect to a human decision
+- Dry-run/read-only behavior by default — no side effects
+
+## When to Use
+
+- User asks for current or recent information
+- User explicitly says "search", "look up", "google", or "find online"
+- The topic requires up-to-date data (news, prices, events, people)
+- Internal knowledge may be outdated or insufficient
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Recency first** — always prefer the most recent, authoritative sources; flag if results are older than 6 months
+2. **Summarize, don't dump** — extract the key insight from results; do not paste raw search output
+3. **Cite your sources** — always include the source name and URL for every major claim
+4. **Acknowledge uncertainty** — if results are conflicting or sparse, say so explicitly
+
+### Search Strategy
+
+- Break complex queries into 2–3 focused sub-queries
+- Prefer official sites, reputable news outlets, and peer-reviewed sources
+- Cross-reference at least 2 sources before presenting a fact as confirmed
+- For ambiguous queries, clarify intent before searching
+
+### Mistakes to Avoid
+
+- Never fabricate URLs or source names — only cite real results
+- Don't present a single source as consensus
+- Avoid summarizing opinion pieces as facts
+
+## Guidelines
+
+- Always end with: "Sources: [name](url)" for each reference used
+- If search returns no useful results, tell the user clearly and suggest alternative queries
+- Keep summaries under 200 words unless the user asks for detail


### PR DESCRIPTION
## Summary
Adds 14 read-only informational skills for the IronClaw agent runtime. Skills cover crypto market sentiment, chart reading, technical indicators, trend detection, web search, crypto price tracking, news fetching, summarization, translation, fact checking, alpha hunting, news trading signals, decision making, and planning. All skills are read-only with no order placement, no credentials, and no side effects.

## Closes
Closes #173

## Type
- [ ] Use case
- [ ] New tool
- [x] New skill
- [ ] Bug fix
- [ ] Documentation / process
- [ ] Infrastructure

## Artifact checklist

Skill PRs:
- [x] Adds or updates `skills/<skill-name>/SKILL.md`
- [x] Documents required tool dependencies
- [x] Includes activation behavior in `SKILL.md`
- [x] Tests at least one prompt that should activate the skill

## Testing
Prompts tested and activation behavior:

- "What is the current crypto market sentiment?" → activates market-sentiment
- "Read this chart and tell me if it's bullish" → activates chart-reader
- "What does the RSI say?" → activates indicator-analyst
- "Is this an uptrend or downtrend?" → activates trend-detector
- "Search the web for latest NEAR news" → activates web-search
- "What is the price of ETH?" → activates crypto-tracker
- "What's the latest news on Bitcoin?" → activates news-fetcher
- "Summarize this article" → activates summarizer
- "Translate this to Spanish" → activates translator
- "Is this claim true?" → activates fact-checker
- "What are whales doing on-chain?" → activates alpha-hunter
- "How does this news affect the market?" → activates news-trader
- "Help me decide between two options" → activates decision-maker
- "Make me a plan to achieve this goal" → activates planner

All 14 skills tested locally on IronClaw agent runtime via Telegram channel.