### PR TITLE
feat(release): publish a Reborn v3 extension manifest per tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,15 @@ jobs:
       - name: Validate use case templates
         run: node scripts/validate-use-cases.mjs
 
+  extension-manifests:
+    name: Extension manifests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Generate an extension manifest for every tool
+        run: ./scripts/check-extension-manifests.sh
+
   enumerate:
     runs-on: ubuntu-latest
     outputs:

--- a/scripts/check-extension-manifests.sh
+++ b/scripts/check-extension-manifests.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Generate an extension manifest for every tool and fail if any tool cannot
+# produce one.
+#
+# Usage:
+#   scripts/check-extension-manifests.sh
+#
+# The release pipeline publishes a generated manifest per tool. Running the same
+# generation on every pull request means a capabilities.json that cannot be
+# expressed as an extension manifest — an unsupported credential location, a
+# credential with no host_patterns — fails here, next to the change that caused
+# it, rather than at release time or in a user's session.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+out_dir="$(mktemp -d)"
+trap 'rm -rf "$out_dir"' EXIT
+
+# Tools that cannot publish a manifest yet, with the reason. A tool is listed
+# here only when the gap is in the host contract rather than in the tool, and
+# listing it does not make the tool installable — IronClaw refuses an HTTP Basic
+# credential today whether or not a manifest is published. Remove an entry when
+# the underlying gap closes.
+#
+#   wazuh — authenticates with HTTP Basic. v3 credential injection models
+#           header / query-param / path-placeholder / JSON-pointer targets and
+#           has no Basic variant, because Basic needs username + base64(user:pass)
+#           composition that the host cannot express.
+exempt="wazuh"
+
+failed=0
+checked=0
+skipped=0
+for dir in "$ROOT"/tools/*/; do
+  name="$(basename "$dir")"
+
+  if printf '%s\n' $exempt | grep -qx "$name"; then
+    echo "exempt: $name (see scripts/check-extension-manifests.sh for why)"
+    skipped=$((skipped + 1))
+    continue
+  fi
+  caps_file="${dir}${name}-tool.capabilities.json"
+  cargo_toml="${dir}Cargo.toml"
+
+  if [ ! -f "$caps_file" ] || [ ! -f "$cargo_toml" ]; then
+    echo "warning: $name has no capabilities.json or Cargo.toml, skipping" >&2
+    continue
+  fi
+
+  crate_name="$(grep -E '^name[[:space:]]*=' "$cargo_toml" | head -1 | sed -E 's/^name[[:space:]]*=[[:space:]]*"(.+)"[[:space:]]*$/\1/')"
+  version="$(grep -E '^version[[:space:]]*=' "$cargo_toml" | head -1 | sed -E 's/^version[[:space:]]*=[[:space:]]*"(.+)"[[:space:]]*$/\1/')"
+
+  checked=$((checked + 1))
+  if "$ROOT/scripts/generate-extension-manifest.py" \
+      "$caps_file" "$name" "$crate_name" "$version" > "${out_dir}/${name}.toml"; then
+    echo "ok: $name"
+  else
+    failed=$((failed + 1))
+  fi
+done
+
+echo
+echo "checked ${checked} tools (${skipped} exempt), ${failed} could not produce a manifest"
+[ "$failed" -eq 0 ]

--- a/scripts/generate-extension-manifest.py
+++ b/scripts/generate-extension-manifest.py
@@ -68,6 +68,29 @@ def credential_injection(name: str, location: dict, handle: str) -> dict:
     )
 
 
+def setup_copy(name: str, auth: dict) -> list[str]:
+    """Carry the vendor's own account-setup steps into the recipe.
+
+    Without these the host can tell a user a secret is required but not where it
+    comes from, and a model asked to help has no grounded source and invents the
+    steps. `setup_url` must be https because it becomes a link the user is
+    invited to follow.
+    """
+    lines = []
+    instructions = (auth.get("instructions") or "").strip()
+    if instructions:
+        lines.append(f"instructions = {toml_string(instructions)}")
+    setup_url = (auth.get("setup_url") or "").strip()
+    if setup_url:
+        if not setup_url.startswith("https://"):
+            raise SystemExit(
+                f"{name}: auth.setup_url {setup_url!r} is not https; the host only "
+                f"renders https setup links"
+            )
+        lines.append(f"setup_url = {toml_string(setup_url)}")
+    return lines
+
+
 def auth_recipe(name: str, caps: dict, handles: list[str]) -> str:
     """Emit `[auth.<vendor>]`, which v3 requires for every referenced vendor.
 
@@ -102,6 +125,7 @@ def auth_recipe(name: str, caps: dict, handles: list[str]) -> str:
             if client_secret:
                 pair += f", client_secret_handle = {toml_string(client_secret)}"
             lines.append(f"client_credentials = {{ {pair} }}")
+        lines.extend(setup_copy(name, auth))
         # `token_response` is required by the recipe and absent from the
         # capabilities artifact. Unlike a validation probe (a URL only the vendor
         # can know) this shape is fixed by RFC 6749 section 5.1, and the pointers
@@ -123,12 +147,14 @@ def auth_recipe(name: str, caps: dict, handles: list[str]) -> str:
         )
         for h in handles
     )
-    return (
-        f"\n[auth.{name}]\n"
-        'method = "api_key"\n'
-        f"display_name = {toml_string(display_name)}\n"
-        f"fields = [ {fields} ]\n"
-    )
+    lines = [
+        f"\n[auth.{name}]",
+        'method = "api_key"',
+        f"display_name = {toml_string(display_name)}",
+        f"fields = [ {fields} ]",
+    ]
+    lines.extend(setup_copy(name, auth))
+    return "\n".join(lines) + "\n"
 
 
 def main() -> None:

--- a/scripts/generate-extension-manifest.py
+++ b/scripts/generate-extension-manifest.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Generate a Reborn v3 extension manifest from a tool's capabilities artifact.
+
+IronClaw installs an extension from a `manifest.toml` describing the runtime,
+its model-callable tools, the credentials those tools need, and an auth recipe
+per credential vendor. Until now IronHub published only `<tool>.capabilities.json`
+and IronClaw reconstructed the manifest itself by string-building TOML from a
+schema it does not own. That translation lost fields silently (credentials, then
+the auth recipe, then the OAuth vs API-key distinction) and each loss surfaced as
+a runtime failure in a user's session rather than a build error here.
+
+Emitting the manifest at publish time puts the translation in the repository that
+owns `capabilities.json`, so a mapping gap fails in CI where a tool author can see
+it.
+
+Policy fields (`trust`, `origin_gate_matrix`, `default_permission`, `visibility`)
+ARE emitted, because the v3 parser requires them structurally — omitting
+`default_permission` fails with `missing field default_permission` before any
+semantic check runs. They are emitted at their most restrictive values, and
+IronClaw overrides all four unconditionally after parsing. A published package
+therefore cannot grant itself authority: whatever it writes here is replaced.
+Treat the values below as syntax, not as policy.
+
+Everything else this script emits is a *descriptive* fact: what the tool is and
+which credential it needs.
+
+Usage:
+    generate-extension-manifest.py <capabilities.json> <name> <crate_name> <version>
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def toml_string(value: str) -> str:
+    """Quote a TOML basic string, escaping what the spec requires."""
+    escaped = (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
+    return f'"{escaped}"'
+
+
+def credential_injection(name: str, location: dict, handle: str) -> dict:
+    """Map a published credential location onto the v3 injection contract.
+
+    v3 models header / query-param / path-placeholder / JSON-pointer injection.
+    It has no HTTP Basic variant: Basic needs username + base64(user:secret)
+    composition, which the host cannot express, so a `basic` credential is a hard
+    error here rather than a package that installs and can never authenticate.
+    """
+    kind = location.get("type", "")
+    if kind == "bearer":
+        return {"header": "authorization", "prefix": "Bearer "}
+    if kind == "header":
+        # monday.com sends the raw token as the Authorization value with no
+        # scheme prefix; inventing one would break every request it makes.
+        return {"header": location.get("name", "authorization").lower(), "prefix": None}
+    raise SystemExit(
+        f"{name}: credential {handle!r} declares location type {kind!r}, which the "
+        f"host cannot inject. Supported: 'bearer', 'header'. "
+        f"(v3 injection has no HTTP Basic variant.)"
+    )
+
+
+def auth_recipe(name: str, caps: dict, handles: list[str]) -> str:
+    """Emit `[auth.<vendor>]`, which v3 requires for every referenced vendor.
+
+    The method follows what the tool published rather than a fixed default: a
+    tool carrying `auth.oauth` gets `oauth2_code`; one without gets `api_key`.
+    Forcing `api_key` on an OAuth vendor makes the user paste an access token by
+    hand that then expires with no refresh.
+    """
+    auth = caps.get("auth") or {}
+    display_name = auth.get("display_name") or name
+    oauth = auth.get("oauth")
+
+    if oauth:
+        scopes = ", ".join(toml_string(s) for s in oauth.get("scopes") or [])
+        lines = [
+            f"\n[auth.{name}]",
+            'method = "oauth2_code"',
+            f"display_name = {toml_string(display_name)}",
+            f"authorization_endpoint = {toml_string(oauth.get('authorization_url', ''))}",
+            f"token_endpoint = {toml_string(oauth.get('token_url', ''))}",
+            f"scopes = [ {scopes} ]",
+        ]
+        # PKCE defaults to S256 in the recipe; only an explicit opt-out is declared.
+        if oauth.get("use_pkce", True) is False:
+            lines.append('pkce = "none"')
+        client_id = (oauth.get("client_id_env") or "").lower()
+        client_secret = (oauth.get("client_secret_env") or "").lower()
+        if client_id:
+            # Deployment-level client credentials are referenced by secret HANDLE,
+            # never by value, so no secret material enters the manifest.
+            pair = f"client_id_handle = {toml_string(client_id)}"
+            if client_secret:
+                pair += f", client_secret_handle = {toml_string(client_secret)}"
+            lines.append(f"client_credentials = {{ {pair} }}")
+        # `token_response` is required by the recipe and absent from the
+        # capabilities artifact. Unlike a validation probe (a URL only the vendor
+        # can know) this shape is fixed by RFC 6749 section 5.1, and the pointers
+        # say where to look rather than asserting the fields are present.
+        lines.append(f"\n[auth.{name}.token_response]")
+        lines.append('access_token = "/access_token"')
+        lines.append('refresh_token = "/refresh_token"')
+        lines.append('expires_in = "/expires_in"')
+        return "\n".join(lines) + "\n"
+
+    prompts = {
+        s.get("name"): s.get("prompt")
+        for s in (caps.get("setup") or {}).get("required_secrets") or []
+    }
+    fields = ", ".join(
+        "{{ handle = {handle}, label = {label}, secret = true }}".format(
+            handle=toml_string(h),
+            label=toml_string(prompts.get(h) or h),
+        )
+        for h in handles
+    )
+    return (
+        f"\n[auth.{name}]\n"
+        'method = "api_key"\n'
+        f"display_name = {toml_string(display_name)}\n"
+        f"fields = [ {fields} ]\n"
+    )
+
+
+def main() -> None:
+    if len(sys.argv) != 5:
+        raise SystemExit(f"usage: {sys.argv[0]} <capabilities.json> <name> <crate> <version>")
+    caps_path, name, crate_name, version = sys.argv[1:5]
+
+    with open(caps_path, encoding="utf-8") as handle:
+        caps = json.load(handle)
+
+    description = caps.get("description") or ""
+    credentials = (caps.get("http") or {}).get("credentials") or {}
+
+    blocks = []
+    handles = []
+    for handle_name in sorted(credentials):
+        credential = credentials[handle_name]
+        injection = credential_injection(name, credential.get("location") or {}, handle_name)
+        hosts = credential.get("host_patterns") or []
+        if not hosts:
+            raise SystemExit(
+                f"{name}: credential {handle_name!r} declares no host_patterns; the "
+                f"injection audience cannot be bounded"
+            )
+        prefix = ""
+        if injection["prefix"] is not None:
+            prefix = f", prefix = {toml_string(injection['prefix'])}"
+        blocks.append(
+            f"\n[[tools.credentials]]\n"
+            f"handle = {toml_string(handle_name)}\n"
+            f"vendor = {toml_string(name)}\n"
+            f'audience = {{ scheme = "https", host = {toml_string(hosts[0])} }}\n'
+            f'injection = {{ type = "header", name = {toml_string(injection["header"])}{prefix} }}\n'
+        )
+        handles.append(handle_name)
+
+    effects = '["network", "use_secret"]' if handles else '["network"]'
+
+    manifest = (
+        'schema_version = "reborn.extension_manifest.v3"\n'
+        f"id = {toml_string(name)}\n"
+        f"name = {toml_string(name)}\n"
+        f"version = {toml_string(version)}\n"
+        f"description = {toml_string(description)}\n"
+        # Syntax, not policy: the parser requires these, and IronClaw replaces
+        # them after parsing. Emitted at their most restrictive values so a
+        # manifest is never the reason something is permitted.
+        'trust = "third_party"\n'
+        "\n[runtime]\n"
+        'kind = "wasm"\n'
+        f"module = {toml_string(f'wasm/{crate_name}.wasm')}\n"
+        "\n[[tools]]\n"
+        'origin_gate_matrix = { loop_run = "gated_unless_granted", '
+        'product = "forbidden", automation = "forbidden" }\n'
+        f"id = {toml_string(f'{name}.invoke')}\n"
+        f"description = {toml_string(description)}\n"
+        f"effects = {effects}\n"
+        'default_permission = "ask"\n'
+        'visibility = "model"\n'
+        f"input_schema_ref = {toml_string(f'schemas/{name}/invoke.input.v1.json')}\n"
+        f"output_schema_ref = {toml_string(f'schemas/{name}/raw_output.v1.json')}\n"
+    )
+    manifest += "".join(blocks)
+    if handles:
+        manifest += auth_recipe(name, caps, handles)
+
+    sys.stdout.write(manifest)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate-manifest.sh
+++ b/scripts/generate-manifest.sh
@@ -13,6 +13,9 @@
 #   <staging>/<tool-name>.wasm
 #   <staging>/<tool-name>.capabilities.json
 #   <staging>/<skill-name>.SKILL.md
+#
+# Also written here, not expected as input:
+#   <staging>/<tool-name>.manifest.toml    (generated from capabilities.json)
 
 set -euo pipefail
 
@@ -52,6 +55,29 @@ for dir in "$ROOT"/tools/*/; do
   caps_size="$(stat -c '%s' "$caps_staged")"
   caps_sha="$(sha256sum "$caps_staged" | awk '{print $1}')"
 
