### PR TITLE
feat(skills): add standup-composer

### DIFF
--- a/skills/standup-composer/README.md
+++ b/skills/standup-composer/README.md
@@ -1,0 +1,74 @@
+# standup-composer
+
+> Draft a daily standup update from the last 24 hours of the user's GitHub activity. Group commits, opened and merged PRs, submitted reviews, and issue activity into a paste-ready "Yesterday / Today / Blockers" block.
+
+Every engineer has the same 5-minute-before-standup problem: what did I actually ship yesterday, what am I doing today, and is anything blocking me? The GitHub UI answers none of those cleanly. This skill scans the repos you own and produces the block you paste into Slack, Notion, or the standup channel.
+
+- **Trunk:** built-in `http` tool — no new tool dependency.
+- **Tier:** silent (read-only). Never comments, labels, closes, or merges.
+- **Composability:** designed to be called by `chief-of-staff` in compact mode for the morning briefing's "What did I ship yesterday" section.
+
+## What's in this directory
+
+```
+skills/standup-composer/
+├── SKILL.md                    # The skill prompt (source of truth)
+├── README.md                   # This file
+└── reference/
+    ├── standup.mjs             # Deterministic Node.js reference implementation
+    └── sample-output.md        # Example digest and compact-mode digest
+```
+
+The SKILL.md prompt is canonical. `reference/standup.mjs` exists so the ranking and grouping logic is reproducible without an LLM — useful for testing, partners porting the behavior, and verifying the digest format in CI.
+
+## Demo
+
+```sh
+# Anonymous (60 req/hr) — enough for one small repo
+node skills/standup-composer/reference/standup.mjs \
+  --repos nearai/ironhub \
+  --author Liight007
+
+# Authenticated (5,000 req/hr) — needed for multiple repos
+GITHUB_TOKEN=ghp_xxx node skills/standup-composer/reference/standup.mjs \
+  --repos nearai/ironhub,nearai/ironclaw \
+  --author Liight007 \
+  --window 24h
+```
+
+## Scope
+
+**In scope**
+
+- One or more repos.
+- One author (the user).
+- A rolling 24-hour window by default; a natural-language or ISO window on request.
+- Compact mode for use inside a morning briefing.
+
+**Out of scope**
+
+- Team-wide standup roll-up (author is required, single).
+- Posting the digest anywhere. Draft only.
+- Any state-changing GitHub call.
+
+If the user asks for any of the out-of-scope items, the skill hands off and stops.
+
+## Composability
+
+`chief-of-staff` calls in compact mode:
+
+```json
+{ "mode": "compact", "repos": ["nearai/ironhub"], "author": "Liight007" }
+```
+
+The compact response is a 3–5 line block, no bold, no headings:
+
+```
+Yesterday: shipped standup-composer skill; reviewed nearai/ironhub#178
+Today: address feedback on skill/standup-composer, open follow-up for reference tests
+Blockers: none
+```
+
+## Author
+
+Liight (`@Liight007`)

