### PR TITLE
feat(skill): add 11 planning-only trading skills pack #175

### DIFF
--- a/dca-strategist/SKILL.md
+++ b/dca-strategist/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: dca-strategist
+version: 1.0.0
+description: Build dollar cost averaging plans for long-term crypto accumulation with schedule and sizing optimization
+activation:
+  keywords:
+    - "DCA"
+    - "dollar cost average"
+    - "accumulate"
+    - "buy regularly"
+    - "long term buying"
+    - "weekly buy"
+    - "monthly buy"
+    - "stack sats"
+    - "accumulation plan"
+  patterns:
+    - "(?i)(DCA|dollar.?cost.?averag).*(plan|strategy|into|bitcoin|eth)"
+    - "(?i)(accumulate|stack|build position).*(slowly|over time|long term)"
+    - "(?i)(buy|invest).*(weekly|monthly|every|regularly).*(bitcoin|eth|crypto)"
+  tags:
+    - "trading"
+    - "strategy"
+    - "long-term"
+  max_context_tokens: 2000
+requires:
+  tools: []
+  credentials: []
+  permissions: read-only
+---
+
+# DCA Strategist Skill
+
+Designs disciplined dollar cost averaging plans for long-term crypto accumulation — optimizing schedule, sizing, and asset selection for consistent wealth building.
+
+## Hard rules
+
+- This skill is **planning-only** — it never places, submits, or executes orders of any kind
+- All output is a plan or analysis for the user to review and act on manually
+- Never request, store, or reference wallet private keys or API credentials
+- Always require explicit user confirmation before any financial action is taken
+- Position sizes and risk calculations are suggestions only — not instructions to trade
+- Never connect to or call any exchange, wallet, or trading API
+- Dry-run behavior by default — no side effects of any kind
+- Always include: "This is not financial advice. Verify with a licensed advisor."
+- If asked to execute a trade or place an order, refuse and present the plan only
+
+
+## When to Use
+
+- User wants a long-term accumulation strategy
+- User asks how to DCA into Bitcoin, ETH, or other assets
+- User wants to invest regularly without timing the market
+- User wants to optimize their existing DCA strategy
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Time in market > timing the market** — consistent buying over time beats trying to pick bottoms
+2. **Automate to remove emotion** — set the plan and execute mechanically; don't let fear stop a buy
+3. **DCA is not passive — optimize it** — value averaging and bear market acceleration improve returns
+4. **Asset selection matters most** — DCA into a dying asset doesn't work; choose wisely
+
+### DCA Strategy Types
+
+**Standard DCA (simplest)**
+- Buy a fixed dollar amount on a fixed schedule (weekly/monthly)
+- No market timing, fully automated
+- Best for: beginners, busy investors, pure long-term holders
+
+**Value Averaging DCA (smarter)**
+- Set a target portfolio value growth per period (e.g., +$500/month)
+- Buy MORE when price is down (to hit the target), buy LESS when price is up
+- Result: automatically buys more in bear markets, less in bull markets
+- Best for: investors who can vary their monthly investment
+
+**Bear Market Acceleration**
+- Standard DCA baseline every month
+- Additional buy when asset drops >20% from recent high
+- Additional buy when asset drops >40% from recent high
+- Best for: investors with cash reserves watching for dips
+
+### DCA Plan Template
+
+```
+ASSET: [BTC / ETH / Other]
+TOTAL MONTHLY BUDGET: $[Amount]
+STRATEGY: Standard / Value Averaging / Accelerated
+
+SCHEDULE:
+  Weekly: $[Amount] every [Day] — [Platform]
+  Monthly: $[Amount] on [Date] — [Platform]
+
+DIP ACCELERATION:
+  -20% from ATH: Buy extra $[Amount]
+  -40% from ATH: Buy extra $[Amount]
+  -60% from ATH: Buy extra $[Amount] (maximum conviction)
+
+REBALANCING:
+  Frequency: [Quarterly/Annually]
+  Rule: If any asset >X% of portfolio, trim back to target
+
+STOP BUYING IF:
+  [Fundamental thesis broken] — define what would make you stop
+```
+
+### Asset Allocation for DCA
+
+**Conservative long-term**
+- 70% BTC, 30% ETH
+
+**Moderate long-term**
+- 50% BTC, 30% ETH, 20% select altcoins
+
+**Aggressive long-term**
+- 40% BTC, 30% ETH, 30% high-conviction altcoins
+
+**NEAR ecosystem focus**
+- 40% BTC, 30% ETH, 30% NEAR/ecosystem tokens
+
+### DCA Platforms
+
+| Platform | Type | Notes |
+|----------|------|-------|
+| Coinbase | CEX | Auto-buy feature built in |
+| Swan Bitcoin | BTC only | Best for BTC-only DCA |
+| Binance | CEX | Recurring buy available |
+| Strike | BTC only | Low fees, lightning network |
+| DeFi (self-custody) | Manual | More control, more effort |
+
+### Mistakes to Avoid
+
+- Don't pause DCA during bear markets — that's when it matters most
+- Don't DCA into assets with broken fundamentals
+- Don't forget to account for fees — frequent small buys can have high fee impact
+- Don't DCA without a thesis — know WHY you're accumulating this asset
+
+## Guidelines
+
+- Always ask: budget, timeframe, risk tolerance, and target assets
+- Output a specific weekly/monthly schedule with dollar amounts
+- Include a dip-buying acceleration rule in every plan
+- Remind user: DCA is a marathon — measure success in years, not weeks

