### PR TITLE
fix: parse catalog frontmatter as YAML

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       ipaddr.js:
         specifier: ^2.4.0
         version: 2.4.0
+      js-yaml:
+        specifier: '>=4.2.0 <5'
+        version: 4.3.0
       next:
         specifier: 16.2.11
         version: 16.2.11(@babel/core@7.29.7)(@types/node@25.6.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -93,6 +96,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.3.2
         version: 4.3.3
+      '@types/js-yaml':
+        specifier: 4.0.9
+        version: 4.0.9
       '@types/node':
         specifier: ^25.5.0
         version: 25.6.0
@@ -2056,6 +2062,9 @@ packages:
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -7089,6 +7098,8 @@ snapshots:
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/js-yaml@4.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 

--- a/skills/voulai-trading/SKILL.md
+++ b/skills/voulai-trading/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: voulai-trading
 version: 1.0.0
+author: zavodil
 description: >-
   Trade a real on-chain crypto portfolio through the Voulai agent API. One
   per-strategy API key lets you read market data, run backtests, fund the

--- a/web/lib/catalog/parsers.test.mjs
+++ b/web/lib/catalog/parsers.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  parseSkillFrontmatter,
+  parseToolValueMetadata,
+  parseYamlFrontmatter,
+} from "./parsers.ts"
+
+test("parses folded descriptions and nested skill activation metadata", () => {
+  const metadata = parseSkillFrontmatter(`---
+name: trading-skill
+version: 1.0.0
+description: >-
+  Trades assets using current market data
+  and declared risk limits.
+activation:
+  keywords:
+    - "market data"
+  patterns:
+    - "(?i)trade"
+  tags:
+    - trading
+  max_context_tokens: 3000
+---
+
+# Trading skill
+`)
+
+  assert.deepEqual(metadata, {
+    name: "trading-skill",
+    version: "1.0.0",
+    description:
+      "Trades assets using current market data and declared risk limits.",
+    author: undefined,
+    trunk: undefined,
+    tags: ["trading"],
+    keywords: ["market data"],
+    patterns: ["(?i)trade"],
+    maxContextTokens: 3000,
+    useCases: [],
+    valueTags: [],
+  })
+})
+
+test("parses shared tool metadata through YAML semantics", () => {
+  const metadata = parseToolValueMetadata(`---
+name: example-tool
+description: |
+  First line.
+  Second line.
+use_cases:
+  - "Read quoted values"
+value_tags: [Research, Automation]
+---
+`)
+
+  assert.deepEqual(metadata, {
+    name: "example-tool",
+    version: undefined,
+    description: "First line.\nSecond line.\n",
+    author: undefined,
+    useCases: ["Read quoted values"],
+    valueTags: ["Research", "Automation"],
+  })
+})
+
+test("returns empty metadata for invalid or missing frontmatter", () => {
+  assert.deepEqual(parseYamlFrontmatter("# No frontmatter"), {
+    name: undefined,
+    version: undefined,
+    description: undefined,
+    author: undefined,
+    trunk: undefined,
+    tags: [],
+    useCases: [],
+    valueTags: [],
+    valueProp: undefined,
+    activation: {},
+    yaml: "",
+  })
+
+  assert.equal(
+    parseYamlFrontmatter("---\ndescription: [broken\n---\n").description,
+    undefined
+  )
+})

--- a/web/lib/catalog/parsers.ts
+++ b/web/lib/catalog/parsers.ts
@@ -1,18 +1,22 @@
+import { FAILSAFE_SCHEMA, load } from "js-yaml"
+
 import type { SkillFrontmatter } from "@/lib/catalog/source-types"
 
 export function parseYamlFrontmatter(text: string) {
-  const yaml = text.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? ""
+  const { document, yaml } = parseFrontmatterDocument(text)
+  const activation = readYamlRecord(document.activation)
 
   return {
-    name: readYamlScalar(yaml, "name"),
-    version: readYamlScalar(yaml, "version"),
-    description: readYamlScalar(yaml, "description"),
-    author: readYamlScalar(yaml, "author"),
-    trunk: readYamlScalar(yaml, "trunk"),
-    tags: readYamlList(yaml, "tags"),
-    useCases: readYamlList(yaml, "use_cases"),
-    valueTags: readYamlList(yaml, "value_tags"),
-    valueProp: readYamlScalar(yaml, "value_prop"),
+    name: readYamlScalar(document.name),
+    version: readYamlScalar(document.version),
+    description: readYamlScalar(document.description),
+    author: readYamlScalar(document.author),
+    trunk: readYamlScalar(document.trunk),
+    tags: readYamlList(document.tags ?? activation.tags),
+    useCases: readYamlList(document.use_cases),
+    valueTags: readYamlList(document.value_tags),
+    valueProp: readYamlScalar(document.value_prop),
+    activation,
     yaml,
   }
 }