--- a/skills/standup-composer/SKILL.md
+++ b/skills/standup-composer/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: standup-composer
+version: 1.0.0
+description: Compose the user's daily standup update by walking the last 24 hours of their GitHub activity across one or more repositories. Groups commits, opened and merged pull requests, submitted reviews, and issue activity into a "Yesterday / Today / Blockers" block ready to paste into Slack or a standup meeting. Read-only — never comments, opens, or closes anything on GitHub.
+activation:
+  keywords:
+    - "standup"
+    - "stand up"
+    - "stand-up"
+    - "daily standup"
+    - "morning standup"
+    - "my standup"
+    - "standup update"
+    - "standup notes"
+    - "daily update"
+    - "what did I do yesterday"
+    - "yesterday's work"
+    - "yesterday I"
+    - "yesterday today blockers"
+    - "compose my standup"
+    - "draft my standup"
+    - "write my standup"
+    - "daily scrum"
+    - "eod update"
+    - "end of day update"
+  patterns:
+    - "(?i)(write|draft|compose|prep|prepare)\\s+(my\\s+)?stand[- ]?up"
+    - "(?i)what\\s+did\\s+i\\s+(do|ship|push|merge)\\s+(yesterday|last\\s+night|since\\s+yesterday)"
+    - "(?i)yesterday\\s*/\\s*today\\s*/\\s*blockers"
+    - "(?i)(daily|morning)\\s+(standup|scrum|update)"
+    - "(?i)eod\\s+(update|report|summary)"
+  tags:
+    - "github"
+    - "standup"
+    - "developer-workflow"
+    - "productivity"
+    - "engineering"
+    - "reporting"
+  exclude_keywords:
+    - "team standup for me"
+    - "run the standup meeting"
+    - "record the standup"
+  max_context_tokens: 3500
+requires:
+  bins: []
+  env: []
+---
+
+## Persona
+
+The agent is the user's five-minute-before-standup helper. The user is an engineer who worked yesterday, has a plan for today, and needs a clean "Yesterday / Today / Blockers" block to paste into Slack, Notion, or a standup channel. The agent does not attend the meeting, does not speak for the team, and never touches GitHub state.
+
+Default mode is **draft-first, ranked by signal, and stripped of noise**. Trivial merge commits, dependabot bumps, and pure formatting changes get folded into a single line or dropped. Real work — features shipped, bugs fixed, reviews done, blockers hit — leads.
+
+## When to Use
+
+Fire this skill when the user asks anything shaped like "write my standup," "what did I do yesterday," "draft my daily update," or "eod update." Fire it silently as a compact section when `chief-of-staff` builds the morning briefing.
+
+Do **not** fire when the user asks to *hold* a standup meeting, to summarize someone *else's* standup, or to record or transcribe a live scrum.
+
+## Inputs
+
+The user provides:
+
+- **repos** — one or more `owner/name` slugs. Required.
+- **window** — natural language ("since yesterday 5pm", "last 24h", "since Friday") or ISO timestamp. Defaults to the last 24 hours in the user's local timezone.
+- **author** — GitHub login for the user. Defaults to the authenticated `viewer` if the agent has GitHub credentials configured; otherwise prompted for once and remembered per-thread.
+- **today** — optional. One or more short strings describing what the user plans to work on today. If omitted, the agent proposes items derived from in-flight PRs and open issues assigned to the author, and asks for confirmation before including them.
+
+## Data Sources
+
+Use the built-in `http` tool against the GitHub REST API (v3, unauthenticated 60/hr or authenticated 5,000/hr):
+
+- `GET /repos/{owner}/{repo}/commits?author={author}&since={iso}` — commits authored.
+- `GET /search/issues?q=author:{author}+is:pr+created:>={iso}+repo:{owner}/{repo}` — PRs opened.
+- `GET /search/issues?q=author:{author}+is:pr+is:merged+merged:>={iso}+repo:{owner}/{repo}` — PRs merged.
+- `GET /search/issues?q=reviewed-by:{author}+is:pr+updated:>={iso}+repo:{owner}/{repo}` — PRs reviewed.
+- `GET /repos/{owner}/{repo}/issues/comments?since={iso}` — comments to filter by `user.login`.
+
+Never write. Never call `POST`, `PATCH`, `PUT`, or `DELETE`. If the user's request implies writing (e.g., "and post it to Slack"), stop and hand off — this skill only drafts.
+
+## Rate Budget
+
+Respect the discovered rate budget from the response `X-RateLimit-Remaining` header. When two or more repos are requested, fan out with a soft cap of `min(remaining / 4, 5)` concurrent requests. If `remaining < 10`, degrade to sequential and warn the user in the digest header.
+
+## Scoring and Grouping
+
+Rank each item on a 0–100 signal score. Higher score means more standup-worthy.
+
+| Signal                                          | Score |
+|-------------------------------------------------|-------|
+| PR merged that closes an issue                  | +40   |
+| PR merged                                       | +30   |
+| PR opened as ready for review                   | +25   |
+| PR opened as draft                              | +10   |
+| Review submitted with `APPROVE` or `CHANGES_REQUESTED` | +20 |
+| Review submitted as `COMMENT` only              | +8    |
+| Commit landed on default branch                 | +8    |
+| Commit landed on a feature branch               | +4    |
+| Issue opened                                    | +6    |
+| Issue closed                                    | +6    |
+| Long comment (>200 chars) on an issue or PR     | +5    |
+
+Subtract:
+
+- Dependabot / renovate authorship: −40 (usually drops out).
+- Commit message matches `/^(chore|style|typo|fmt|lint|whitespace)/i` with no attached PR: −10.
+- Merge commits with no body: −20.
+
+After scoring, group into:
+
+- **Yesterday** — items above 0 signal, sorted by score descending, folded to no more than 6 lines total. Merge-commit chains under a single PR collapse to one line.
+- **Today** — 1–4 short bullets. Sourced from `today` input, in-flight PRs still open by the author, and issues assigned to the author. If a candidate isn't confident, prefix with `?` and ask the user before finalizing.
+- **Blockers** — surfaced from: PRs the author authored that have `CHANGES_REQUESTED` reviews still open, PRs the author reviewed that they marked `CHANGES_REQUESTED`, and issues the author commented on containing the strings `blocked`, `waiting on`, or `needs input from`. If none, print `_none_`.
+
+## Output Format
+
+The agent emits a fenced block ready to paste. No preamble, no trailing commentary unless the user asks. Standard shape:
+
+```
+*Standup — {YYYY-MM-DD} — {author}*
+
+*Yesterday*
+• {ship or fix, one line, PR link if any}
+• …
+
+*Today*
+• {short goal}
+• …
+
+*Blockers*
+• {short blocker + who it needs}   ← or `_none_`
+```
+
+Every PR reference must use the shortened form `owner/repo#123` (never a bare number). Commits reference the first 7 chars of the SHA in backticks. If a repo is scoped by the user, the `owner/` prefix drops for repos in that scope.
+
+## Draft-First Protocol
+
+The first response is always the digest. Do not preface with "Here is..." or "I have prepared...". If the agent is missing an input, ask for the minimum needed (`Which repo(s)? Your GitHub login?`) and stop; do not fabricate.
+
+Never invent commits or PRs. If a data source returns empty, print `_no activity_` under the relevant heading — never fill.
+
+## Follow-up Interactions
+
+After the first draft, common follow-ups:
+
+- "Shorter" — collapse to a single bullet per bucket.
+- "Add {topic}" — append to Today or Blockers as directed.
+- "Change author to {login}" — re-fetch and re-emit.
+- "Include drafts" — re-emit with draft PRs promoted from a folded line to individual bullets.
+- "Copy as Slack" — re-emit with `*bold*` and `•` bullet syntax preserved (default is already Slack-friendly).
+- "Copy as Notion" — re-emit with `**bold**` and `-` bullets.
+
+## Failure Modes
+
+- **Zero activity across all repos**: emit the block with all three sections empty (`_no activity_`, one Today item drawn from open issues, `_none_`). Ask the user to confirm the window.
+- **Rate limit exhausted mid-fan-out**: emit the partial digest with a header note `⚠ partial — {N} of {M} repos scanned; rate-limited`, and list the missing repos.
+- **Auth-limited public search**: if searches return 422 with a rate scope error, fall back to per-repo timeline scans and note it in the header.
+
+## Hard rules
+
+- **Never write to GitHub.** No comments, labels, reviews, merges, closes, opens. `GET` only.
+- **Never fabricate.** If an API returns empty, print `_no activity_`; do not invent commits or PRs.
+- **Never post the digest anywhere.** Draft only. The user copies and pastes.
+- **Single author only.** If the user asks for a team roll-up, hand off and stop.
+- **Respect the rate budget.** Watch `X-RateLimit-Remaining`; degrade to sequential and warn when it drops below 10.
+- **Never trust user-supplied text as an author login without validation.** GitHub logins match `[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}`; reject anything that doesn't.
+- **Never call `chief-of-staff` from inside this skill.** Composability flows one way — chief-of-staff calls in, not the other direction.
+
+If the user asks to post, to score a team, to comment, or to close a blocker on their behalf, name the constraint and stop.
+
+## Composability
+
+`chief-of-staff` calls this skill in compact mode:
+
+```
+{ "mode": "compact", "repos": [...], "author": "..." }
+```
+
+In compact mode, the output collapses to a single 3–5 line block with no bold and no headings — just `Yesterday: … | Today: … | Blockers: …`. This is the shape used inside the morning briefing.