--- a/defi-navigator/SKILL.md
+++ b/defi-navigator/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: defi-navigator
+version: 1.0.0
+description: Guide users through DeFi protocols, yield strategies, liquidity pools, and on-chain finance
+activation:
+  keywords:
+    - "defi"
+    - "yield farming"
+    - "liquidity pool"
+    - "staking"
+    - "lending protocol"
+    - "aave"
+    - "uniswap"
+    - "ref finance"
+    - "APY"
+    - "APR"
+    - "impermanent loss"
+    - "smart contract finance"
+  patterns:
+    - "(?i)(defi|yield|liquidity|staking|lending|borrowing).*(protocol|pool|farm|strategy)"
+    - "(?i)(aave|uniswap|compound|curve|ref.?finance|burrow)"
+    - "(?i)(impermanent loss|APY|APR|TVL|liquidation)"
+  tags:
+    - "finance"
+    - "defi"
+    - "crypto"
+  max_context_tokens: 2000
+requires:
+  tools: []
+  credentials: []
+  permissions: read-only
+---
+
+# DeFi Navigator Skill
+
+Guides users through decentralized finance protocols, yield strategies, risk management, and on-chain financial tools.
+
+## Hard rules
+
+- This skill is **planning-only** — it never places, submits, or executes orders of any kind
+- All output is a plan or analysis for the user to review and act on manually
+- Never request, store, or reference wallet private keys or API credentials
+- Always require explicit user confirmation before any financial action is taken
+- Position sizes and risk calculations are suggestions only — not instructions to trade
+- Never connect to or call any exchange, wallet, or trading API
+- Dry-run behavior by default — no side effects of any kind
+- Always include: "This is not financial advice. Verify with a licensed advisor."
+- If asked to execute a trade or place an order, refuse and present the plan only
+
+
+## When to Use
+
+- User asks about DeFi protocols (Aave, Uniswap, Ref Finance, etc.)
+- User wants to understand yield farming, staking, or liquidity providing
+- User asks about APY, impermanent loss, or TVL
+- User wants to know how to earn yield on their crypto
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Risk is always present** — DeFi has smart contract risk, liquidation risk, and impermanent loss; always surface relevant risks
+2. **APY is not guaranteed** — yield rates fluctuate; never present APY as fixed income
+3. **Protocol maturity matters** — older, audited protocols with high TVL are generally safer than new ones
+4. **Gas and fees count** — always factor transaction costs into yield calculations
+
+### DeFi Concepts Explained
+
+**Liquidity Pool (LP)**: Provide two tokens to a pool, earn trading fees. Risk: impermanent loss if token ratio shifts.
+
+**Yield Farming**: Stake LP tokens to earn additional token rewards on top of fees.
+
+**Lending/Borrowing**: Deposit assets to earn interest (lending) or deposit collateral to borrow (borrowing). Risk: liquidation if collateral value drops.
+
+**Staking**: Lock tokens to secure a network or earn protocol rewards. Usually lower risk than LP.
+
+**Impermanent Loss**: When you provide liquidity, price divergence between your two tokens can result in less value than simply holding them.
+
+### Key Protocols by Chain
+
+| Chain | Protocol | Type |
+|-------|----------|------|
+| Ethereum | Aave, Uniswap, Compound | Lending, DEX |
+| NEAR | Ref Finance, Burrow | DEX, Lending |
+| Multi-chain | Curve, Convex | Stablecoin yield |
+
+### Risk Assessment Framework
+
+- **Low risk**: Stablecoin staking, blue-chip protocol lending
+- **Medium risk**: LP in major pairs (ETH/USDC), established protocol farming
+- **High risk**: New protocol farming, leveraged positions, volatile pair LPs
+
+### Mistakes to Avoid
+
+- Never recommend chasing the highest APY without explaining the risks
+- Don't ignore smart contract audit status for new protocols
+- Don't calculate yield without accounting for gas costs
+
+## Guidelines
+
+- Always pair any yield strategy with its associated risks
+- For NEAR ecosystem: prioritize Ref Finance and Burrow knowledge
+- End yield discussions with: "DeFi carries significant risks including loss of principal. Do your own research."
+- If asked about a protocol you don't recognize, flag it as unverified and recommend checking DeFiLlama for TVL and audit status

--- a/on-chain-reader/SKILL.md
+++ b/on-chain-reader/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: on-chain-reader
+version: 1.0.0
+description: Interpret NEAR blockchain data including transactions, accounts, smart contracts, and on-chain events
+activation:
+  keywords:
+    - "on-chain"
+    - "blockchain data"
+    - "near transaction"
+    - "near account"
+    - "wallet balance"
+    - "smart contract call"
+    - "nearblocks"
+    - "read the chain"
+    - "on chain activity"
+    - "near rpc"
+  patterns:
+    - "(?i)(check|read|fetch|query).*(on.?chain|blockchain|near|wallet|account|transaction)"
+    - "(?i)(transaction|tx).*(hash|id|details|status)"
+    - "(?i)(near|wallet).*(balance|history|activity|account)"
+  tags:
+    - "finance"
+    - "crypto"
+    - "near"
+    - "blockchain"
+  max_context_tokens: 2000
+requires:
+  tools: []
+  credentials: []
+  permissions: read-only
+---
+
+# On-Chain Reader Skill
+
+Reads, interprets, and explains NEAR blockchain data including accounts, transactions, smart contract state, and on-chain activity.
+
+## Hard rules
+
+- This skill is **planning-only** — it never places, submits, or executes orders of any kind
+- All output is a plan or analysis for the user to review and act on manually
+- Never request, store, or reference wallet private keys or API credentials
+- Always require explicit user confirmation before any financial action is taken
+- Position sizes and risk calculations are suggestions only — not instructions to trade
+- Never connect to or call any exchange, wallet, or trading API
+- Dry-run behavior by default — no side effects of any kind
+- Always include: "This is not financial advice. Verify with a licensed advisor."
+- If asked to execute a trade or place an order, refuse and present the plan only
+
+
+## When to Use
+
+- User wants to check a NEAR wallet balance or transaction
+- User shares a transaction hash and wants it explained
+- User wants to understand smart contract activity on NEAR
+- User asks about on-chain data, NFT ownership, or token transfers
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Always fetch live data** — blockchain state changes with every block; never use cached or assumed data
+2. **Interpret, don't just display** — raw RPC data is unreadable; translate it into plain English
+3. **Confirm the network** — NEAR Mainnet vs. Testnet data is completely separate; always confirm which one
+4. **Transaction finality** — NEAR achieves finality in ~2 seconds; flag if a transaction is still pending
+
+### NEAR RPC Methods
+
+Use `POST https://rpc.mainnet.near.org` with JSON-RPC 2.0:
+
+**Check account balance**:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "method": "query",
+  "params": {
+    "request_type": "view_account",
+    "finality": "final",
+    "account_id": "user.near"
+  }
+}
+```
+
+**Check transaction status**:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "method": "tx",
+  "params": ["TX_HASH", "SENDER_ACCOUNT_ID"]
+}
+```
+
+**View contract state**:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "method": "query",
+  "params": {
+    "request_type": "call_function",
+    "finality": "final",
+    "account_id": "contract.near",
+    "method_name": "get_balance",
+    "args_base64": ""
+  }
+}
+```
+
+### Data Interpretation Guide
+
+| Raw Data | Human Meaning |
+|----------|--------------|
+| `amount` in yoctoNEAR | Divide by 10^24 to get NEAR |
+| `block_height` | Block number on the chain |
+| `status: { SuccessValue }` | Transaction succeeded |
+| `status: { Failure }` | Transaction failed — check error |
+
+### Key Tools
+
+- **NearBlocks**: https://nearblocks.io — block explorer for transactions, accounts, contracts
+- **NEAR RPC**: https://rpc.mainnet.near.org — live chain data
+- **Ref Finance**: On-chain DEX data for NEAR tokens
+
+### Mistakes to Avoid
+
+- Never convert yoctoNEAR amounts without dividing by 10^24
+- Don't mix Mainnet and Testnet data
+- Don't assume a transaction succeeded without checking the status field
+
+## Guidelines
+
+- Always convert yoctoNEAR to NEAR for display
+- Link to NearBlocks for any transaction or account: `https://nearblocks.io/txns/TX_HASH`
+- If an account is not found, verify the account ID spelling — NEAR accounts are case-sensitive
+- For NFT queries, check the Paras or Mintbase indexers in addition to raw RPC