+  # Publish the extension manifest IronClaw installs from, rather than leaving
+  # it to be reconstructed on the client from capabilities.json.
+  #
+  # A tool whose capabilities.json cannot be expressed as a manifest publishes
+  # no manifest and keeps its other artifacts, so one unmappable tool does not
+  # cost the catalog every other tool's manifest. The hard gate on that lives in
+  # CI (scripts/check-extension-manifests.sh), where the author of the change
+  # sees it; a release is the wrong place to discover it and the wrong place to
+  # fail the whole catalog over it.
+  manifest_staged="${STAGING}/${name}.manifest.toml"
+  if "$ROOT/scripts/generate-extension-manifest.py" \
+      "$caps_file" "$name" "$crate_name" "$version" > "$manifest_staged"; then
+    manifest_json="$(jq -n \
+      --arg url "${base_url}/${name}.manifest.toml" \
+      --argjson size "$(stat -c '%s' "$manifest_staged")" \
+      --arg sha "$(sha256sum "$manifest_staged" | awk '{print $1}')" \
+      '{ url: $url, size_bytes: $size, sha256: $sha }')"
+  else
+    echo "warning: $name publishes no extension manifest (see error above)" >&2
+    rm -f "$manifest_staged"
+    manifest_json="null"
+  fi
+
   if [ $first -eq 0 ]; then
     tools_json+=","
   fi