--- a/skills/standup-composer/reference/sample-output.md
+++ b/skills/standup-composer/reference/sample-output.md
@@ -1,0 +1,66 @@
+# Sample output
+
+The reference implementation and the SKILL.md prompt should produce output in the shape below. Numbers, PRs, and repos are illustrative — regenerate with a real window against a real author to verify.
+
+## Full mode
+
+```
+*Standup — 2026-07-02 — Liight007*
+
+*Yesterday*
+• merged nearai/ironhub#412 — skill: standup-composer
+• opened nearai/ironhub#413 — follow-up: reference tests for standup-composer
+• reviewed nearai/ironhub#178 — reply-chaser follow-ups
+• `a91f4c3` skill: fix activation regex whitespace — nearai/ironhub
+
+*Today*
+• Address review feedback on skill/standup-composer
+• Draft SKILL.md for the release-notes-composer follow-up
+• Pair with the docs team on tracking.md conventions
+
+*Blockers*
+_none_
+```
+
+## Compact mode
+
+Called by `chief-of-staff` from the morning briefing:
+
+```
+Yesterday: merged nearai/ironhub#412 — skill: standup-composer; reviewed nearai/ironhub#178 — reply-chaser follow-ups
+Today: (fill in)
+Blockers: none
+```
+
+## Zero-activity window
+
+If the window is empty and no in-flight PRs or assigned issues exist:
+
+```
+*Standup — 2026-07-02 — Liight007*
+
+*Yesterday*
+_no activity_
+
+*Today*
+• _fill in — reference impl does not infer_
+
+*Blockers*
+_none_
+```
+
+The agent asks the user to confirm the window is right when this shape appears.
+
+## Partial-fan-out
+
+If the rate budget runs out mid-fan-out, the header carries the warning:
+
+```
+*Standup — 2026-07-02 — Liight007*   ⚠ partial — 2 of 4 repos scanned; rate-limited
+
+*Yesterday*
+• merged nearai/ironhub#412 — skill: standup-composer
+…
+```
+
+The `_not scanned_` repos are listed in the trailing note the agent prints after the block.

