### PR TITLE
Harden extension manifest generation and carry it into the catalog

### DIFF
--- a/scripts/check-extension-manifests.sh
+++ b/scripts/check-extension-manifests.sh
@@ -45,7 +45,8 @@ for dir in "$ROOT"/tools/*/; do
   cargo_toml="${dir}Cargo.toml"
 
   if [ ! -f "$caps_file" ] || [ ! -f "$cargo_toml" ]; then
-    echo "warning: $name has no capabilities.json or Cargo.toml, skipping" >&2
+    echo "error: $name has no capabilities.json or Cargo.toml" >&2
+    failed=$((failed + 1))
     continue
   fi
 

--- a/scripts/generate-extension-manifest.py
+++ b/scripts/generate-extension-manifest.py
@@ -34,16 +34,35 @@ import json
 import sys
 
 
+TOML_ESCAPES = {
+    "\\": "\\\\",
+    '"': '\\"',
+    "\b": "\\b",
+    "\t": "\\t",
+    "\n": "\\n",
+    "\f": "\\f",
+    "\r": "\\r",
+}
+
+
 def toml_string(value: str) -> str:
-    """Quote a TOML basic string, escaping what the spec requires."""
-    escaped = (
-        value.replace("\\", "\\\\")
-        .replace('"', '\\"')
-        .replace("\n", "\\n")
-        .replace("\r", "\\r")
-        .replace("\t", "\\t")
-    )
-    return f'"{escaped}"'
+    """Quote a TOML basic string, escaping what the spec requires.
+
+    A basic string may not carry a raw control character, so anything in that
+    range without a named escape is emitted as \\uXXXX. Escaping only the five
+    common ones leaves a description containing, say, a form feed to produce a
+    manifest that fails to parse at install time rather than here.
+    """
+    out = []
+    for char in value:
+        escape = TOML_ESCAPES.get(char)
+        if escape is not None:
+            out.append(escape)
+        elif char < " " or char == "\x7f":
+            out.append(f"\\u{ord(char):04X}")
+        else:
+            out.append(char)
+    return '"{}"'.format("".join(out))
 
 
 def credential_injection(name: str, location: dict, handle: str) -> dict:

--- a/web/lib/catalog/manifest-types.ts
+++ b/web/lib/catalog/manifest-types.ts
@@ -19,6 +19,7 @@ export type HubToolEntry = {
   provenance: Provenance
   wasm: HubArtifact
   capabilities: HubArtifact
+  manifest?: HubArtifact
 }
 
 export type HubSkillEntry = {

--- a/web/lib/catalog/manifest.server.ts
+++ b/web/lib/catalog/manifest.server.ts
@@ -54,6 +54,7 @@ type GithubTool = {
   description?: string | null
   wasm: GithubArtifact
   capabilities: GithubArtifact
+  manifest?: GithubArtifact | null
 }
 type GithubSkill = {
   name: string
@@ -130,6 +131,9 @@ async function fetchOfficialManifest(): Promise<{
     provenance: "official" as const,
     wasm: rewriteGithubArtifact(tool.wasm),
     capabilities: rewriteGithubArtifact(tool.capabilities),
+    ...(tool.manifest
+      ? { manifest: rewriteGithubArtifact(tool.manifest) }
+      : {}),
   }))
   const skills = (manifest.skills ?? []).map((skill) => ({
     name: skill.name,


### PR DESCRIPTION
Escapes the full control range when quoting TOML strings, and fails the check
when a tool is missing its capabilities.json instead of warning and passing.
Also carries the published manifest artifact into the served catalog, which was
rebuilt from the release with an explicit field list that dropped it, so no
client saw it.