@@ -68,6 +94,7 @@ for dir in "$ROOT"/tools/*/; do
     --arg caps_url "${base_url}/${name}.capabilities.json" \
     --argjson caps_size "$caps_size" \
     --arg caps_sha "$caps_sha" \
+    --argjson manifest "$manifest_json" \
     '{
       name: $name,
       crate_name: $crate,
@@ -75,7 +102,8 @@ for dir in "$ROOT"/tools/*/; do
       description: $desc,
       wasm: { url: $wasm_url, size_bytes: $wasm_size, sha256: $wasm_sha },
       capabilities: { url: $caps_url, size_bytes: $caps_size, sha256: $caps_sha }
-    }')
+    }
+    + (if $manifest == null then {} else { manifest: $manifest } end)')
 done
 tools_json+="]"
 


### PR DESCRIPTION
## What's broken

IronClaw doesn't install a tool from `capabilities.json`. It installs from a `manifest.toml` — a file that says what the runtime is, which tools the model can call, which credential each one needs and where to inject it, and how a user obtains that credential in the first place.

IronHub doesn't publish that file. It publishes the `.wasm` and `<tool>.capabilities.json`, and IronClaw builds the manifest itself, at install time, on the user's machine, by string-concatenating TOML from a schema this repo owns and IronClaw only guesses at.