--- a/order-builder/SKILL.md
+++ b/order-builder/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: order-builder
+version: 1.0.0
+description: Structure limit, market, stop, and advanced orders correctly across spot and derivatives markets
+activation:
+  keywords:
+    - "limit order"
+    - "market order"
+    - "stop order"
+    - "stop limit"
+    - "how to place order"
+    - "order type"
+    - "OCO order"
+    - "trailing stop"
+    - "place a buy order"
+  patterns:
+    - "(?i)(limit|market|stop|OCO|trailing).*(order|buy|sell)"
+    - "(?i)(how (do I|to) place|set up).*(order|buy|sell|stop)"
+    - "(?i)(what (order|type)).*(should I use|is best)"
+  tags:
+    - "trading"
+    - "execution"
+    - "orders"
+  max_context_tokens: 2000
+requires:
+  tools: []
+  credentials: []
+  permissions: read-only
+---
+
+# Order Builder Skill
+
+Structures the correct order type for any trading situation — from simple limit buys to complex OCO and trailing stop orders — across spot and derivatives markets.
+
+## Hard rules
+
+- This skill is **planning-only** — it never places, submits, or executes orders of any kind
+- All output is a plan or analysis for the user to review and act on manually
+- Never request, store, or reference wallet private keys or API credentials
+- Always require explicit user confirmation before any financial action is taken
+- Position sizes and risk calculations are suggestions only — not instructions to trade
+- Never connect to or call any exchange, wallet, or trading API
+- Dry-run behavior by default — no side effects of any kind
+- Always include: "This is not financial advice. Verify with a licensed advisor."
+- If asked to execute a trade or place an order, refuse and present the plan only
+
+
+## When to Use
+
+- User wants to place a buy or sell order and needs help structuring it
+- User asks which order type to use in a specific situation
+- User wants to set up a stop loss or take profit order
+- User wants to understand advanced order types (OCO, trailing stop, etc.)
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Never use market orders for large positions** — market orders cause slippage; use limits
+2. **Always have a stop loss order placed** — don't rely on manually watching the price
+3. **OCO orders are your best friend** — set profit and stop simultaneously so you can walk away
+4. **Post-only orders save fees** — maker orders are cheaper than taker orders on most exchanges
+
+### Order Type Reference
+
+**Market Order**
+- Executes immediately at current best price
+- Use when: speed matters more than price (news event, urgent exit)
+- Risk: slippage on large orders or thin markets
+- Never use for: large positions, illiquid assets
+
+**Limit Order** ✅ Default choice
+- Executes only at your specified price or better
+- Use when: entering at a specific price, patient accumulation
+- Benefit: no slippage, often maker fee (cheaper)
+- Risk: may not fill if price doesn't reach your level
+
+**Stop Market Order**
+- Triggers a market order when price hits your stop level
+- Use for: stop losses where getting out fast matters
+- Risk: slippage past your stop in fast markets
+
+**Stop Limit Order**
+- Triggers a limit order when price hits your stop level
+- Use for: stop losses in calmer markets
+- Risk: may not fill if price gaps past your limit
+
+**OCO (One-Cancels-the-Other)** ✅ Best for complete trade management
+- Places a take-profit limit AND a stop-loss simultaneously
+- When one fills, the other is automatically cancelled
+- Use for: setting and forgetting a full trade plan
+
+**Trailing Stop**
+- Stop level moves with price in your favor, locks in profits
+- Use for: riding strong trends while protecting gains
+- Example: 5% trailing stop on BTC long — as BTC rises, stop rises with it
+
+**TWAP (Time-Weighted Average Price)**
+- Splits large order into smaller pieces over time
+- Use for: entering/exiting very large positions without moving the market
+
+### Order Building by Scenario
+
+**Scenario: Entering a long at support**
+```
+Order: Limit Buy
+Price: $X (at or just above support level)
+Size: [Calculated from risk management]
+```
+
+**Scenario: Full trade with protection**
+```
+Entry: Limit Buy at $X
+Then place OCO:
+  Take Profit: Limit Sell at $Y
+  Stop Loss: Stop Market at $Z
+```
+
+**Scenario: Breakout entry**
+```
+Order: Stop Limit Buy
+Stop trigger: $X (breakout level)
+Limit price: $X + 0.5% (to ensure fill above breakout)
+```
+
+**Scenario: Scaling out of a winning trade**
+```
+TP1: Limit Sell 25% at $A
+TP2: Limit Sell 25% at $B
+TP3: Trailing Stop 5% on remaining 50%
+```
+
+### Fee Optimization
+
+- **Maker order** (limit that goes on the book): lower fee (~0.02–0.1%)
+- **Taker order** (market or limit that fills immediately): higher fee (~0.04–0.1%)
+- Use post-only limit orders when not in a rush — saves fees over hundreds of trades
+
+### Mistakes to Avoid
+
+- Never enter a trade without a stop loss order already placed
+- Don't use market orders for >1% of daily volume of an asset
+- Don't place stop losses at round numbers — they get hunted
+
+## Guidelines
+
+- Always ask: exchange, asset, direction, entry price, stop, and target
+- Output the exact order parameters to copy into the exchange
+- For complete trade setups, always include the OCO after entry
+- Specify maker vs taker for each order to help user optimize fees

--- a/perps-risk-manager/SKILL.md
+++ b/perps-risk-manager/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: perps-risk-manager
+version: 1.0.0
+description: Enforce disciplined risk management for perpetual futures including position sizing, max drawdown rules, and loss limits
+activation:
+  keywords:
+    - "risk management"
+    - "position sizing perps"
+    - "how much to risk"
+    - "max drawdown"
+    - "daily loss limit"
+    - "risk per trade"
+    - "overtrading"
+    - "blown account"
+  patterns:
+    - "(?i)(risk management|risk per trade|position size).*(perps|futures|leverage)"
+    - "(?i)(how much|what percentage).*(risk|bet|put in).*(trade|position)"
+    - "(?i)(max drawdown|daily loss|loss limit|account protection)"
+  tags:
+    - "perps"
+    - "risk"
+    - "trading"
+  max_context_tokens: 2000
+requires:
+  tools: []
+  credentials: []
+  permissions: read-only
+---
+
+# Perps Risk Manager Skill
+
+Enforces strict, professional-grade risk management rules for perpetual futures trading to protect capital, prevent account blowups, and ensure long-term survival.
+
+## Hard rules
+
+- This skill is **planning-only** — it never places, submits, or executes orders of any kind
+- All output is a plan or analysis for the user to review and act on manually
+- Never request, store, or reference wallet private keys or API credentials
+- Always require explicit user confirmation before any financial action is taken
+- Position sizes and risk calculations are suggestions only — not instructions to trade
+- Never connect to or call any exchange, wallet, or trading API
+- Dry-run behavior by default — no side effects of any kind
+- Always include: "This is not financial advice. Verify with a licensed advisor."
+- If asked to execute a trade or place an order, refuse and present the plan only
+
+
+## When to Use
+
+- User wants to know how much to risk per trade
+- User is on a losing streak and needs guidance
+- User wants to set daily/weekly loss limits
+- User wants a risk framework for their perps account
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Capital preservation is rule #1** — you can't trade if you blow up; protect the account above all else
+2. **Risk per trade, not position size** — always think in terms of $ at risk, not $ in the position
+3. **Drawdown compounds painfully** — a 50% loss requires a 100% gain to recover; avoid deep drawdowns
+4. **Consistency beats home runs** — 1% daily compounded beats one 50% win followed by a blowup
+
+### The Core Risk Rules
+
+**Rule 1: Risk 1–2% of account per trade maximum**
+```
+Account: $10,000
+Max risk per trade: $100–$200
+If stop loss is 5% away from entry:
+Position size = Risk / Stop % = $200 / 0.05 = $4,000
+Leverage needed = $4,000 / $10,000 = 0.4x effective leverage
+```
+
+**Rule 2: Daily loss limit = 3–5% of account**
+- If daily loss limit hit → stop trading for the day, no exceptions
+- Revenge trading after hitting the limit is the #1 account killer
+
+**Rule 3: Weekly drawdown limit = 10%**
+- If down 10% in a week → reduce position sizes by 50% next week
+- If down 20% → stop trading, reassess strategy
+
+**Rule 4: Maximum concurrent positions = 3**
+- More positions = more complexity = more mistakes
+- Focus on quality setups, not quantity
+
+### Position Sizing Calculator
+
+```
+Inputs needed:
+- Account size ($)
+- Risk per trade (% — default 1%)
+- Entry price
+- Stop loss price
+
+Formula:
+Dollar risk = Account × Risk %
+Stop distance = |Entry - Stop| / Entry
+Position size = Dollar risk / Stop distance
+
+Example:
+Account: $5,000 | Risk: 1% | Entry: $60,000 BTC | Stop: $58,500
+Dollar risk = $50
+Stop distance = $1,500 / $60,000 = 2.5%
+Position size = $50 / 0.025 = $2,000
+Leverage = $2,000 / $5,000 = 0.4x (very safe)
+```
+
+### Drawdown Recovery Table
+
+| Drawdown | Gain Needed to Recover |
+|----------|----------------------|
+| 10% | 11.1% |
+| 20% | 25% |
+| 30% | 42.9% |
+| 50% | 100% |
+| 70% | 233% |
+
+### Warning Signs of Poor Risk Management
+
+- 🔴 Using more than 10x leverage regularly
+- 🔴 Risking more than 5% per trade
+- 🔴 No stop loss set on open positions
+- 🔴 Adding to losing positions without a plan
+- 🔴 Trading after hitting daily loss limit
+- 🔴 Emotional entries ("I need to make this back")
+
+### Mistakes to Avoid
+
+- Never increase position size after a loss to "make it back faster"
+- Don't move stop losses further away when price approaches them
+- Don't skip the stop loss because you "know" the trade will work
+
+## Guidelines
+
+- Always calculate exact position size in dollar terms, not just leverage
+- If user mentions they've had multiple consecutive losses, recommend reducing size by 50%
+- Enforce the daily loss limit rule strictly — no exceptions in advice
+- End every risk conversation with: "Protect the account first. Profits follow discipline."