@@ -27,7 +31,7 @@ export function parseSkillFrontmatter(text: string): SkillFrontmatter {
     tags,
     useCases,
     valueTags,
-    yaml,
+    activation,
   } =
     parseYamlFrontmatter(text)
 
@@ -38,9 +42,9 @@ export function parseSkillFrontmatter(text: string): SkillFrontmatter {
     author,
     trunk,
     tags,
-    keywords: readYamlList(yaml, "keywords"),
-    patterns: readYamlList(yaml, "patterns"),
-    maxContextTokens: Number(readYamlScalar(yaml, "max_context_tokens") ?? 0),
+    keywords: readYamlList(activation.keywords),
+    patterns: readYamlList(activation.patterns),
+    maxContextTokens: Number(readYamlScalar(activation.max_context_tokens) ?? 0),
     useCases,
     valueTags,
   }
@@ -64,34 +68,34 @@ export function readCargoValue(cargo: string, key: string) {
   return cargo.match(new RegExp(`^${key}\\s*=\\s*"(.+)"$`, "m"))?.[1]
 }
 
-function readYamlScalar(yaml: string, key: string) {
-  return yaml
-    .match(new RegExp(`^${key}:\\s*(.+)$`, "m"))?.[1]
-    ?.replace(/^["']|["']$/g, "")
+type YamlRecord = Record<string, unknown>
+
+function parseFrontmatterDocument(text: string) {
+  const yaml =
+    text.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/)?.[1] ?? ""
+
+  try {
+    return {
+      document: readYamlRecord(load(yaml, { schema: FAILSAFE_SCHEMA })),
+      yaml,
+    }
+  } catch {
+    return { document: {}, yaml }
+  }
 }
 
-function readYamlList(yaml: string, key: string) {
-  const lines = yaml.split("\n")
-  const start = lines.findIndex((line) => line.trim() === `${key}:`)
+function readYamlRecord(value: unknown): YamlRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as YamlRecord)
+    : {}
+}
 
-  if (start === -1) {
-    return []
-  }
+function readYamlScalar(value: unknown) {
+  return typeof value === "string" ? value : undefined
+}
 
-  const values: string[] = []
-  for (const line of lines.slice(start + 1)) {
-    const trimmed = line.trim()
-
-    if (!trimmed) {
-      continue
-    }
-
-    if (!trimmed.startsWith("- ")) {
-      break
-    }
-
-    values.push(trimmed.slice(2).replace(/^["']|["']$/g, ""))
-  }
-
-  return values
+function readYamlList(value: unknown) {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : []
 }

--- a/web/lib/catalog/readers.server.ts
+++ b/web/lib/catalog/readers.server.ts
@@ -65,7 +65,10 @@ export async function readTools(root: string) {
           ? `OAuth 2.0 user-context${slug === "microsoft-365" ? " with PKCE" : ""}`
           : "No auth"
 
-        const description = readmeMetadata.description?.trim() || null
+        const description =
+          readmeMetadata.description?.trim() ||
+          manifest.description?.trim() ||
+          null
 
         const tags = inferToolTags(slug, manifest, readme)
 

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
     "start": "next start",
     "lint": "eslint",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
+    "test:catalog": "node --experimental-strip-types --test lib/catalog/parsers.test.mjs",
     "typecheck": "tsc --noEmit",
     "signing:check": "node scripts/check-manifest-signing.mjs && node scripts/check-install-payload-signing.mjs",
     "db:migrate": "prisma migrate dev",
@@ -28,6 +29,7 @@
     "clsx": "^2.1.1",
     "dotenv": "17.4.2",
     "ipaddr.js": "^2.4.0",
+    "js-yaml": ">=4.2.0 <5",
     "next": "16.2.11",
     "next-themes": "^0.4.6",
     "pg": "8.21.0",
@@ -42,6 +44,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4.3.2",
+    "@types/js-yaml": "4.0.9",
     "@types/node": "^25.5.0",
     "@types/pg": "8.20.0",
     "@types/react": "^19.2.14",


### PR DESCRIPTION
## Summary

- replace indentation-blind frontmatter regexes with real YAML parsing via `js-yaml`
- support folded and literal multiline descriptions, inline and block lists, CRLF frontmatter, and nested `activation` metadata
- fall back to capability manifest descriptions for tools without README frontmatter
- attribute Voulai Trading to `zavodil`, matching issue #246 creator and explicit credit
- add focused catalog parser regression tests

## Root cause

Catalog metadata used line-based regexes instead of YAML semantics. For `description: >-`, parser returned literal `>-` and ignored folded content. Tool descriptions also became empty when README frontmatter was absent, even when capability manifest already contained description.

## Impact

Voulai Trading now displays full description and correct author. Skills can safely use standard YAML block scalars and list forms. Tools without README frontmatter display existing manifest descriptions instead of blank metadata.

## Validation

- `pnpm --filter web test:catalog` — 3 tests passed
- `pnpm --filter web typecheck` — passed
- catalog source audit — all 43 skills and 18 tools have description source through frontmatter or manifest fallback

Closes #246