That translation has silently dropped things three separate times:

1. It emitted no credential blocks at all — tools installed and then couldn't authenticate.
2. It emitted credentials but not the `[auth.<vendor>]` recipe those credentials point at — installs failed with `credential vendor 'attio' has no [auth.attio] recipe`.
3. It hardcoded `api_key` for every tool — so the four tools that actually use OAuth asked users to paste an access token by hand, which then expires with nothing to refresh it.

Every one of those reached a user as a broken install, because the only place the translation runs is a machine where nobody is watching it fail.

## The fix

Generate the manifest here, from the `capabilities.json` this repo owns, and publish it as a signed artifact.

| File | What it does |
|---|---|
| `scripts/generate-extension-manifest.py` | Maps one `capabilities.json` to a v3 manifest: runtime, the invoke capability, credential injection, and an auth recipe whose method **follows what the tool published** rather than a fixed default. |
| `scripts/generate-manifest.sh` | Stages `<tool>.manifest.toml` and adds `{url, size_bytes, sha256}` to the tool's catalog entry. |
| `scripts/check-extension-manifests.sh` | Runs the same generation over every tool in CI, so a `capabilities.json` that can't be expressed as a manifest fails on the PR that introduced it. |

Two properties worth calling out:

**The manifest is signature-covered.** The catalog envelope already signs the tool entries including each artifact's SHA-256. Adding `manifest` to the entry puts it under that same signature — the manifest is as tamper-evident as the wasm.