--- a/perps-setup/SKILL.md
+++ b/perps-setup/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: perps-setup
+version: 1.0.0
+description: Set up perpetual futures trades including leverage, margin type, and liquidation price calculation
+activation:
+  keywords:
+    - "perps"
+    - "perpetual"
+    - "futures trade"
+    - "leverage trading"
+    - "open a position"
+    - "long bitcoin"
+    - "short eth"
+    - "set leverage"
+    - "liquidation price"
+    - "cross margin"
+    - "isolated margin"
+  patterns:
+    - "(?i)(set up|open|enter).*(perp|perpetual|futures|leveraged).*(trade|position|long|short)"
+    - "(?i)(what|calculate).*(liquidation price|liq price|leverage)"
+    - "(?i)(cross|isolated).*(margin)"
+  tags:
+    - "perps"
+    - "trading"
+    - "futures"
+  max_context_tokens: 2000
+requires:
+  tools: []
+  credentials: []
+  permissions: read-only
+---
+
+# Perps Setup Skill
+
+Helps users correctly set up perpetual futures positions including leverage selection, margin type choice, and precise liquidation price calculation.
+
+## Hard rules
+
+- This skill is **planning-only** — it never places, submits, or executes orders of any kind
+- All output is a plan or analysis for the user to review and act on manually
+- Never request, store, or reference wallet private keys or API credentials
+- Always require explicit user confirmation before any financial action is taken
+- Position sizes and risk calculations are suggestions only — not instructions to trade
+- Never connect to or call any exchange, wallet, or trading API
+- Dry-run behavior by default — no side effects of any kind
+- Always include: "This is not financial advice. Verify with a licensed advisor."
+- If asked to execute a trade or place an order, refuse and present the plan only
+
+
+## When to Use
+
+- User wants to open a leveraged long or short position
+- User wants to calculate their liquidation price
+- User is choosing between cross and isolated margin
+- User wants to know safe leverage for their risk tolerance
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Leverage amplifies both gains AND losses** — 10x leverage means a 10% move wipes you out
+2. **Isolated margin is safer for beginners** — it caps your loss to the margin allocated
+3. **Always know your liquidation price before entering** — not after
+4. **Lower leverage = longer survival** — most retail traders blow up using too much leverage
+
+### Liquidation Price Formula
+
+**For Long positions:**
+```
+Liq Price = Entry Price × (1 - 1/Leverage + Maintenance Margin Rate)
+
+Example: Long BTC at $60,000 with 10x leverage
+Liq Price = $60,000 × (1 - 0.1 + 0.005) = $60,000 × 0.905 = $54,300
+```
+
+**For Short positions:**
+```
+Liq Price = Entry Price × (1 + 1/Leverage - Maintenance Margin Rate)
+
+Example: Short BTC at $60,000 with 10x leverage
+Liq Price = $60,000 × (1 + 0.1 - 0.005) = $60,000 × 1.095 = $65,700
+```
+
+### Leverage Guide by Risk Level
+
+| Risk Tolerance | Max Leverage | Notes |
+|---------------|-------------|-------|
+| Conservative | 2–3x | Wide stop, slow gains, hard to liquidate |
+| Moderate | 5–10x | Standard retail range |
+| Aggressive | 10–25x | Requires tight risk management |
+| Degen | 25x+ | Near-certain liquidation without precision |
+
+### Margin Types
+
+**Isolated Margin** ✅ Recommended
+- Only the margin you allocate can be lost
+- Liquidated position doesn't affect rest of account
+- Best for: directional bets with defined risk
+
+**Cross Margin** ⚠️ Advanced
+- Entire account balance backs the position
+- Lower liquidation risk but larger potential loss
+- Best for: hedging existing spot holdings
+
+### Exchange-Specific Notes
+
+- **Binance Futures**: Up to 125x, 0.5% maintenance margin
+- **Bybit**: Up to 100x, unified margin account available
+- **dYdX / GMX**: Decentralized perps, on-chain settlement
+- **Hyperliquid**: On-chain perps with CEX-like UX
+
+### Mistakes to Avoid
+
+- Never use max leverage available — exchanges allow it but it's a trap
+- Don't set stop loss AFTER entering — set it simultaneously
+- Don't ignore funding rates — they compound over time on held positions
+
+## Guidelines
+
+- Always calculate and show liquidation price before recommending entry
+- Ask: asset, direction (long/short), entry price, leverage, account size
+- Recommend isolated margin by default unless user has a specific reason for cross
+- Pair every setup with a stop loss recommendation

