### PR TITLE
Add use case: alert me when an Amazon item drops below my target price

### DIFF
--- a/use-cases/alert-me-when-an-amazon-item-drops-below-my-target-price/USE_CASE.md
+++ b/use-cases/alert-me-when-an-amazon-item-drops-below-my-target-price/USE_CASE.md
@@ -1,0 +1,40 @@
+### 1. Title
+
+Alert me when an Amazon item drops below my target price
+
+### 2. Example prompt
+
+"Track this Amazon listing for the Sony WH-1000XM5 and message me on Telegram the second it drops below $250 — and check every couple of hours during Prime Day so I don't miss it again."
+
+### 3. What the agent does
+
+The agent scrapes the product page with Firecrawl on a schedule you set, pulls the live price (including any coupon or "Prime deal" price), and compares it to your target. The moment the price is at or below your threshold, it sends a Telegram alert with the current price, how big the drop is versus the item's recent average, and a direct buy link. It keeps a small price-history log between runs, so it can flag "lowest in 30 days" and avoid pinging you on fake or trivial markdowns. During sale events like Prime Day it automatically bumps up the check frequency. It never buys anything for you — it just surfaces the deal so you decide.
+
+### 4. Skills & tools used
+
+- firecrawl — reliably scrapes JS-heavy Amazon product pages and returns clean, structured price data; generous free tier with no credit card required (https://www.firecrawl.dev, https://github.com/firecrawl/firecrawl-mcp-server)
+- scheduled-tasks — runs the price check on a cadence (daily, hourly, or every couple of hours during Prime Day)
+- telegram — delivers the price-drop alert straight to the user's phone (https://core.telegram.org/bots/api)
+- price-history-log — stores each check so the agent detects genuine drops (lowest/average over time) instead of reacting to noise
+
+### 5. Categories
+
+- [x] Personal assistant
+- [ ] Web 3 / Crypto
+- [ ] Coding / dev workflow
+- [ ] Research
+- [ ] Marketing / content
+- [ ] Business ops
+- [ ] Sales / CRM
+- [ ] Files / knowledge
+- [x] Automation
+- [ ] Design / media
+- [ ] Skill creation
+
+### 6. Source (optional)
+
+_No response_
+
+### 7. Author (optional)
+
+Halfblood


### PR DESCRIPTION
## Summary

Adds `use-cases/alert-me-when-an-amazon-item-drops-below-my-target-price/USE_CASE.md`: an agent that scrapes an Amazon product page with Firecrawl on a schedule, compares the live price against a user-set target, and sends a Telegram alert (with the discount vs. the item's recent average and a direct buy link) the moment it drops — automatically bumping the check frequency during sale events like Prime Day. It surfaces the deal but never buys, keeping the human in the loop.

## Closes

N/A — no tracking issue filed; proposing the use case directly.

## Type

- [x] Use case
- [ ] New tool
- [ ] New skill
- [ ] Bug fix
- [ ] Documentation / process
- [ ] Infrastructure

## Artifact checklist

Use case PRs:

- [x] Adds or updates `use-cases/<slug>/USE_CASE.md`
- [x] Uses the exact seven-section `USE_CASE.md` template
- [x] Uses strict skill/tool rows: `- name — description`
- [x] Selects at least one category
- [x] Passes `node scripts/validate-use-cases.mjs`

Skill PRs:

- [ ] Adds or updates `skills/<skill-name>/SKILL.md`
- [ ] Documents required tool dependencies
- [ ] Includes activation behavior in `SKILL.md`
- [ ] Tests at least one prompt that should activate the skill

Tool PRs:

- [ ] Adds or updates `tools/<tool-name>/README.md`
- [ ] Adds or updates `tools/<tool-name>/<tool-name>-tool.capabilities.json`
- [ ] Documents auth, scopes, limits, and target use cases
- [ ] Tests representative action calls and records the results below

Docs/process PRs:

- [ ] No `tracking.md` or README shipped-catalog change is needed
- [ ] Or, shipped catalog changes are reflected in both `tracking.md` and README

## Testing

List the commands or manual checks run. For tools, include action calls and returned behavior. For skills, include prompts tested and activation behavior. For use cases, include the validator result.