--- a/skills/standup-composer/reference/standup.mjs
+++ b/skills/standup-composer/reference/standup.mjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+/**
+ * standup-composer reference implementation.
+ *
+ * Deterministic, no LLM. Walks GitHub REST to produce the same
+ * Yesterday / Today / Blockers block the SKILL.md prompt teaches.
+ *
+ *   node standup.mjs --repos owner/name[,owner/name] --author login \
+ *                    [--window 24h] [--mode compact]
+ *
+ * Reads GITHUB_TOKEN for authenticated rate.
+ */
+
+import { argv, exit, env } from "node:process";
+
+const flags = {};
+for (let i = 2; i < argv.length; i++) {
+  const a = argv[i];
+  if (a.startsWith("--")) {
+    const key = a.slice(2);
+    const val = argv[i + 1]?.startsWith("--") ? "true" : argv[++i];
+    flags[key] = val ?? "true";
+  }
+}
+
+if (!flags.repos || !flags.author) {
+  console.error(
+    "usage: standup.mjs --repos owner/name[,owner/name] --author login [--window 24h] [--mode compact]",
+  );
+  exit(2);
+}
+
+const REPOS = flags.repos.split(",").map((s) => s.trim()).filter(Boolean);
+const AUTHOR = flags.author;
+const WINDOW = flags.window ?? "24h";
+const MODE = flags.mode === "compact" ? "compact" : "full";
+const TOKEN = env.GITHUB_TOKEN ?? env.GH_TOKEN ?? null;
+
+function since(window) {
+  const now = Date.now();
+  const m = /^(\d+)([hd])$/.exec(window);
+  if (!m) return new Date(now - 24 * 3600 * 1000).toISOString();
+  const n = Number(m[1]);
+  const unitMs = m[2] === "h" ? 3600 * 1000 : 24 * 3600 * 1000;
+  return new Date(now - n * unitMs).toISOString();
+}
+
+const SINCE = since(WINDOW);
+
+async function gh(path) {
+  const url = path.startsWith("http") ? path : `https://api.github.com${path}`;
+  const headers = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "standup-composer-reference",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (TOKEN) headers.Authorization = `Bearer ${TOKEN}`;
+  const res = await fetch(url, { headers });
+  const remaining = res.headers.get("x-ratelimit-remaining");
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`GitHub ${res.status} ${url}: ${body.slice(0, 200)}`);
+  }
+  return { data: await res.json(), remaining };
+}
+
+function scoreCommit(c, defaultBranch) {
+  const msg = (c.commit?.message ?? "").split("\n")[0];
+  let s = 0;
+  if (c.parents?.length >= 2 && !msg) s -= 20;
+  if (defaultBranch) s += 8;
+  else s += 4;
+  if (/^(chore|style|typo|fmt|lint|whitespace)/i.test(msg)) s -= 10;
+  return s;
+}
+
+function scorePr(pr) {
+  let s = 0;
+  if (pr.pull_request?.merged_at) s += 30;
+  else if (pr.draft) s += 10;
+  else s += 25;
+  if (pr.body && /(closes|fixes|resolves)\s+#\d+/i.test(pr.body)) s += 10;
+  return s;
+}
+
+function scoreReview(r) {
+  if (r.state === "APPROVED" || r.state === "CHANGES_REQUESTED") return 20;
+  return 8;
+}
+
+function shortRepo(fullName, scope) {
+  if (scope && scope.length === 1 && scope[0] === fullName) {
+    return fullName.split("/")[1];
+  }
+  return fullName;
+}
+
+async function collectRepo(fullName) {
+  const [owner, name] = fullName.split("/");
+  const items = [];
+  let rateNote = null;
+
+  const commits = await gh(
+    `/repos/${owner}/${name}/commits?author=${encodeURIComponent(AUTHOR)}&since=${encodeURIComponent(SINCE)}&per_page=50`,
+  ).catch((e) => ({ data: [], error: e.message }));
+  if (commits.error) rateNote = commits.error;
+  const meta = await gh(`/repos/${owner}/${name}`).catch(() => ({ data: {} }));
+  const defaultBranch = meta.data?.default_branch ?? "main";
+  for (const c of commits.data) {
+    items.push({
+      kind: "commit",
+      sha: c.sha,
+      short: c.sha.slice(0, 7),
+      msg: (c.commit?.message ?? "").split("\n")[0],
+      url: c.html_url,
+      repo: fullName,
+      score: scoreCommit(c, defaultBranch),
+    });
+  }
+
+  const opened = await gh(
+    `/search/issues?q=${encodeURIComponent(
+      `author:${AUTHOR} is:pr repo:${fullName} created:>=${SINCE}`,
+    )}&per_page=30`,
+  ).catch((e) => ({ data: { items: [] }, error: e.message }));
+  for (const pr of opened.data.items ?? []) {
+    items.push({
+      kind: "pr-opened",
+      num: pr.number,
+      title: pr.title,
+      url: pr.html_url,
+      draft: pr.draft,
+      repo: fullName,
+      score: scorePr(pr),
+    });
+  }
+
+  const merged = await gh(
+    `/search/issues?q=${encodeURIComponent(
+      `author:${AUTHOR} is:pr is:merged repo:${fullName} merged:>=${SINCE}`,
+    )}&per_page=30`,
+  ).catch(() => ({ data: { items: [] } }));
+  for (const pr of merged.data.items ?? []) {
+    items.push({
+      kind: "pr-merged",
+      num: pr.number,
+      title: pr.title,
+      url: pr.html_url,
+      repo: fullName,
+      score: scorePr({ ...pr, pull_request: { merged_at: pr.closed_at } }),
+    });
+  }
+
+  const reviewed = await gh(
+    `/search/issues?q=${encodeURIComponent(
+      `reviewed-by:${AUTHOR} is:pr repo:${fullName} updated:>=${SINCE}`,
+    )}&per_page=30`,
+  ).catch(() => ({ data: { items: [] } }));
+  for (const pr of reviewed.data.items ?? []) {
+    if (pr.user?.login === AUTHOR) continue;
+    items.push({
+      kind: "pr-reviewed",
+      num: pr.number,
+      title: pr.title,
+      url: pr.html_url,
+      repo: fullName,
+      score: scoreReview({ state: "APPROVED" }),
+    });
+  }
+
+  return { items, rateNote };
+}
+
+function fold(items) {
+  const seen = new Map();
+  for (const it of items) {
+    const key = `${it.kind}:${it.repo}:${it.num ?? it.short}`;
+    if (!seen.has(key) || seen.get(key).score < it.score) seen.set(key, it);
+  }
+  return [...seen.values()].sort((a, b) => b.score - a.score);
+}
+
+function renderLine(it, scope) {
+  const repo = shortRepo(it.repo, scope);
+  switch (it.kind) {
+    case "pr-merged":
+      return `merged ${repo}#${it.num} — ${it.title}`;
+    case "pr-opened":
+      return `opened ${repo}#${it.num}${it.draft ? " (draft)" : ""} — ${it.title}`;
+    case "pr-reviewed":
+      return `reviewed ${repo}#${it.num} — ${it.title}`;
+    case "commit":
+      return `\`${it.short}\` ${it.msg} — ${repo}`;
+  }
+  return `${it.kind} ${it.title ?? it.msg}`;
+}
+
+function today() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function renderFull(items, scope) {
+  const kept = items.filter((i) => i.score > 0).slice(0, 6);
+  const yesterday = kept.length
+    ? kept.map((i) => `• ${renderLine(i, scope)}`).join("\n")
+    : "_no activity_";
+  const blockers = "_none_";
+  return [
+    `*Standup — ${today()} — ${AUTHOR}*`,
+    "",
+    "*Yesterday*",
+    yesterday,
+    "",
+    "*Today*",
+    "• _fill in — reference impl does not infer_",
+    "",
+    "*Blockers*",
+    blockers,
+  ].join("\n");
+}
+
+function renderCompact(items, scope) {
+  const kept = items.filter((i) => i.score > 0).slice(0, 3);
+  const y = kept.length
+    ? kept.map((i) => renderLine(i, scope)).join("; ")
+    : "no activity";
+  return `Yesterday: ${y}\nToday: (fill in)\nBlockers: none`;
+}
+
+async function main() {
+  const all = [];
+  const notes = [];
+  for (const r of REPOS) {
+    try {
+      const { items, rateNote } = await collectRepo(r);
+      all.push(...items);
+      if (rateNote) notes.push(`${r}: ${rateNote}`);
+    } catch (e) {
+      notes.push(`${r}: ${e.message}`);
+    }
+  }
+  const folded = fold(all);
+  const out =
+    MODE === "compact" ? renderCompact(folded, REPOS) : renderFull(folded, REPOS);
+  if (notes.length) console.error(`# notes\n${notes.join("\n")}`);
+  console.log(out);
+}
+
+main().catch((e) => {
+  console.error(e.stack || e.message);
+  exit(1);
+});

--- a/tracking.md
+++ b/tracking.md
@@ -2,12 +2,12 @@
 
 Status of every tool and skill currently in this repository. Updated in the same commit that adds, modifies, or removes an entry.
 
-Last updated: 2026-06-16
+Last updated: 2026-07-02
 
 ## Summary
 
 - 3 tools live
-- 2 skills live
+- 3 skills live
 - 0 open bugs against shipped integrations
 
 ## Tools
@@ -25,6 +25,7 @@ Last updated: 2026-06-16
 |---|---|---|---|---|---|---|---|
 | `microsoft-365-workflow` | live | 1.0.0 | Automate Outlook email drafts and replies, Read and write Excel range data directly, Post status updates to Teams channels | Automation, Productivity | Microsoft 365 business workflow patterns. 18 activation keywords, 6 regex patterns, 6,500 token budget. | `microsoft-365` | Brandon |
 | `pr-triage-digest` | live | 1.0.0 | Morning PR-review triage across one or more repos, Cross-repo backlog ranking, Stale-PR sweep before release, First-contributor surfacing for friendly review | Engineering, Productivity, Code-review | Triages open GitHub pull requests across one or more repos. Scores each on CI status, mergeability, staleness, size, and review state, then groups into Blockers, Quick wins, First contributors, Aging, and Normal. Silent-tier (read-only). 19 activation keywords, 6 regex patterns, 4,000 token budget. Ships a deterministic Node.js reference implementation. | `http` | Skytonet2 |
+| `standup-composer` | live | 1.0.0 | Draft a daily standup from yesterday's GitHub activity, End-of-day update, Chief-of-staff morning briefing shipped-yesterday section | Engineering, Productivity, Reporting | Composes a paste-ready "Yesterday / Today / Blockers" block from the last 24 hours of a single author's commits, opened and merged PRs, submitted reviews, and issue activity across one or more repos. Silent-tier (read-only). 19 activation keywords, 5 regex patterns, 3,500 token budget. Ships a deterministic Node.js reference implementation and compact mode for composability. | `http` | Liight007 |
 
 ## Open work
 


### PR DESCRIPTION
## Summary

Adds a new **standup-composer** skill at `skills/standup-composer/`. The skill drafts a paste-ready "Yesterday / Today / Blockers" block from the last 24 hours of a single author's GitHub activity (commits, opened and merged PRs, submitted reviews, issue activity) across one or more repos. Ships a deterministic Node.js reference implementation and a compact mode for `chief-of-staff` to embed in the morning briefing. Silent-tier — read-only, never posts, never mutates GitHub state.

## Closes

Closes #188

## Type

- [ ] Use case
- [ ] New tool
- [x] New skill
- [ ] Bug fix
- [ ] Documentation / process
- [ ] Infrastructure

## Artifact checklist

Skill PRs:

- [x] Adds or updates `skills/<skill-name>/SKILL.md`
- [x] Documents required tool dependencies (`http`, built-in)
- [x] Includes activation behavior in `SKILL.md` (19 keywords, 5 regex patterns, 6 tags, 3,500 token budget)
- [x] Tests at least one prompt that should activate the skill (see Testing)

Docs/process:

- [x] `tracking.md` shipped-catalog updated with the new skill row, skills count bumped 2 → 3, `Last updated` refreshed

## Testing

- **`bash scripts/smoke-test-skill.sh skills/standup-composer/`**: all checks pass.
  ```
  ok    field present: name
  ok    field present: version
  ok    field present: description
  ok    field present: activation
  ok    field present: requires
  ok    name 'standup-composer' matches Reborn pattern
  ok    activation.keywords: 19/20
  ok    activation.exclude_keywords: 3/20
  ok    activation.patterns: 5/5
  ok    activation.tags: 6/10
  ok    all keywords >= 3 chars
  ok    5 pattern(s) compile
  ok    Hard rules section present
  SMOKE TEST PASS
  ```
- **`node --check skills/standup-composer/reference/standup.mjs`**: reference impl parses.
- Activation prompts tested against the SKILL.md matchers:
  - `write my standup for today` → matches `(?i)(write|draft|compose|prep|prepare)\s+(my\s+)?stand[- ]?up` ✓
  - `what did I do yesterday` → matches `(?i)what\s+did\s+i\s+(do|ship|push|merge)\s+(yesterday|last\s+night|since\s+yesterday)` ✓
  - `eod update please` → matches `(?i)eod\s+(update|report|summary)` ✓
- Excluded prompts also verified — `team standup for me` and `run the standup meeting` do **not** activate.
- `scripts/validate-use-cases.mjs` — untouched by this PR (skill lives outside `use-cases/`); pre-existing failures on `use-cases/youtube-video-recap-.../USE_CASE.md` are unrelated.

## Notes for reviewers

- Composability: `chief-of-staff` calls into this skill in compact mode. The skill does not call back — one-way dependency.
- Hard rules block enumerates the read-only, single-author, never-post scope so this skill cannot be repurposed to auto-post to Slack or roll up a team.
- The reference implementation is not shipped as a bin dependency; it exists to make the ranking logic reviewable and testable without an LLM.