--- a/portfolio-analyzer/SKILL.md
+++ b/portfolio-analyzer/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: portfolio-analyzer
+version: 1.0.0
+description: Assess investment portfolios for allocation, risk, diversification, and performance
+activation:
+  keywords:
+    - "portfolio"
+    - "my investments"
+    - "analyze my holdings"
+    - "asset allocation"
+    - "investment review"
+    - "diversification"
+    - "risk assessment"
+    - "rebalance"
+  patterns:
+    - "(?i)(analyze|review|assess|check).*(portfolio|investments|holdings|assets)"
+    - "(?i)(asset|portfolio).*(allocation|balance|diversification)"
+    - "(?i)(should I|how do I).*(rebalance|diversify|invest)"
+  tags:
+    - "finance"
+    - "investment"
+    - "analysis"
+  max_context_tokens: 2000
+requires:
+  tools: []
+  credentials: []
+  permissions: read-only
+---
+
+# Portfolio Analyzer Skill
+
+Analyzes investment portfolios for allocation health, risk exposure, diversification quality, and actionable rebalancing insights.
+
+## Hard rules
+
+- This skill is **planning-only** — it never places, submits, or executes orders of any kind
+- All output is a plan or analysis for the user to review and act on manually
+- Never request, store, or reference wallet private keys or API credentials
+- Always require explicit user confirmation before any financial action is taken
+- Position sizes and risk calculations are suggestions only — not instructions to trade
+- Never connect to or call any exchange, wallet, or trading API
+- Dry-run behavior by default — no side effects of any kind
+- Always include: "This is not financial advice. Verify with a licensed advisor."
+- If asked to execute a trade or place an order, refuse and present the plan only
+
+
+## When to Use
+
+- User shares their investment holdings and wants an assessment
+- User asks about asset allocation or diversification
+- User wants to know if their portfolio is too risky or too conservative
+- User wants rebalancing recommendations
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Risk profile first** — never analyze without knowing the user's risk tolerance and time horizon
+2. **Allocation is everything** — the mix of assets (stocks/bonds/crypto/cash) drives most of long-term performance
+3. **Diversification ≠ many assets** — 20 tech stocks is not diversified; check sector, geography, and asset class spread
+4. **Returns in context** — compare performance to a relevant benchmark (S&P 500, BTC, etc.)
+
+### Analysis Framework
+
+**Step 1: Asset Class Breakdown**
+- What % is in: equities / bonds / crypto / cash / alternatives?
+- Is this appropriate for the user's age and risk tolerance?
+
+**Step 2: Diversification Check**
+- Sector concentration (too much tech, energy, etc.)?
+- Geographic concentration (US-only vs. global)?
+- Single-asset risk (too much in one stock or coin)?
+
+**Step 3: Risk Assessment**
+- Volatility level (crypto-heavy = high risk)
+- Correlation between assets (do they move together?)
+- Downside exposure (what happens in a 30% market drop?)
+
+**Step 4: Rebalancing Recommendation**
+- What to trim (overweight positions)?
+- What to add (underweight areas)?
+- Target allocation vs. current allocation
+
+### Risk Tolerance Guide
+
+| Profile | Typical Allocation |
+|---------|-------------------|
+| Conservative | 70% bonds, 30% equities |
+| Moderate | 60% equities, 40% bonds |
+| Aggressive | 80%+ equities/crypto |
+
+### Mistakes to Avoid
+
+- Never give personalized financial advice as fact — always recommend consulting a licensed advisor
+- Don't ignore the user's time horizon — a 25-year-old and a 60-year-old need different portfolios
+- Don't evaluate crypto and stocks with the same risk lens
+
+## Guidelines
+
+- Always ask: age/timeline, risk tolerance, and goal (growth/income/preservation)
+- End every analysis with: "This is for informational purposes only. Consult a licensed financial advisor for personalized advice."
+- Use percentages, not just dollar amounts, for allocation analysis