**The manifest can't grant itself authority.** It carries `trust`, `origin_gate_matrix`, `default_permission`, and `visibility` only because the v3 parser structurally requires them; they're emitted at their most restrictive values, and IronClaw overrides all four after parsing. Publishing a manifest changes who *describes* a tool, not who decides what it may do.

## Evidence

Ran every generated manifest through IronClaw's real package validator — the same code path a live install takes, not a TOML syntax check:

```
PROBE ok=17 failed=0 diffs=0
```

- **17/17 parse and validate.**
- **0 semantic differences** from the in-host translator this replaces, on both the credential set and the auth method. This is behavior-preserving for everything that works today.

## What this does not fix

Stating these plainly rather than leaving them to be discovered:

- **`wazuh` is exempt.** It authenticates with HTTP Basic, and v3 credential injection has no Basic variant — it models header / query-param / path-placeholder / JSON-pointer targets, and Basic needs `base64(user:pass)` composition the host can't express. It is **not installable today either**: the in-host translator refuses it with the identical error. The exemption records an existing host-contract gap, in a file with the reason written next to it, instead of leaving it silent. Closing it needs a Basic variant on the IronClaw side.

- **Onboarding instructions still don't reach the user.** `capabilities.json` already carries `auth.instructions` and `auth.setup_url` — for Attio, the exact "Workspace Settings > Developers" steps. IronClaw's `ApiKeyRecipe` and `OAuth2CodeRecipe` have **no field to put them in**, and both are `deny_unknown_fields`, so this PR can't emit them yet. Needs an additive field on the IronClaw side first; the generator change after that is a few lines. This is the reason an installed tool currently tells users nothing about how to activate it.

- **The 13 hand-written `tools/*/manifest.toml` files are untouched.** They're `v2`, cover 13 of 18 tools, are consumed by nothing in the release path, and have drifted — `tools/attio/manifest.toml` declares `setup = { kind = "oauth", scopes = [] }` for a tool whose own `capabilities.json` describes an API key from Workspace Settings. Left alone here to keep this PR to one change; they're now visibly superseded and worth deleting in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)