### PR TITLE
fix: preserve HTTP authority in v3 extension manifests

### DIFF
--- a/scripts/check-extension-manifests.sh
+++ b/scripts/check-extension-manifests.sh
@@ -18,17 +18,28 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 out_dir="$(mktemp -d)"
 trap 'rm -rf "$out_dir"' EXIT
 
+# Run semantic regression coverage before checking that every real tool can be
+# generated. A syntactically valid manifest is still unusable if translation
+# dropped its network targets or credentials.
+PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover \
+  -s "$ROOT/scripts" \
+  -p 'test_generate_extension_manifest.py'
+
 # Tools that cannot publish a manifest yet, with the reason. A tool is listed
 # here only when the gap is in the host contract rather than in the tool, and
 # listing it does not make the tool installable — IronClaw refuses an HTTP Basic
 # credential today whether or not a manifest is published. Remove an entry when
 # the underlying gap closes.
 #
-#   wazuh — authenticates with HTTP Basic. v3 credential injection models
-#           header / query-param / path-placeholder / JSON-pointer targets and
-#           has no Basic variant, because Basic needs username + base64(user:pass)
-#           composition that the host cannot express.
-exempt="wazuh"
+#   wazuh     — authenticates with HTTP Basic. v3 credential injection models
+#               header / query-param / path-placeholder / JSON-pointer targets
+#               and has no Basic variant, because Basic needs username +
+#               base64(user:pass) composition that the host cannot express.
+#   wordpress — supports alternative WordPress Basic and WooCommerce query-param
+#               credentials on one tool. Query-param injection is expressible,
+#               but the Basic alternative is not; dropping it would publish a
+#               partially working manifest.
+exempt="wazuh wordpress"
 
 failed=0
 checked=0

--- a/scripts/generate-extension-manifest.py
+++ b/scripts/generate-extension-manifest.py
@@ -22,7 +22,7 @@ therefore cannot grant itself authority: whatever it writes here is replaced.
 Treat the values below as syntax, not as policy.
 
 Everything else this script emits is a *descriptive* fact: what the tool is and
-which credential it needs.
+which network targets and credentials it needs.
 
 Usage:
     generate-extension-manifest.py <capabilities.json> <name> <crate_name> <version>