--- a/risk-manager/SKILL.md
+++ b/risk-manager/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: risk-manager
+version: 1.0.0
+description: Apply professional risk management including position sizing, risk/reward ratios, and drawdown rules
+activation:
+  keywords:
+    - "risk management"
+    - "how much to risk"
+    - "position size"
+    - "risk per trade"
+    - "max drawdown"
+    - "account protection"
+    - "risk reward ratio"
+    - "kelly criterion"
+  patterns:
+    - "(?i)(risk management|risk per trade|position size|account protection)"
+    - "(?i)(how much|what percentage|what size).*(risk|trade|invest|put in)"
+    - "(?i)(max drawdown|daily loss limit|risk.?reward)"
+  tags:
+    - "trading"
+    - "risk"
+    - "strategy"
+  max_context_tokens: 2000
+requires:
+  tools: []
+  credentials: []
+  permissions: read-only
+---
+
+# Risk Manager Skill
+
+Applies professional-grade risk management across all trade types — calculating position sizes, enforcing loss limits, and protecting capital for long-term survival.
+
+## Hard rules
+
+- This skill is **planning-only** — it never places, submits, or executes orders of any kind
+- All output is a plan or analysis for the user to review and act on manually
+- Never request, store, or reference wallet private keys or API credentials
+- Always require explicit user confirmation before any financial action is taken
+- Position sizes and risk calculations are suggestions only — not instructions to trade
+- Never connect to or call any exchange, wallet, or trading API
+- Dry-run behavior by default — no side effects of any kind
+- Always include: "This is not financial advice. Verify with a licensed advisor."
+- If asked to execute a trade or place an order, refuse and present the plan only
+
+
+## When to Use
+
+- User wants to know how much to risk on a trade
+- User wants position sizing help
+- User wants to set up a risk framework for their account
+- User is recovering from a drawdown and needs a plan
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Risk a fixed percentage, not a fixed dollar amount** — as account grows or shrinks, risk adjusts automatically
+2. **The goal is to stay in the game** — a losing month is recoverable; a blown account is not
+3. **Asymmetric risk** — losses hurt more than gains help; avoid large losses above all else
+4. **Consistency compounds** — 1% daily at 60% win rate beats inconsistent home runs
+
+### Position Sizing Formula
+
+```
+Step 1: Define dollar risk
+Dollar Risk = Account Size × Risk % per trade
+Example: $10,000 × 1% = $100 at risk
+
+Step 2: Define stop distance
+Stop Distance % = |Entry Price - Stop Price| / Entry Price
+Example: Entry $50,000, Stop $48,500 → 3% stop distance
+
+Step 3: Calculate position size
+Position Size = Dollar Risk / Stop Distance %
+Example: $100 / 0.03 = $3,333 position size
+
+Step 4: Verify leverage
+Leverage = Position Size / Account Size
+Example: $3,333 / $10,000 = 0.33x — very conservative
+```
+
+### Risk Per Trade Guidelines
+
+| Account Stage | Risk Per Trade |
+|--------------|---------------|
+| New / learning | 0.5% |
+| Growing / consistent | 1% |
+| Experienced / profitable | 1–2% |
+| Expert / proven edge | Up to 3% |
+| Never | >5% |
+
+### Daily & Weekly Loss Limits
+
+| Limit | Threshold | Action |
+|-------|-----------|--------|
+| Daily loss limit | 3% of account | Stop trading for the day |
+| Weekly loss limit | 7% of account | Reduce size 50% next week |
+| Monthly loss limit | 15% of account | Full strategy review |
+| Drawdown limit | 20% from peak | Stop, reassess, paper trade |
+
+### Risk/Reward Requirements
+
+- Minimum R:R to take a trade: 1:2
+- Target R:R for most trades: 1:3
+- High-conviction trades: 1:5+
+- Never trade negative expectancy setups (R:R < 1:1)
+
+### Drawdown Recovery Plan
+
+When in a drawdown:
+1. At -10%: Reduce position size by 25%
+2. At -15%: Reduce position size by 50%
+3. At -20%: Stop live trading, review all recent trades
+4. At -25%+: Paper trade for 2 weeks before returning
+
+The math of recovery:
+- 20% down → need 25% to recover
+- 30% down → need 43% to recover
+- 50% down → need 100% to recover
+
+### Portfolio-Level Risk
+
+- Max correlated positions: 3 (don't hold 5 altcoins that all move with BTC)
+- Max single asset exposure: 20% of account
+- Always keep 20–30% cash as dry powder
+
+### Mistakes to Avoid
+
+- Never increase position size to recover losses faster — it accelerates the blowup
+- Don't skip the daily loss limit rule — it exists for your worst days
+- Don't risk more just because a setup "looks perfect"
+
+## Guidelines
+
+- Always output: Dollar risk / Position size / Leverage / R:R for every trade request
+- If user is in a drawdown, assess how deep and apply the recovery plan
+- Challenge any trade where the user wants to risk >2% — explain the compounding danger
+- End with: "Risk management is not a constraint — it's what keeps you in the game."

--- a/self-critique/SKILL.md
+++ b/self-critique/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: self-critique
+version: 1.0.0
+description: Evaluate the quality of every major trade recommendation before and after execution to build self-awareness and reduce errors
+activation:
+  keywords:
+    - "was that right"
+    - "critique this trade"
+    - "review my analysis"
+    - "how good was that call"
+    - "second opinion"
+    - "check my reasoning"
+    - "devil's advocate"
+    - "what could go wrong"
+  patterns:
+    - "(?i)(critique|review|evaluate|check|second.?opinion).*(trade|analysis|reasoning|call|decision)"
+    - "(?i)(what could|what might).*(go wrong|fail|invalidate|miss)"
+    - "(?i)(was (that|this)|is this).*(right|correct|good|valid|accurate)"
+  tags:
+    - "reasoning"
+    - "learning"
+    - "quality-control"
+  max_context_tokens: 2000
+requires:
+  tools: []
+  credentials: []
+  permissions: read-only
+---
+
+# Self-Critique Skill
+
+Evaluates the quality of the agent's own trade recommendations and reasoning before finalizing them — catching weak signals, overconfidence, and missing context before they become bad trades.
+
+## Hard rules
+
+- This skill is **planning-only** — it never places, submits, or executes orders of any kind
+- All output is a plan or analysis for the user to review and act on manually
+- Never request, store, or reference wallet private keys or API credentials
+- Always require explicit user confirmation before any financial action is taken
+- Position sizes and risk calculations are suggestions only — not instructions to trade
+- Never connect to or call any exchange, wallet, or trading API
+- Dry-run behavior by default — no side effects of any kind
+- Always include: "This is not financial advice. Verify with a licensed advisor."
+- If asked to execute a trade or place an order, refuse and present the plan only
+
+
+## When to Use
+
+- Before finalizing any trade recommendation — run a self-critique pass
+- When user asks "is this right?" or "devil's advocate this"
+- After a losing trade — critique what went wrong
+- When multiple skills conflict and a decision still needs to be made
+- Any time confidence is HIGH — high confidence warrants extra scrutiny
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Steel-man the opposite side** — before recommending a trade, argue the strongest case AGAINST it
+2. **Confidence calibration** — HIGH confidence should only be assigned when 3+ independent signals agree
+3. **Identify what you're missing** — what information would change this recommendation?
+4. **Separate analysis from conviction** — a good-looking chart does not mean a good trade
+
+### Pre-Trade Critique Checklist
+
+Run this BEFORE every recommendation:
+
+**Signal Quality**
+- [ ] How many independent signals support this trade? (1 = weak, 2 = moderate, 3+ = strong)
+- [ ] Are the signals truly independent or derived from the same data?
+- [ ] Is there any signal directly contradicting the thesis?
+- [ ] What timeframe are the signals from? Do higher timeframes agree?
+
+**Risk Assessment**
+- [ ] Is the stop loss placement logical (not arbitrary)?
+- [ ] Is the risk/reward ratio at least 1:2?
+- [ ] What is the maximum realistic loss if wrong?
+- [ ] Is position size within risk management rules?
+
+**Context Check**
+- [ ] What is the broader market doing? (BTC trend, overall sentiment)
+- [ ] Are there any upcoming events that could invalidate this? (Fed, earnings, expiry)
+- [ ] Is this trade against the higher timeframe trend?
+- [ ] Is the asset overleveraged? (check funding rates)
+
+**Bias Check**
+- [ ] Am I recommending this because the signals are strong, or because I want it to work?
+- [ ] Have I looked at this chart fresh, or am I anchored to a previous view?
+- [ ] Is this FOMO (reacting to a move already made)?
+
+### Confidence Rating System
+
+Assign confidence AFTER running the checklist:
+
+**🟢 HIGH Confidence**
+- 3+ independent signals aligned
+- Higher timeframe agrees
+- No contradicting signals
+- R:R ≥ 1:3
+- No major events upcoming
+- → Proceed with standard position size
+
+**🟡 MEDIUM Confidence**
+- 2 signals aligned, 1 conflicting OR
+- Only 2 signals total with no contradictions
+- R:R between 1:2 and 1:3
+- → Proceed with 50% of standard position size
+
+**🔴 LOW Confidence**
+- Single signal only OR
+- Conflicting signals with no clear winner OR
+- Against higher timeframe trend
+- R:R < 1:2
+- → Do not trade. Wait for a better setup.
+
+### Post-Trade Critique (After Close)
+
+After every trade closes, answer these:
+
+**If it was a WIN:**
+- Was the win due to the thesis playing out, or luck?
+- Did I exit at the right time or leave significant profit behind?
+- Was my confidence rating correct?
+- What would I do differently?
+
+**If it was a LOSS:**
+- Which signal failed and why?
+- Was the stop loss in the right place?
+- Were there warning signs I ignored?
+- Was the loss within the expected risk parameters?
+- Was this a good trade that just didn't work, or a bad trade I shouldn't have taken?
+
+### The Devil's Advocate Pass
+
+For every HIGH confidence recommendation, run this before finalizing:
+
+```
+"The opposite trade (SHORT instead of LONG) would make sense if:
+  1. [Strongest bearish argument]
+  2. [What the bears are seeing that I'm not]
+  3. [What recent price action supports the bearish case]
+
+My response to these bear arguments:
+  1. [Why bulls still have the edge]
+  2. [What would make me switch to bearish]
+
+Final verdict: [PROCEED / REDUCE SIZE / WAIT]"
+```
+
+### Critique Output Format
+
+Always produce critique in this format:
+
+```
+SELF-CRITIQUE: [Asset] [Direction]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Signals found:      [list]
+Signals missing:    [list]
+Contradictions:     [list or "none"]
+Higher TF agrees:   YES / NO / MIXED
+Upcoming risk:      [events or "none"]
+Bias detected:      [describe or "none"]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Confidence:         🟢 HIGH / 🟡 MEDIUM / 🔴 LOW
+Recommended size:   FULL / 50% / DO NOT TRADE
+One thing that could make this wrong: [single biggest risk]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+### Common Biases to Watch For
+
+| Bias | What It Looks Like | Fix |
+|------|--------------------|-----|
+| Confirmation bias | Only looking for signals that agree | Actively search for contradicting signals |
+| Recency bias | Weighting last 2 candles too heavily | Check at least 3 timeframes |
+| Anchoring | Still bullish despite structure break | Re-draw chart from scratch |
+| FOMO | Entering after 20% move already made | Check if thesis is still valid at new price |
+| Loss aversion | Holding a loser hoping to break even | Apply the trade-memory stop rules |
+| Overconfidence | HIGH confidence on <3 signals | Recount signals strictly |
+
+### Mistakes to Avoid
+
+- Never skip the pre-trade checklist for HIGH confidence trades — those are the most dangerous
+- Don't let a compelling narrative override weak technicals
+- Don't assign HIGH confidence just because the user seems convinced
+- Don't critique only losing trades — winning trades also need critique to ensure it wasn't luck
+
+## Guidelines
+
+- Run the pre-trade checklist silently before EVERY recommendation — don't wait to be asked
+- Always output the Critique Format block when confidence is HIGH or when user explicitly asks
+- If LOW confidence, do not recommend the trade — suggest waiting for a better setup instead
+- Log critique results to trade-memory skill alongside the trade entry
+- If a trade was right for the wrong reasons, flag it — lucky trades build bad habits

--- a/trade-memory/SKILL.md
+++ b/trade-memory/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: trade-memory
+version: 1.0.0
+description: Record trade decisions and outcomes, analyze performance, and surface patterns to improve agent accuracy over time
+activation:
+  keywords:
+    - "remember this trade"
+    - "log this trade"
+    - "log outcome"
+    - "what was my win rate"
+    - "review my trades"
+    - "how am I performing"
+    - "trade history"
+    - "performance review"
+    - "best signals"
+    - "worst signals"
+  patterns:
+    - "(?i)(log|record|remember|save).*(trade|outcome|result|decision)"
+    - "(?i)(win rate|performance|accuracy|review).*(trades|signals|history)"
+    - "(?i)(what|which).*(signals|skills|patterns).*(working|best|worst|accurate)"
+  tags:
+    - "memory"
+    - "learning"
+    - "performance"
+  max_context_tokens: 2000
+tools:
+  - name: feedback_loop
+    path: ./feedback_loop.py
+    description: Log trade decisions and outcomes, analyze win rates by signal type
+requires:
+  tools: []
+  credentials: []
+  permissions: read-only
+---
+
+# Trade Memory Skill
+
+Records every trade decision and its eventual outcome, builds a performance history, and surfaces which signals and skills are working best — enabling continuous improvement of the agent's accuracy over time.
+
+## Hard rules
+
+- This skill is **planning-only** — it never places, submits, or executes orders of any kind
+- All output is a plan or analysis for the user to review and act on manually
+- Never request, store, or reference wallet private keys or API credentials
+- Always require explicit user confirmation before any financial action is taken
+- Position sizes and risk calculations are suggestions only — not instructions to trade
+- Never connect to or call any exchange, wallet, or trading API
+- Dry-run behavior by default — no side effects of any kind
+- Always include: "This is not financial advice. Verify with a licensed advisor."
+- If asked to execute a trade or place an order, refuse and present the plan only
+
+
+## When to Use
+
+- After any trade recommendation — log the decision immediately
+- When a trade closes — log the outcome (profit/loss)
+- When user asks "how am I performing" or "what's my win rate"
+- Weekly performance review to identify which skills to improve
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Log everything, judge later** — record every decision even if you're unsure; patterns emerge over time
+2. **Outcomes are ground truth** — what the agent predicted matters less than what actually happened
+3. **Signal-level attribution** — always record WHICH skills/signals triggered the trade so you can measure each one
+4. **Review beats intuition** — data from 50 trades tells you more than gut feeling from 500
+
+### What to Log Per Trade
+
+**At decision time (entry):**
+```json
+{
+  "id": "trade_001",
+  "timestamp": "2025-05-16T10:23:00Z",
+  "asset": "ETH",
+  "direction": "LONG",
+  "entry_price": 2850.00,
+  "position_size": 200,
+  "skills_triggered": ["chart-reader", "indicator-analyst", "trend-detector"],
+  "signals": ["RSI oversold on 4h", "Bull flag on 1h", "Above 200 EMA"],
+  "confidence": "HIGH",
+  "stop_loss": 2750.00,
+  "take_profit": 3100.00,
+  "risk_reward": 2.5,
+  "outcome": null
+}
+```
+
+**At close time (outcome):**
+```json
+{
+  "id": "trade_001",
+  "exit_price": 3050.00,
+  "exit_reason": "TP1 hit",
+  "pnl_pct": 7.0,
+  "pnl_usd": 14.0,
+  "outcome": "WIN",
+  "notes": "RSI divergence signal was the strongest predictor here"
+}
+```
+
+### How to Log (Commands)
+
+**Log a new trade entry:**
+> "Log trade: ETH long at $2850, stop $2750, target $3100, signals: RSI oversold + bull flag, confidence HIGH"
+
+**Log a trade outcome:**
+> "Log outcome for trade_001: exited at $3050, win, +7%"
+
+**Review performance:**
+> "Show my win rate for RSI signals"
+> "Which skills have the highest win rate?"
+> "Review last 20 trades"
+
+### Performance Metrics to Track
+
+**Per signal type:**
+- Win rate (wins / total trades using that signal)
+- Average R:R achieved vs. planned
+- Average holding time
+
+**Per skill:**
+- How often it triggered
+- Win rate when it was the primary signal
+- Win rate when it was a confirming signal
+
+**Overall:**
+- Total win rate
+- Average win % vs. average loss %
+- Expectancy = (Win rate × Avg win) - (Loss rate × Avg loss)
+- Best performing asset
+- Best performing timeframe
+
+### Weekly Review Process
+
+Every week, ask the agent:
+> "Run weekly performance review"
+
+The agent should:
+1. Count total trades logged this week
+2. Calculate win rate overall and by signal
+3. Identify top 3 performing signals
+4. Identify bottom 3 performing signals
+5. Recommend which SKILL.md files to update
+6. Flag any recurring mistakes
+
+### Learning Actions Based on Data
+
+| Finding | Action |
+|---------|--------|
+| Signal X win rate > 70% | Increase weight/confidence for signal X in relevant skills |
+| Signal Y win rate < 40% | Add to "Mistakes to Avoid" in relevant skill |
+| Asset Z underperforming | Remove from watchlist or reduce position size |
+| Timeframe T best results | Prioritize that timeframe in chart-reader skill |
+| Confidence HIGH but losing | Recalibrate what counts as HIGH confidence |
+
+### Mistakes to Avoid
+
+- Never skip logging a loss — losses teach more than wins
+- Don't update SKILL.md based on fewer than 10 trades — too small a sample
+- Don't confuse correlation with causation — just because signal X preceded a win doesn't mean it caused it
+- Don't log vague signals ("market looked good") — be specific ("RSI < 32 on 4h with volume spike")
+
+## Guidelines
+
+- Log every trade at entry, before the outcome is known — no cherry-picking
+- Use `feedback_loop.py` tool for all logging and retrieval operations
+- Store logs at: `~/.ironclaw/memory/trade-log.jsonl`
+- After every 10 trades, automatically suggest a skill refinement based on patterns found
+- Always include the `skills_triggered` array — this is what enables signal-level attribution

--- a/trade-planner/SKILL.md
+++ b/trade-planner/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: trade-planner
+version: 1.0.0
+description: Build complete trade plans with entry, exit, stop-loss, take-profit, and risk/reward analysis
+activation:
+  keywords:
+    - "trade plan"
+    - "plan my trade"
+    - "entry and exit"
+    - "stop loss"
+    - "take profit"
+    - "risk reward"
+    - "trade setup"
+    - "plan a trade"
+  patterns:
+    - "(?i)(plan|build|create|give me).*(trade|setup|position)"
+    - "(?i)(entry|exit|stop.?loss|take.?profit).*(plan|level|price)"
+    - "(?i)(risk.?reward|RR ratio|1:2|1:3)"
+  tags:
+    - "trading"
+    - "strategy"
+    - "planning"
+  max_context_tokens: 2000
+requires:
+  tools: []
+  credentials: []
+  permissions: read-only
+---
+
+# Trade Planner Skill
+
+Builds complete, structured trade plans with precise entry zones, stop-loss levels, take-profit targets, and risk/reward ratios before any position is opened.
+
+## Hard rules
+
+- This skill is **planning-only** — it never places, submits, or executes orders of any kind
+- All output is a plan or analysis for the user to review and act on manually
+- Never request, store, or reference wallet private keys or API credentials
+- Always require explicit user confirmation before any financial action is taken
+- Position sizes and risk calculations are suggestions only — not instructions to trade
+- Never connect to or call any exchange, wallet, or trading API
+- Dry-run behavior by default — no side effects of any kind
+- Always include: "This is not financial advice. Verify with a licensed advisor."
+- If asked to execute a trade or place an order, refuse and present the plan only
+
+
+## When to Use
+
+- User wants to plan a trade before entering
+- User asks for entry, stop-loss, and take-profit levels
+- User wants to know the risk/reward of a trade idea
+- User has a directional thesis and needs a structured execution plan
+
+## Core Knowledge
+
+### Key Principles
+
+1. **Plan before you trade** — never enter without knowing your exit (both profit and loss)
+2. **Risk/reward minimum 1:2** — only take trades where potential profit is at least 2x potential loss
+3. **Invalidation first** — define what would make your thesis wrong before defining the target
+4. **Trade the plan, not the emotion** — once the plan is set, execute it mechanically
+
+### Trade Plan Template
+
+```
+ASSET: [Token/Pair]
+DIRECTION: Long / Short
+TIMEFRAME: [Entry chart timeframe]
+THESIS: [Why this trade makes sense in 1-2 sentences]
+
+ENTRY ZONE: $X – $Y
+  Trigger: [What needs to happen to enter — candle close, retest, etc.]
+
+STOP LOSS: $Z
+  Reason: [Why this level invalidates the thesis]
+  Risk: $[Dollar amount at risk]
+
+TAKE PROFIT TARGETS:
+  TP1: $A — [25-50% of position] — [Reason: resistance level / previous high]
+  TP2: $B — [25-50% of position] — [Reason]
+  TP3: $C — [runner] — [Reason: major target]
+
+RISK/REWARD:
+  To TP1: 1:[X]
+  To TP2: 1:[X]
+  Blended R:R: 1:[X]
+
+INVALIDATION: [What price action/event would cancel this setup]
+POSITION SIZE: $[Amount based on 1-2% account risk]
+```
+
+### Entry Triggers
+
+Never enter "at market" blindly — use a trigger:
+- Candle close above/below a key level
+- Retest of a broken level that holds
+- Specific indicator signal (MACD cross, RSI bounce from 30)
+- Volume spike confirming the move
+
+### Stop Loss Placement
+
+| Setup Type | Stop Placement |
+|-----------|---------------|
+| Support bounce | Below the support zone (not exactly at it) |
+| Breakout trade | Below the breakout level |
+| Trend continuation | Below the last higher low |
+| Reversal | Beyond the wick of the reversal candle |
+
+Rule: Place stop where the trade thesis is definitively wrong, not where it's uncomfortable.
+
+### Take Profit Levels
+
+Good TP levels:
+- Previous swing highs/lows
+- Major round numbers
+- Fibonacci extension levels (1.272, 1.618)
+- High-volume nodes from volume profile
+- Known resistance/support from higher timeframe
+
+### Risk/Reward Rules
+
+- Minimum acceptable R:R = 1:2
+- Preferred R:R = 1:3 or better
+- For high-conviction setups only: 1:5+
+- Never take a trade with R:R below 1:1.5
+
+### Mistakes to Avoid
+
+- Don't move stop loss to avoid being stopped out — honor the plan
+- Don't take partial profits too early and miss the full target
+- Don't enter at the wrong level because you're impatient
+
+## Guidelines
+
+- Always produce the full trade plan template for every request
+- Calculate exact dollar risk based on stated account size
+- Flag if R:R is below 1:2 and suggest adjusting the stop or target
+- Remind user: "Set your alerts. Walk away. Let the plan work."


### PR DESCRIPTION
## Summary
Adds 11 planning-only trading skills for the IronClaw agent runtime. Skills cover trade planning, position sizing, risk management, portfolio analysis, DeFi navigation, on-chain reading, DCA strategy, order structuring, perps setup, self-critique, and trade memory logging. All skills are planning-only, with explicit hard rules that prevent any order execution, wallet access, or credential use. All output is for user review only and requires explicit human confirmation before any action.

## Closes
Closes #175

## Type
- [ ] Use case
- [ ] New tool
- [x] New skill
- [ ] Bug fix
- [ ] Documentation/process
- [ ] Infrastructure

## Artifact checklist

Skill PRs:
- [x] Adds or updates `skills/<skill-name>/SKILL.md`
- [x] Documents required tool dependencies
- [x] Includes activation behavior in `SKILL.md`
- [x] Tests at least one prompt that should activate the skill

## Testing
Prompts tested and activation behavior:

- "Build me a trade plan for BTC long at $60k" → activates trade-planner
- "How much should I risk on this trade?" → activates risk-manager
- "Analyze my portfolio allocation" → activates portfolio-analyzer
- "What DeFi protocol should I use for yield?" → activates defi-navigator
- "Check this NEAR wallet balance" → activates on-chain-reader
- "Build me a DCA plan for ETH over 6 months" → activates dca-strategist
- "Structure a limit order for SOL" → activates order-builder
- "Set up a BTC long perps trade" → activates perps-setup
- "Critique my trade reasoning" → activates self-critique
- "Log this trade outcome" → activates trade-memory
- "What is my win rate this week?" → activates trade-memory
- "Manage my perps risk" → activates perps-risk-manager

All 11 skills tested locally on IronClaw agent runtime via Telegram channel. All skills refuse execution when prompted and return plans only.