@@ -73,18 +73,96 @@ def credential_injection(name: str, location: dict, handle: str) -> dict:
     composition, which the host cannot express, so a `basic` credential is a hard
     error here rather than a package that installs and can never authenticate.
     """
+    if not isinstance(location, dict):
+        raise SystemExit(f"{name}: credential {handle!r} location must be an object")
     kind = location.get("type", "")
     if kind == "bearer":
-        return {"header": "authorization", "prefix": "Bearer "}
+        return {
+            "type": "header",
+            "name": "authorization",
+            "prefix": "Bearer ",
+        }
     if kind == "header":
         # monday.com sends the raw token as the Authorization value with no
         # scheme prefix; inventing one would break every request it makes.
-        return {"header": location.get("name", "authorization").lower(), "prefix": None}
+        header = location.get("name", "authorization")
+        if not isinstance(header, str) or not header.strip():
+            raise SystemExit(
+                f"{name}: credential {handle!r} declares a header location "
+                f"without a name"
+            )
+        return {
+            "type": "header",
+            "name": header.strip().lower(),
+            "prefix": None,
+        }
+    if kind == "query_param":
+        parameter = location.get("name")
+        if not isinstance(parameter, str) or not parameter.strip():
+            raise SystemExit(
+                f"{name}: credential {handle!r} declares a query_param location "
+                f"without a name"
+            )
+        return {"type": "query_param", "name": parameter.strip()}
     raise SystemExit(
         f"{name}: credential {handle!r} declares location type {kind!r}, which the "
-        f"host cannot inject. Supported: 'bearer', 'header'. "
+        f"host cannot inject. Supported: 'bearer', 'header', 'query_param'. "
         f"(v3 injection has no HTTP Basic variant.)"
     )
+
+
+def http_capability(name: str, caps: dict) -> dict:
+    """Return the HTTP capability without silently choosing between schemas.
+
+    Most tools publish `http` at the document root. Newer component-model tools
+    publish it under `capabilities.http`. Both are supported, but declaring both
+    is ambiguous and must be resolved by the tool author rather than by a
+    precedence rule here.
+    """
+    root_http = caps.get("http") if "http" in caps else None
+    capabilities = caps.get("capabilities")
+    if capabilities is not None and not isinstance(capabilities, dict):
+        raise SystemExit(f"{name}: capabilities must be an object")
+    nested_http = (
+        capabilities.get("http")
+        if isinstance(capabilities, dict) and "http" in capabilities
+        else None
+    )
+
+    if root_http is not None and nested_http is not None:
+        raise SystemExit(
+            f"{name}: HTTP capability is declared in both 'http' and "
+            f"'capabilities.http'; keep exactly one representation"
+        )
+    http = root_http if root_http is not None else nested_http
+    if http is None:
+        raise SystemExit(
+            f"{name}: no HTTP capability found at 'http' or 'capabilities.http'"
+        )
+    if not isinstance(http, dict):
+        raise SystemExit(f"{name}: HTTP capability must be an object")
+    return http
+
+
+def network_hosts(name: str, http: dict) -> list[str]:
+    """Return each allowlisted host once, preserving declaration order."""
+    allowlist = http.get("allowlist")
+    if not isinstance(allowlist, list) or not allowlist:
+        raise SystemExit(f"{name}: HTTP capability must declare a non-empty allowlist")
+
+    hosts = []
+    for index, entry in enumerate(allowlist):
+        if not isinstance(entry, dict):
+            raise SystemExit(f"{name}: HTTP allowlist entry {index} must be an object")
+        host = entry.get("host")
+        if not isinstance(host, str) or not host.strip():
+            raise SystemExit(
+                f"{name}: HTTP allowlist entry {index} must declare a non-empty host"
+            )
+        host = host.strip()
+        if host not in hosts:
+            hosts.append(host)
+    return hosts
 
 
 def setup_copy(name: str, auth: dict) -> list[str]:
@@ -176,41 +254,77 @@ def auth_recipe(name: str, caps: dict, handles: list[str]) -> str:
     return "\n".join(lines) + "\n"
 
 
-def main() -> None:
-    if len(sys.argv) != 5:
-        raise SystemExit(f"usage: {sys.argv[0]} <capabilities.json> <name> <crate> <version>")
-    caps_path, name, crate_name, version = sys.argv[1:5]
-
-    with open(caps_path, encoding="utf-8") as handle:
-        caps = json.load(handle)
-
+def generate_manifest(caps: dict, name: str, crate_name: str, version: str) -> str:
+    """Translate a capabilities document into a complete v3 manifest."""
     description = caps.get("description") or ""
-    credentials = (caps.get("http") or {}).get("credentials") or {}
+    http = http_capability(name, caps)
+    hosts = network_hosts(name, http)
+    credentials = http.get("credentials") or {}
+    if not isinstance(credentials, dict):
+        raise SystemExit(f"{name}: HTTP credentials must be an object")
 
     blocks = []
     handles = []
     for handle_name in sorted(credentials):
         credential = credentials[handle_name]
+        if not isinstance(credential, dict):
+            raise SystemExit(f"{name}: credential {handle_name!r} must be an object")
         injection = credential_injection(name, credential.get("location") or {}, handle_name)
-        hosts = credential.get("host_patterns") or []
-        if not hosts:
+        credential_hosts = credential.get("host_patterns") or []
+        if not isinstance(credential_hosts, list) or not credential_hosts:
             raise SystemExit(
                 f"{name}: credential {handle_name!r} declares no host_patterns; the "
                 f"injection audience cannot be bounded"
             )
-        prefix = ""
-        if injection["prefix"] is not None:
-            prefix = f", prefix = {toml_string(injection['prefix'])}"
+        if len(credential_hosts) != 1:
+            raise SystemExit(
+                f"{name}: credential {handle_name!r} declares {len(credential_hosts)} "
+                f"host_patterns, but a v3 credential has one audience; split the "
+                f"credential or extend the v3 contract instead of dropping hosts"
+            )
+        credential_host = credential_hosts[0]
+        if not isinstance(credential_host, str) or not credential_host.strip():
+            raise SystemExit(
+                f"{name}: credential {handle_name!r} declares an invalid host_pattern"
+            )
+        credential_host = credential_host.strip()
+        if credential_host not in hosts:
+            raise SystemExit(
+                f"{name}: credential {handle_name!r} targets {credential_host!r}, "
+                f"which is absent from the HTTP allowlist"
+            )
+        optional = credential.get("optional", False)
+        if not isinstance(optional, bool):
+            raise SystemExit(
+                f"{name}: credential {handle_name!r} optional must be a boolean"
+            )
+        if injection["type"] == "header":
+            prefix = ""
+            if injection["prefix"] is not None:
+                prefix = f", prefix = {toml_string(injection['prefix'])}"
+            injection_toml = (
+                f'{{ type = "header", name = {toml_string(injection["name"])}'
+                f"{prefix} }}"
+            )
+        else:
+            injection_toml = (
+                f'{{ type = "query_param", name = {toml_string(injection["name"])} }}'
+            )
         blocks.append(
             f"\n[[tools.credentials]]\n"
             f"handle = {toml_string(handle_name)}\n"
             f"vendor = {toml_string(name)}\n"
-            f'audience = {{ scheme = "https", host = {toml_string(hosts[0])} }}\n'
-            f'injection = {{ type = "header", name = {toml_string(injection["header"])}{prefix} }}\n'
+            f'audience = {{ scheme = "https", host = {toml_string(credential_host)} }}\n'
+            f"injection = {injection_toml}\n"
+            f"required = {'false' if optional else 'true'}\n"
         )
         handles.append(handle_name)
 
     effects = '["network", "use_secret"]' if handles else '["network"]'
+    targets = ", ".join(
+        f'{{ scheme = "https", host_pattern = {toml_string(host)} }}'
+        for host in hosts
+    )
 
     manifest = (
         'schema_version = "reborn.extension_manifest.v3"\n'
@@ -231,6 +345,7 @@ def main() -> None:
         f"id = {toml_string(f'{name}.invoke')}\n"
         f"description = {toml_string(description)}\n"
         f"effects = {effects}\n"
+        f"network_targets = [ {targets} ]\n"
         'default_permission = "ask"\n'
         'visibility = "model"\n'
         f"input_schema_ref = {toml_string(f'schemas/{name}/invoke.input.v1.json')}\n"
@@ -240,6 +355,18 @@ def main() -> None:
     if handles:
         manifest += auth_recipe(name, caps, handles)
 
+    return manifest
+
+
+def main() -> None:
+    if len(sys.argv) != 5:
+        raise SystemExit(f"usage: {sys.argv[0]} <capabilities.json> <name> <crate> <version>")
+    caps_path, name, crate_name, version = sys.argv[1:5]
+
+    with open(caps_path, encoding="utf-8") as handle:
+        caps = json.load(handle)
+
+    manifest = generate_manifest(caps, name, crate_name, version)
     sys.stdout.write(manifest)
 
 

--- a/scripts/test_generate_extension_manifest.py
+++ b/scripts/test_generate_extension_manifest.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Regression tests for capabilities.json -> Reborn v3 translation."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import re
+import unittest
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.9/3.10 can still run the core checks.
+    tomllib = None
+
+
+ROOT = Path(__file__).resolve().parent.parent
+GENERATOR_PATH = ROOT / "scripts" / "generate-extension-manifest.py"
+SPEC = importlib.util.spec_from_file_location("extension_manifest_generator", GENERATOR_PATH)
+GENERATOR = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(GENERATOR)
+
+# Wazuh and WordPress use HTTP Basic, which the v3 injection contract cannot
+# express. The production check carries the same documented exemptions.
+EXEMPT_TOOLS = {"wazuh", "wordpress"}
+
+
+def source_http(caps: dict) -> dict:
+    """Read either supported source shape independently of the generator."""
+    if "http" in caps:
+        return caps["http"]
+    return caps["capabilities"]["http"]
+
+
+def expected_hosts(caps: dict) -> list[str]:
+    return list(
+        dict.fromkeys(
+            entry["host"].strip() for entry in source_http(caps)["allowlist"]
+        )
+    )
+
+
+class ExtensionManifestTranslationTests(unittest.TestCase):
+    def generated_tool(self, tool_name: str) -> tuple[dict, str]:
+        tool_dir = ROOT / "tools" / tool_name
+        with (tool_dir / f"{tool_name}-tool.capabilities.json").open(
+            encoding="utf-8"
+        ) as handle:
+            caps = json.load(handle)
+        cargo_toml = (tool_dir / "Cargo.toml").read_text(encoding="utf-8")
+        crate_name = re.search(r'^name\s*=\s*"([^"]+)"', cargo_toml, re.MULTILINE)
+        version = re.search(r'^version\s*=\s*"([^"]+)"', cargo_toml, re.MULTILINE)
+        self.assertIsNotNone(crate_name)
+        self.assertIsNotNone(version)
+
+        manifest = GENERATOR.generate_manifest(
+            caps,
+            tool_name,
+            crate_name.group(1),
+            version.group(1),
+        )
+        self.assertEqual(manifest.count("[[tools]]"), 1)
+        return caps, manifest
+
+    def test_every_supported_tool_preserves_http_authority(self) -> None:
+        """Every source host and credential must survive into the v3 manifest."""
+        for tool_dir in sorted((ROOT / "tools").iterdir()):
+            if not tool_dir.is_dir() or tool_dir.name in EXEMPT_TOOLS:
+                continue
+            with self.subTest(tool=tool_dir.name):
+                caps, manifest = self.generated_tool(tool_dir.name)
+                expected_credentials = sorted(
+                    (source_http(caps).get("credentials") or {}).keys()
+                )
+
+                self.assertEqual(
+                    re.findall(r'host_pattern = "([^"]+)"', manifest),
+                    expected_hosts(caps),
+                )
+                self.assertEqual(
+                    re.findall(r'^handle = "([^"]+)"$', manifest, re.MULTILINE),
+                    expected_credentials,
+                )
+                effects = re.search(r"^effects = (.+)$", manifest, re.MULTILINE)
+                self.assertIsNotNone(effects)
+                self.assertIn('"network"', effects.group(1))
+                self.assertEqual(
+                    '"use_secret"' in effects.group(1),
+                    bool(expected_credentials),
+                )
+                self.assertEqual(
+                    f"\n[auth.{tool_dir.name}]\n" in manifest,
+                    bool(expected_credentials),
+                )
+
+    def test_nested_firecrawl_http_keeps_target_credential_and_auth(self) -> None:
+        caps, manifest = self.generated_tool("firecrawl")
+
+        self.assertNotIn("http", caps)
+        self.assertIn(
+            'network_targets = [ { scheme = "https", '
+            'host_pattern = "api.firecrawl.dev" } ]',
+            manifest,
+        )
+        self.assertIn('handle = "firecrawl_api_key"', manifest)
+        self.assertIn(
+            'audience = { scheme = "https", host = "api.firecrawl.dev" }',
+            manifest,
+        )
+        self.assertIn('[auth.firecrawl]\nmethod = "api_key"', manifest)
+
+    def test_credential_free_tool_still_gets_network_targets(self) -> None:
+        _, manifest = self.generated_tool("evm-rpc")
+
+        self.assertGreater(len(re.findall(r"host_pattern =", manifest)), 1)
+        self.assertIn('effects = ["network"]', manifest)
+        self.assertNotIn("[[tools.credentials]]", manifest)
+
+    def test_ambiguous_http_shapes_fail_instead_of_picking_one(self) -> None:
+        http = {"allowlist": [{"host": "api.example.com"}], "credentials": {}}
+        caps = {"http": http, "capabilities": {"http": http}}
+
+        with self.assertRaisesRegex(SystemExit, "declared in both"):
+            GENERATOR.generate_manifest(caps, "example", "example_tool", "1.0.0")
+
+    def test_multiple_credential_audiences_fail_instead_of_dropping_hosts(self) -> None:
+        caps = {
+            "http": {
+                "allowlist": [
+                    {"host": "api.example.com"},
+                    {"host": "uploads.example.com"},
+                ],
+                "credentials": {
+                    "example_key": {
+                        "location": {"type": "bearer"},
+                        "host_patterns": [
+                            "api.example.com",
+                            "uploads.example.com",
+                        ],
+                    }
+                },
+            }
+        }
+
+        with self.assertRaisesRegex(SystemExit, "v3 credential has one audience"):
+            GENERATOR.generate_manifest(caps, "example", "example_tool", "1.0.0")
+
+    def test_query_param_and_optional_credential_are_preserved(self) -> None:
+        caps = {
+            "http": {
+                "allowlist": [{"host": "api.example.com"}],
+                "credentials": {
+                    "example_key": {
+                        "location": {
+                            "type": "query_param",
+                            "name": "api_key",
+                        },
+                        "host_patterns": ["api.example.com"],
+                        "optional": True,
+                    }
+                },
+            }
+        }
+
+        manifest = GENERATOR.generate_manifest(
+            caps, "example", "example_tool", "1.0.0"
+        )
+
+        self.assertIn(
+            'injection = { type = "query_param", name = "api_key" }',
+            manifest,
+        )
+        self.assertIn("required = false", manifest)
+
+    def test_generated_manifests_are_valid_toml(self) -> None:
+        if tomllib is None:
+            self.skipTest("tomllib requires Python 3.11+")
+
+        for tool_dir in sorted((ROOT / "tools").iterdir()):
+            if not tool_dir.is_dir() or tool_dir.name in EXEMPT_TOOLS:
+                continue
+            with self.subTest(tool=tool_dir.name):
+                _, manifest = self.generated_tool(tool_dir.name)
+                parsed = tomllib.loads(manifest)
+                self.assertEqual(parsed["schema_version"], "reborn.extension_manifest.v3")
+
+    def test_exempt_tools_fail_for_the_documented_basic_auth_gap(self) -> None:
+        for tool_name in EXEMPT_TOOLS:
+            with self.subTest(tool=tool_name):
+                with self.assertRaisesRegex(SystemExit, "no HTTP Basic variant"):
+                    self.generated_tool(tool_name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix the shared `capabilities.json` → Reborn v3 translator so published manifests preserve the HTTP authority tools actually declare. This is a follow-up to #254 and #255: Firecrawl and seven other tools were receiving `effects = ["network"]` with no `network_targets`, and nested credentials under `capabilities.http` were silently omitted. IronClaw therefore denied their network obligation before WASM execution.

The translator now:

- accepts both supported source layouts (`http` and `capabilities.http`) and rejects ambiguous documents that declare both;
- emits a deduplicated v3 `network_targets` entry for every source allowlist host, including credential-free tools;
- translates nested credentials, query-parameter injection, and optional/required semantics;
- rejects mappings that v3 cannot represent without data loss, including multiple credential audiences and HTTP Basic;
- runs semantic regression coverage across every representable catalog tool, not only a generator-exit check.

Wazuh and WordPress are explicit exemptions because both depend on HTTP Basic, which the current v3 credential injection contract cannot represent. WordPress also has WooCommerce query credentials, but publishing only those would produce a partially working package.

## Closes

Follow-up to #254 and #255. No linked issue.

## Type

- [ ] Use case
- [ ] New tool
- [ ] New skill
- [x] Bug fix
- [ ] Documentation / process
- [x] Infrastructure

## Artifact checklist

Use case PRs:

- [ ] Not applicable: no use-case artifact changes

Skill PRs:

- [ ] Not applicable: no skill artifact changes

Tool PRs:

- [ ] Not applicable: shared publishing/translation fix; no tool implementation changes

Docs/process PRs:

- [x] No `tracking.md` or README shipped-catalog change is needed

## Compatibility, security, and rollback

- No `capabilities.json` schema or tool runtime changes.
- The next IronHub release regenerates corrected manifests for all 16 representable tools. Existing installations retain their downloaded manifest and need an upgrade/forced reinstall to receive the corrected policy.
- Manifest v3 currently represents network targets at scheme/host/port granularity; source method and path constraints remain outside this translator because v3 has no fields for them.
- Rollback is a revert of this commit, but that would restore empty egress policies and silently omitted nested credentials.

## Testing

- `PYTHONDONTWRITEBYTECODE=1 python3.11 -m unittest discover -s scripts -p 'test_generate_extension_manifest.py'` — 8 passed
- `PYTHONDONTWRITEBYTECODE=1 ./scripts/check-extension-manifests.sh` — 16 passed, 2 documented Basic-auth exemptions
- `bash -n scripts/check-extension-manifests.sh scripts/generate-manifest.sh`
- `node scripts/validate-use-cases.mjs` — 107 use cases validated
- `git diff --check`
- Against current `nearai/ironclaw`: `cargo test -p ironclaw_extensions --test manifest_v3_contract` — 39 passed
