### PR TITLE
fix: preserve v3 manifest security semantics

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,6 +36,7 @@ Tool PRs:
 
 - [ ] Adds or updates `tools/<tool-name>/README.md`
 - [ ] Adds or updates `tools/<tool-name>/<tool-name>-tool.capabilities.json`
+- [ ] Adds input/output schema assets that exactly match the generated manifest refs
 - [ ] Documents auth, scopes, limits, and target use cases
 - [ ] Tests representative action calls and records the results below
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,9 @@ tools/<tool-name>/
 ├── Cargo.toml
 ├── README.md
 ├── <tool-name>-tool.capabilities.json
+├── schemas/<tool-name>/
+│   ├── invoke.input.v1.json
+│   └── raw_output.v1.json
 └── src/
     ├── lib.rs        # Guest entry point and dispatch
     ├── types.rs      # MyAction tagged enum and schema types
@@ -122,6 +125,11 @@ schemars = "1"
 ```
 
 The tool exports the `sandboxed-tool` world from `wit/tool.wit` (vendored at the repo root). Implement the `Guest::execute`, `Guest::schema`, and `Guest::description` functions in `src/lib.rs`.
+
+The committed input schema must describe the same parameters returned by
+`Guest::schema`. Release generation fails unless the generated extension
+manifest's input/output schema references exactly match the committed files
+under `schemas/`; those files are published as digest-pinned catalog artifacts.
 
 ## Adding a skill
 

--- a/scripts/check-extension-manifests.sh
+++ b/scripts/check-extension-manifests.sh
@@ -23,7 +23,7 @@ trap 'rm -rf "$out_dir"' EXIT
 # dropped its network targets or credentials.
 PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover \
   -s "$ROOT/scripts" \
-  -p 'test_generate_extension_manifest.py'
+  -p 'test_*.py'
 
 # Tools that cannot publish a manifest yet, with the reason. A tool is listed
 # here only when the gap is in the host contract rather than in the tool, and

--- a/scripts/generate-extension-manifest.py
+++ b/scripts/generate-extension-manifest.py
@@ -34,6 +34,8 @@ import json
 import sys
 
 
+PUBLISHED_EFFECTS = {"external_write", "financial"}
+
 TOML_ESCAPES = {
     "\\": "\\\\",
     '"': '\\"',
@@ -165,6 +167,83 @@ def network_hosts(name: str, http: dict) -> list[str]:
     return hosts
 
 
+def declared_effects(name: str, caps: dict) -> list[str]:
+    """Return security-relevant effects explicitly declared by the publisher."""
+    effects = caps.get("effects")
+    if not isinstance(effects, list):
+        raise SystemExit(
+            f"{name}: effects must be an explicit list (use [] for read-only tools)"
+        )
+
+    seen = set()
+    for effect in effects:
+        if not isinstance(effect, str) or effect not in PUBLISHED_EFFECTS:
+            allowed = ", ".join(sorted(PUBLISHED_EFFECTS))
+            raise SystemExit(
+                f"{name}: unsupported effect {effect!r}; supported: {allowed}"
+            )
+        if effect in seen:
+            raise SystemExit(f"{name}: duplicate effect {effect!r}")
+        seen.add(effect)
+    return effects
+
+
+def oauth_scopes(name: str, caps: dict) -> list[str] | None:
+    """Return OAuth scopes, distinguishing OAuth with no scopes from API keys."""
+    auth = caps.get("auth") or {}
+    if not isinstance(auth, dict):
+        raise SystemExit(f"{name}: auth must be an object")
+    oauth = auth.get("oauth")
+    if oauth is None:
+        return None
+    if not isinstance(oauth, dict):
+        raise SystemExit(f"{name}: auth.oauth must be an object")
+    scopes = oauth.get("scopes", [])
+    if not isinstance(scopes, list):
+        raise SystemExit(f"{name}: auth.oauth.scopes must be a list")
+
+    normalized = []
+    for scope in scopes:
+        if not isinstance(scope, str) or not scope.strip():
+            raise SystemExit(f"{name}: OAuth scopes must be non-empty strings")
+        scope = scope.strip()
+        if scope in normalized:
+            raise SystemExit(f"{name}: duplicate OAuth scope {scope!r}")
+        normalized.append(scope)
+    return normalized
+
+
+def secret_names(name: str, caps: dict) -> list[str]:
+    """Read the supported secrets shape without silently choosing precedence."""
+    root_secrets = caps.get("secrets") if "secrets" in caps else None
+    capabilities = caps.get("capabilities")
+    nested_secrets = (
+        capabilities.get("secrets")
+        if isinstance(capabilities, dict) and "secrets" in capabilities
+        else None
+    )
+    if root_secrets is not None and nested_secrets is not None:
+        raise SystemExit(
+            f"{name}: secrets are declared in both 'secrets' and "
+            f"'capabilities.secrets'; keep exactly one representation"
+        )
+    secrets = root_secrets if root_secrets is not None else nested_secrets
+    if secrets is None:
+        secrets = {}
+    if not isinstance(secrets, dict):
+        raise SystemExit(f"{name}: secrets capability must be an object")
+    allowed_names = secrets.get("allowed_names", [])
+    if not isinstance(allowed_names, list):
+        raise SystemExit(f"{name}: secrets.allowed_names must be a list")
+    if any(not isinstance(secret, str) or not secret.strip() for secret in allowed_names):
+        raise SystemExit(
+            f"{name}: secrets.allowed_names must contain non-empty strings"
+        )
+    if len(set(allowed_names)) != len(allowed_names):
+        raise SystemExit(f"{name}: secrets.allowed_names contains duplicates")
+    return allowed_names
+
+
 def setup_copy(name: str, auth: dict) -> list[str]:
     """Carry the vendor's own account-setup steps into the recipe.
 
@@ -200,8 +279,8 @@ def auth_recipe(name: str, caps: dict, handles: list[str]) -> str:
     display_name = auth.get("display_name") or name
     oauth = auth.get("oauth")
 
-    if oauth:
-        scopes = ", ".join(toml_string(s) for s in oauth.get("scopes") or [])
+    if oauth is not None:
+        scopes = ", ".join(toml_string(s) for s in oauth_scopes(name, caps) or [])
         lines = [
             f"\n[auth.{name}]",
             'method = "oauth2_code"',
@@ -257,18 +336,38 @@ def auth_recipe(name: str, caps: dict, handles: list[str]) -> str:
 def generate_manifest(caps: dict, name: str, crate_name: str, version: str) -> str:
     """Translate a capabilities document into a complete v3 manifest."""
     description = caps.get("description") or ""
+    source_version = caps.get("version")
+    if source_version != version:
+        raise SystemExit(
+            f"{name}: capabilities version {source_version!r} does not match "
+            f"Cargo version {version!r}"
+        )
+    published_effects = declared_effects(name, caps)
+    scopes = oauth_scopes(name, caps)
     http = http_capability(name, caps)
     hosts = network_hosts(name, http)
-    credentials = http.get("credentials") or {}
+    credentials = http.get("credentials", {})
     if not isinstance(credentials, dict):
         raise SystemExit(f"{name}: HTTP credentials must be an object")
+    handles = sorted(credentials)
+    allowed_names = secret_names(name, caps)
+    if sorted(allowed_names) != handles:
+        raise SystemExit(
+            f"{name}: credential handles {handles!r} must exactly match "
+            f"secrets.allowed_names {sorted(allowed_names)!r}"
+        )
 
     blocks = []
-    handles = []
-    for handle_name in sorted(credentials):
+    for handle_name in handles:
         credential = credentials[handle_name]
         if not isinstance(credential, dict):
             raise SystemExit(f"{name}: credential {handle_name!r} must be an object")
+        secret_name = credential.get("secret_name")
+        if secret_name != handle_name:
+            raise SystemExit(
+                f"{name}: credential handle {handle_name!r} must match its "
+                f"secret_name {secret_name!r}"
+            )
         injection = credential_injection(name, credential.get("location") or {}, handle_name)
         credential_hosts = credential.get("host_patterns") or []
         if not isinstance(credential_hosts, list) or not credential_hosts:
@@ -310,17 +409,25 @@ def generate_manifest(caps: dict, name: str, crate_name: str, version: str) -> s
             injection_toml = (
                 f'{{ type = "query_param", name = {toml_string(injection["name"])} }}'
             )
+        scope_line = ""
+        if scopes is not None:
+            scope_values = ", ".join(toml_string(scope) for scope in scopes)
+            scope_line = f"scopes = [ {scope_values} ]\n"
         blocks.append(
             f"\n[[tools.credentials]]\n"
             f"handle = {toml_string(handle_name)}\n"
             f"vendor = {toml_string(name)}\n"
             f'audience = {{ scheme = "https", host = {toml_string(credential_host)} }}\n'
             f"injection = {injection_toml}\n"
+            f"{scope_line}"
             f"required = {'false' if optional else 'true'}\n"
         )
-        handles.append(handle_name)
 
-    effects = '["network", "use_secret"]' if handles else '["network"]'
+    effects = ["network"]
+    if handles:
+        effects.append("use_secret")
+    effects.extend(published_effects)
+    effects_toml = "[{}]".format(", ".join(toml_string(effect) for effect in effects))
     targets = ", ".join(
         f'{{ scheme = "https", host_pattern = {toml_string(host)} }}'
         for host in hosts
@@ -344,7 +451,7 @@ def generate_manifest(caps: dict, name: str, crate_name: str, version: str) -> s
         'product = "forbidden", automation = "forbidden" }\n'
         f"id = {toml_string(f'{name}.invoke')}\n"
         f"description = {toml_string(description)}\n"
-        f"effects = {effects}\n"
+        f"effects = {effects_toml}\n"
         f"network_targets = [ {targets} ]\n"
         'default_permission = "ask"\n'
         'visibility = "model"\n'

--- a/scripts/generate-manifest.sh
+++ b/scripts/generate-manifest.sh
@@ -16,6 +16,8 @@
 #
 # Also written here, not expected as input:
 #   <staging>/<tool-name>.manifest.toml    (generated from capabilities.json)
+#   <staging>/<tool-name>.schema.<path-sha256>.json
+#                                          (copied from manifest schema refs)
 
 set -euo pipefail
 
@@ -46,8 +48,8 @@ for dir in "$ROOT"/tools/*/; do
     continue
   fi
 
-  crate_name="$(grep -E '^name\s*=' "$cargo_toml" | head -1 | sed -E 's/^name\s*=\s*"(.+)"\s*$/\1/')"
-  version="$(grep -E '^version\s*=' "$cargo_toml" | head -1 | sed -E 's/^version\s*=\s*"(.+)"\s*$/\1/')"
+  crate_name="$(grep -E '^name[[:space:]]*=' "$cargo_toml" | head -1 | sed -E 's/^name[[:space:]]*=[[:space:]]*"(.+)"[[:space:]]*$/\1/')"
+  version="$(grep -E '^version[[:space:]]*=' "$cargo_toml" | head -1 | sed -E 's/^version[[:space:]]*=[[:space:]]*"(.+)"[[:space:]]*$/\1/')"
   description="$(jq -r '.description // ""' "$caps_file")"
 
   wasm_size="$(stat -c '%s' "$wasm_path")"
@@ -72,10 +74,13 @@ for dir in "$ROOT"/tools/*/; do
       --argjson size "$(stat -c '%s' "$manifest_staged")" \
       --arg sha "$(sha256sum "$manifest_staged" | awk '{print $1}')" \
       '{ url: $url, size_bytes: $size, sha256: $sha }')"
+    schemas_json="$(python3 "$ROOT/scripts/package_tool_schemas.py" \
+      "$dir" "$manifest_staged" "$STAGING" "$base_url")"
   else
     echo "warning: $name publishes no extension manifest (see error above)" >&2
     rm -f "$manifest_staged"
     manifest_json="null"
+    schemas_json="null"
   fi
 
   if [ $first -eq 0 ]; then
@@ -95,6 +100,7 @@ for dir in "$ROOT"/tools/*/; do
     --argjson caps_size "$caps_size" \
     --arg caps_sha "$caps_sha" \
     --argjson manifest "$manifest_json" \
+    --argjson schemas "$schemas_json" \
     '{
       name: $name,
       crate_name: $crate,
@@ -103,7 +109,7 @@ for dir in "$ROOT"/tools/*/; do
       wasm: { url: $wasm_url, size_bytes: $wasm_size, sha256: $wasm_sha },
       capabilities: { url: $caps_url, size_bytes: $caps_size, sha256: $caps_sha }
     }
-    + (if $manifest == null then {} else { manifest: $manifest } end)')
+    + (if $manifest == null then {} else { manifest: $manifest, schemas: $schemas } end)')
 done
 tools_json+="]"
 

--- a/scripts/package_tool_schemas.py
+++ b/scripts/package_tool_schemas.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Stage manifest-referenced tool schemas and emit signed-catalog metadata."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+import re
+import shutil
+import sys
+
+
+MAX_SCHEMA_ARTIFACTS = 32
+MAX_SCHEMA_BYTES = 1024 * 1024
+TOOL_NAME = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+
+class SchemaPackagingError(ValueError):
+    """The manifest and committed schema assets are inconsistent."""
+
+
+def manifest_schema_refs(manifest_path: Path) -> set[str]:
+    try:
+        manifest = manifest_path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise SchemaPackagingError(f"cannot read generated manifest: {error}") from error
+
+    refs = set(
+        re.findall(
+            r'^(?:input|output)_schema_ref\s*=\s*"([^"]+)"\s*$',
+            manifest,
+            re.MULTILINE,
+        )
+    )
+    if not refs:
+        raise SchemaPackagingError("generated manifest declares no tool schema refs")
+    return refs
+
+
+def validate_schema_path(path: str) -> PurePosixPath:
+    parsed = PurePosixPath(path)
+    if (
+        parsed.is_absolute()
+        or not parsed.parts
+        or any(part in ("", ".", "..") for part in parsed.parts)
+    ):
+        raise SchemaPackagingError(f"invalid manifest schema path: {path!r}")
+    if parsed.suffix != ".json" or parsed.parts[0] != "schemas":
+        raise SchemaPackagingError(
+            f"schema path must be a JSON file below schemas/: {path!r}"
+        )
+    return parsed
+
+
+def committed_schema_paths(tool_dir: Path) -> set[str]:
+    schema_root = tool_dir / "schemas"
+    if not schema_root.is_dir():
+        return set()
+    paths: set[str] = set()
+    for schema_path in schema_root.rglob("*.json"):
+        if schema_path.is_symlink():
+            raise SchemaPackagingError(
+                f"schema assets must not be symlinks: {schema_path}"
+            )
+        paths.add(schema_path.relative_to(tool_dir).as_posix())
+    return paths
+
+
+def package_tool_schemas(
+    tool_dir: Path,
+    manifest_path: Path,
+    staging_dir: Path,
+    base_url: str,
+) -> dict[str, dict[str, object]]:
+    name = tool_dir.name
+    if not TOOL_NAME.fullmatch(name):
+        raise SchemaPackagingError(f"invalid tool directory name: {name!r}")
+    referenced = manifest_schema_refs(manifest_path)
+    committed = committed_schema_paths(tool_dir)
+    if referenced != committed:
+        missing = sorted(referenced - committed)
+        unreferenced = sorted(committed - referenced)
+        raise SchemaPackagingError(
+            f"{name}: schema assets do not match generated manifest "
+            f"(missing={missing}, unreferenced={unreferenced})"
+        )
+    if len(referenced) > MAX_SCHEMA_ARTIFACTS:
+        raise SchemaPackagingError(
+            f"{name}: more than {MAX_SCHEMA_ARTIFACTS} schema artifacts"
+        )
+
+    staging_dir.mkdir(parents=True, exist_ok=True)
+    catalog: dict[str, dict[str, object]] = {}
+    for relative in sorted(referenced):
+        schema_path = tool_dir / validate_schema_path(relative)
+        content = schema_path.read_bytes()
+        if len(content) > MAX_SCHEMA_BYTES:
+            raise SchemaPackagingError(
+                f"{name}: schema {relative!r} exceeds {MAX_SCHEMA_BYTES} bytes"
+            )
+        try:
+            document = json.loads(content)
+        except json.JSONDecodeError as error:
+            raise SchemaPackagingError(
+                f"{name}: schema {relative!r} is invalid JSON: {error}"
+            ) from error
+        if not isinstance(document, dict):
+            raise SchemaPackagingError(
+                f"{name}: schema {relative!r} must be a JSON object"
+            )
+
+        path_digest = hashlib.sha256(relative.encode()).hexdigest()
+        asset_name = f"{name}.schema.{path_digest}.json"
+        shutil.copyfile(schema_path, staging_dir / asset_name)
+        catalog[relative] = {
+            "url": f"{base_url}/{asset_name}",
+            "size_bytes": len(content),
+            "sha256": hashlib.sha256(content).hexdigest(),
+        }
+    return catalog
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("tool_dir", type=Path)
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument("staging_dir", type=Path)
+    parser.add_argument("base_url")
+    args = parser.parse_args()
+    try:
+        catalog = package_tool_schemas(
+            args.tool_dir, args.manifest, args.staging_dir, args.base_url.rstrip("/")
+        )
+    except (OSError, SchemaPackagingError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    json.dump(catalog, sys.stdout, sort_keys=True)
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_generate_extension_manifest.py
+++ b/scripts/test_generate_extension_manifest.py
@@ -41,6 +41,33 @@ def expected_hosts(caps: dict) -> list[str]:
     )
 
 
+def source_secret_names(caps: dict) -> list[str]:
+    if "secrets" in caps:
+        return caps["secrets"].get("allowed_names") or []
+    return (caps.get("capabilities", {}).get("secrets") or {}).get(
+        "allowed_names"
+    ) or []
+
+
+def expected_injection(credential: dict) -> dict:
+    location = credential["location"]
+    if location["type"] == "bearer":
+        return {
+            "type": "header",
+            "name": "authorization",
+            "prefix": "Bearer ",
+        }
+    if location["type"] == "header":
+        return {
+            "type": "header",
+            "name": location.get("name", "authorization").strip().lower(),
+        }
+    return {
+        "type": "query_param",
+        "name": location["name"].strip(),
+    }
+
+
 class ExtensionManifestTranslationTests(unittest.TestCase):
     def generated_tool(self, tool_name: str) -> tuple[dict, str]:
         tool_dir = ROOT / "tools" / tool_name
@@ -89,10 +116,40 @@ class ExtensionManifestTranslationTests(unittest.TestCase):
                     '"use_secret"' in effects.group(1),
                     bool(expected_credentials),
                 )
+                for declared_effect in caps["effects"]:
+                    self.assertIn(f'"{declared_effect}"', effects.group(1))
                 self.assertEqual(
                     f"\n[auth.{tool_dir.name}]\n" in manifest,
                     bool(expected_credentials),
                 )
+
+    def test_catalog_sources_are_internally_consistent(self) -> None:
+        """Source metadata must agree before any manifest is generated."""
+        for tool_dir in sorted((ROOT / "tools").iterdir()):
+            capabilities_path = tool_dir / f"{tool_dir.name}-tool.capabilities.json"
+            cargo_path = tool_dir / "Cargo.toml"
+            if not tool_dir.is_dir() or not capabilities_path.exists():
+                continue
+            with self.subTest(tool=tool_dir.name):
+                with capabilities_path.open(encoding="utf-8") as handle:
+                    caps = json.load(handle)
+                cargo_toml = cargo_path.read_text(encoding="utf-8")
+                version = re.search(
+                    r'^version\s*=\s*"([^"]+)"', cargo_toml, re.MULTILINE
+                )
+                self.assertIsNotNone(version)
+                self.assertEqual(caps["version"], version.group(1))
+
+                effects = caps.get("effects")
+                self.assertIsInstance(effects, list)
+                self.assertEqual(len(effects), len(set(effects)))
+                self.assertTrue(set(effects).issubset(GENERATOR.PUBLISHED_EFFECTS))
+
+                credentials = source_http(caps).get("credentials") or {}
+                handles = sorted(credentials)
+                self.assertEqual(sorted(source_secret_names(caps)), handles)
+                for handle, credential in credentials.items():
+                    self.assertEqual(credential.get("secret_name"), handle)
 
     def test_nested_firecrawl_http_keeps_target_credential_and_auth(self) -> None:
         caps, manifest = self.generated_tool("firecrawl")
@@ -119,13 +176,20 @@ class ExtensionManifestTranslationTests(unittest.TestCase):
 
     def test_ambiguous_http_shapes_fail_instead_of_picking_one(self) -> None:
         http = {"allowlist": [{"host": "api.example.com"}], "credentials": {}}
-        caps = {"http": http, "capabilities": {"http": http}}
+        caps = {
+            "version": "1.0.0",
+            "effects": [],
+            "http": http,
+            "capabilities": {"http": http},
+        }
 
         with self.assertRaisesRegex(SystemExit, "declared in both"):
             GENERATOR.generate_manifest(caps, "example", "example_tool", "1.0.0")
 
     def test_multiple_credential_audiences_fail_instead_of_dropping_hosts(self) -> None:
         caps = {
+            "version": "1.0.0",
+            "effects": [],
             "http": {
                 "allowlist": [
                     {"host": "api.example.com"},
@@ -133,6 +197,7 @@ class ExtensionManifestTranslationTests(unittest.TestCase):
                 ],
                 "credentials": {
                     "example_key": {
+                        "secret_name": "example_key",
                         "location": {"type": "bearer"},
                         "host_patterns": [
                             "api.example.com",
@@ -140,7 +205,8 @@ class ExtensionManifestTranslationTests(unittest.TestCase):
                         ],
                     }
                 },
-            }
+            },
+            "secrets": {"allowed_names": ["example_key"]},
         }
 
         with self.assertRaisesRegex(SystemExit, "v3 credential has one audience"):
@@ -148,10 +214,13 @@ class ExtensionManifestTranslationTests(unittest.TestCase):
 
     def test_query_param_and_optional_credential_are_preserved(self) -> None:
         caps = {
+            "version": "1.0.0",
+            "effects": [],
             "http": {
                 "allowlist": [{"host": "api.example.com"}],
                 "credentials": {
                     "example_key": {
+                        "secret_name": "example_key",
                         "location": {
                             "type": "query_param",
                             "name": "api_key",
@@ -160,7 +229,8 @@ class ExtensionManifestTranslationTests(unittest.TestCase):
                         "optional": True,
                     }
                 },
-            }
+            },
+            "secrets": {"allowed_names": ["example_key"]},
         }
 
         manifest = GENERATOR.generate_manifest(
@@ -173,6 +243,81 @@ class ExtensionManifestTranslationTests(unittest.TestCase):
         )
         self.assertIn("required = false", manifest)
 
+    def test_missing_or_unknown_effects_fail_closed(self) -> None:
+        base = {
+            "version": "1.0.0",
+            "http": {
+                "allowlist": [{"host": "api.example.com"}],
+                "credentials": {},
+            },
+        }
+        with self.assertRaisesRegex(SystemExit, "explicit list"):
+            GENERATOR.generate_manifest(base, "example", "example_tool", "1.0.0")
+
+        base["effects"] = ["network"]
+        with self.assertRaisesRegex(SystemExit, "unsupported effect"):
+            GENERATOR.generate_manifest(base, "example", "example_tool", "1.0.0")
+
+    def test_source_version_and_secret_handles_must_match(self) -> None:
+        caps = {
+            "version": "0.9.0",
+            "effects": [],
+            "http": {
+                "allowlist": [{"host": "api.example.com"}],
+                "credentials": {},
+            },
+        }
+        with self.assertRaisesRegex(SystemExit, "does not match Cargo version"):
+            GENERATOR.generate_manifest(caps, "example", "example_tool", "1.0.0")
+
+        caps["version"] = "1.0.0"
+        caps["http"]["credentials"] = {
+            "example_key": {
+                "secret_name": "different_key",
+                "location": {"type": "bearer"},
+                "host_patterns": ["api.example.com"],
+            }
+        }
+        caps["secrets"] = {"allowed_names": ["example_key"]}
+        with self.assertRaisesRegex(SystemExit, "must match its secret_name"):
+            GENERATOR.generate_manifest(caps, "example", "example_tool", "1.0.0")
+
+        caps["http"]["credentials"]["example_key"]["secret_name"] = "example_key"
+        caps["secrets"]["allowed_names"] = []
+        with self.assertRaisesRegex(SystemExit, "must exactly match"):
+            GENERATOR.generate_manifest(caps, "example", "example_tool", "1.0.0")
+
+    def test_oauth_scopes_are_attached_to_credential_requirements(self) -> None:
+        for tool_name in ("gitlab", "microsoft-365", "xero"):
+            with self.subTest(tool=tool_name):
+                caps, manifest = self.generated_tool(tool_name)
+                expected_scopes = caps["auth"]["oauth"]["scopes"]
+                scope_line = re.search(
+                    r"^scopes = \[ (.*) \]$", manifest, re.MULTILINE
+                )
+                self.assertIsNotNone(scope_line)
+                self.assertEqual(
+                    re.findall(r'"([^"]+)"', scope_line.group(1)),
+                    expected_scopes,
+                )
+
+    def test_nova_uses_host_bounded_credential_injection(self) -> None:
+        caps, manifest = self.generated_tool("nova-submit")
+        credential = source_http(caps)["credentials"]["nova_api_key"]
+
+        self.assertEqual(
+            credential["path_patterns"], ["/api/auth/session-token"]
+        )
+        self.assertIn('handle = "nova_api_key"', manifest)
+        self.assertIn(
+            'injection = { type = "header", name = "x-api-key" }',
+            manifest,
+        )
+        self.assertIn(
+            'effects = ["network", "use_secret", "external_write"]',
+            manifest,
+        )
+
     def test_generated_manifests_are_valid_toml(self) -> None:
         if tomllib is None:
             self.skipTest("tomllib requires Python 3.11+")
@@ -184,6 +329,46 @@ class ExtensionManifestTranslationTests(unittest.TestCase):
                 _, manifest = self.generated_tool(tool_dir.name)
                 parsed = tomllib.loads(manifest)
                 self.assertEqual(parsed["schema_version"], "reborn.extension_manifest.v3")
+                with (
+                    tool_dir / f"{tool_dir.name}-tool.capabilities.json"
+                ).open(encoding="utf-8") as handle:
+                    caps = json.load(handle)
+                tool = parsed["tools"][0]
+                credentials = source_http(caps).get("credentials") or {}
+                expected_effects = ["network"]
+                if credentials:
+                    expected_effects.append("use_secret")
+                expected_effects.extend(caps["effects"])
+                self.assertEqual(tool["effects"], expected_effects)
+                self.assertEqual(
+                    sorted(c["handle"] for c in tool.get("credentials", [])),
+                    sorted(credentials),
+                )
+                generated_credentials = {
+                    credential["handle"]: credential
+                    for credential in tool.get("credentials", [])
+                }
+                for handle, source_credential in credentials.items():
+                    generated = generated_credentials[handle]
+                    self.assertEqual(
+                        generated["audience"],
+                        {
+                            "scheme": "https",
+                            "host": source_credential["host_patterns"][0],
+                        },
+                    )
+                    self.assertEqual(
+                        generated["injection"],
+                        expected_injection(source_credential),
+                    )
+                    self.assertEqual(
+                        generated["required"],
+                        not source_credential.get("optional", False),
+                    )
+                scopes = (caps.get("auth") or {}).get("oauth", {}).get("scopes")
+                if scopes is not None:
+                    for credential in tool.get("credentials", []):
+                        self.assertEqual(credential["scopes"], scopes)
 
     def test_exempt_tools_fail_for_the_documented_basic_auth_gap(self) -> None:
         for tool_name in EXEMPT_TOOLS:

--- a/scripts/test_generate_extension_manifest.py
+++ b/scripts/test_generate_extension_manifest.py
@@ -123,6 +123,30 @@ class ExtensionManifestTranslationTests(unittest.TestCase):
                     bool(expected_credentials),
                 )
 
+    def test_every_published_manifest_has_exact_schema_assets(self) -> None:
+        """Every manifest schema ref must resolve to one committed artifact."""
+        for tool_dir in sorted((ROOT / "tools").iterdir()):
+            if not tool_dir.is_dir() or tool_dir.name in EXEMPT_TOOLS:
+                continue
+            with self.subTest(tool=tool_dir.name):
+                _, manifest = self.generated_tool(tool_dir.name)
+                referenced = set(
+                    re.findall(
+                        r'^(?:input|output)_schema_ref = "([^"]+)"$',
+                        manifest,
+                        re.MULTILINE,
+                    )
+                )
+                published = {
+                    path.relative_to(tool_dir).as_posix()
+                    for path in (tool_dir / "schemas").rglob("*.json")
+                }
+                self.assertEqual(
+                    published,
+                    referenced,
+                    "signed catalog schemas must exactly match manifest refs",
+                )
+
     def test_catalog_sources_are_internally_consistent(self) -> None:
         """Source metadata must agree before any manifest is generated."""
         for tool_dir in sorted((ROOT / "tools").iterdir()):

--- a/scripts/test_package_tool_schemas.py
+++ b/scripts/test_package_tool_schemas.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from package_tool_schemas import SchemaPackagingError, package_tool_schemas
+
+
+class PackageToolSchemasTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.tool = self.root / "evm-rpc"
+        self.staging = self.root / "staging"
+        self.input_ref = "schemas/evm-rpc/invoke.input.v1.json"
+        self.output_ref = "schemas/evm-rpc/raw_output.v1.json"
+        for relative, content in (
+            (self.input_ref, b'{"type":"object","required":["action"]}\n'),
+            (self.output_ref, b'{"description":"raw output"}\n'),
+        ):
+            target = self.tool / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(content)
+        self.manifest = self.root / "manifest.toml"
+        self.manifest.write_text(
+            "[[tools]]\n"
+            f'input_schema_ref = "{self.input_ref}"\n'
+            f'output_schema_ref = "{self.output_ref}"\n',
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def test_stages_path_addressed_assets_and_emits_catalog_metadata(self) -> None:
+        catalog = package_tool_schemas(
+            self.tool,
+            self.manifest,
+            self.staging,
+            "https://example.test/release",
+        )
+
+        self.assertEqual(set(catalog), {self.input_ref, self.output_ref})
+        for relative, artifact in catalog.items():
+            path_digest = hashlib.sha256(relative.encode()).hexdigest()
+            asset_name = f"evm-rpc.schema.{path_digest}.json"
+            staged = self.staging / asset_name
+            self.assertEqual(staged.read_bytes(), (self.tool / relative).read_bytes())
+            self.assertEqual(
+                artifact,
+                {
+                    "url": f"https://example.test/release/{asset_name}",
+                    "size_bytes": staged.stat().st_size,
+                    "sha256": hashlib.sha256(staged.read_bytes()).hexdigest(),
+                },
+            )
+
+    def test_rejects_missing_or_unreferenced_schema_assets(self) -> None:
+        (self.tool / self.output_ref).unlink()
+        extra = self.tool / "schemas/evm-rpc/extra.json"
+        extra.write_text(json.dumps({"type": "object"}), encoding="utf-8")
+
+        with self.assertRaisesRegex(
+            SchemaPackagingError, "missing=.*raw_output.*unreferenced=.*extra"
+        ):
+            package_tool_schemas(
+                self.tool,
+                self.manifest,
+                self.staging,
+                "https://example.test/release",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/attio/attio-tool.capabilities.json
+++ b/tools/attio/attio-tool.capabilities.json
@@ -2,6 +2,7 @@
   "version": "0.1.0",
   "wit_version": "0.3.0",
   "description": "Attio CRM API v2 read and write access. Queries, fetches, creates, updates, asserts, and deletes records for any object (people, companies, deals, users, workspaces, or custom), reads the object catalog and per-object attribute schemas, lists lists and queries list entries, and lists and creates notes and tasks. Exposes a raw attio_request action for any v2 endpoint bounded by the same host allowlist. Authenticated with an Attio workspace API key presented as a Bearer header against api.attio.com.",
+  "effects": ["external_write"],
   "http": {
     "allowlist": [
       {

--- a/tools/bluesky-analytics/bluesky-analytics-tool.capabilities.json
+++ b/tools/bluesky-analytics/bluesky-analytics-tool.capabilities.json
@@ -2,6 +2,7 @@
   "version": "0.1.0",
   "wit_version": "0.3.0",
   "description": "Read-only Bluesky (AT Protocol) analytics. Browse public accounts and engagement via the unauthenticated AppView 'public.api.bsky.app'. Actions: 'get_profile' (follower/follows/post counts + bio), 'get_author_feed' (an account's posts with like/repost/reply/quote counts), 'get_post_thread' (a post and its reply/comment tree), 'get_followers' and 'get_follows' (social graph), 'get_likes' and 'get_reposted_by' (who engaged with a post), 'search_actors' (find accounts by keyword). All data is public; no authentication, secret, or login is required. Posting, replying, liking and other writes are NOT supported (they require an authenticated session, which a stateless WASM tool cannot perform).",
+  "effects": [],
   "capabilities": {
     "http": {
       "allowlist": [

--- a/tools/bluesky-analytics/schemas/bluesky-analytics/invoke.input.v1.json
+++ b/tools/bluesky-analytics/schemas/bluesky-analytics/invoke.input.v1.json
@@ -1,0 +1,163 @@
+{
+    "type": "object",
+    "required": ["action"],
+    "oneOf": [
+        {
+            "properties": {
+                "action": { "const": "get_profile" },
+                "actor": {
+                    "type": "string",
+                    "description": "Account identifier: a handle (e.g. 'alice.bsky.social') or DID (e.g. 'did:plc:...')."
+                }
+            },
+            "required": ["action", "actor"]
+        },
+        {
+            "properties": {
+                "action": { "const": "get_author_feed" },
+                "actor": {
+                    "type": "string",
+                    "description": "Account identifier: a handle (e.g. 'alice.bsky.social') or DID (e.g. 'did:plc:...')."
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max results (1-100, default 50).",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 50
+                },
+                "cursor": {
+                    "type": "string",
+                    "description": "Opaque pagination cursor from a previous response. Pass it back to fetch the next page."
+                },
+                "filter": {
+                    "type": "string",
+                    "description": "Optional server-side filter: 'posts_with_replies', 'posts_no_replies', 'posts_with_media', or 'posts_and_author_threads'.",
+                    "enum": ["posts_with_replies", "posts_no_replies", "posts_with_media", "posts_and_author_threads"]
+                }
+            },
+            "required": ["action", "actor"]
+        },
+        {
+            "properties": {
+                "action": { "const": "get_post_thread" },
+                "uri": {
+                    "type": "string",
+                    "description": "Post at-uri (e.g. 'at://did:plc:.../app.bsky.feed.post/<rkey>'). Obtain one from get_author_feed output."
+                },
+                "depth": {
+                    "type": "integer",
+                    "description": "Reply-tree depth (default 6, max 100).",
+                    "minimum": 0,
+                    "maximum": 100
+                }
+            },
+            "required": ["action", "uri"]
+        },
+        {
+            "properties": {
+                "action": { "const": "get_followers" },
+                "actor": {
+                    "type": "string",
+                    "description": "Account identifier: a handle (e.g. 'alice.bsky.social') or DID (e.g. 'did:plc:...')."
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max results (1-100, default 50).",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 50
+                },
+                "cursor": {
+                    "type": "string",
+                    "description": "Opaque pagination cursor from a previous response. Pass it back to fetch the next page."
+                }
+            },
+            "required": ["action", "actor"]
+        },
+        {
+            "properties": {
+                "action": { "const": "get_follows" },
+                "actor": {
+                    "type": "string",
+                    "description": "Account identifier: a handle (e.g. 'alice.bsky.social') or DID (e.g. 'did:plc:...')."
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max results (1-100, default 50).",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 50
+                },
+                "cursor": {
+                    "type": "string",
+                    "description": "Opaque pagination cursor from a previous response. Pass it back to fetch the next page."
+                }
+            },
+            "required": ["action", "actor"]
+        },
+        {
+            "properties": {
+                "action": { "const": "get_likes" },
+                "uri": {
+                    "type": "string",
+                    "description": "Post at-uri (e.g. 'at://did:plc:.../app.bsky.feed.post/<rkey>'). Obtain one from get_author_feed output."
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max results (1-100, default 50).",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 50
+                },
+                "cursor": {
+                    "type": "string",
+                    "description": "Opaque pagination cursor from a previous response. Pass it back to fetch the next page."
+                }
+            },
+            "required": ["action", "uri"]
+        },
+        {
+            "properties": {
+                "action": { "const": "get_reposted_by" },
+                "uri": {
+                    "type": "string",
+                    "description": "Post at-uri (e.g. 'at://did:plc:.../app.bsky.feed.post/<rkey>'). Obtain one from get_author_feed output."
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max results (1-100, default 50).",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 50
+                },
+                "cursor": {
+                    "type": "string",
+                    "description": "Opaque pagination cursor from a previous response. Pass it back to fetch the next page."
+                }
+            },
+            "required": ["action", "uri"]
+        },
+        {
+            "properties": {
+                "action": { "const": "search_actors" },
+                "q": {
+                    "type": "string",
+                    "description": "Keyword query (matches handle/display name/bio)."
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max results (1-100, default 50).",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 50
+                },
+                "cursor": {
+                    "type": "string",
+                    "description": "Opaque pagination cursor from a previous response. Pass it back to fetch the next page."
+                }
+            },
+            "required": ["action", "q"]
+        }
+    ]
+}

--- a/tools/bluesky-analytics/schemas/bluesky-analytics/raw_output.v1.json
+++ b/tools/bluesky-analytics/schemas/bluesky-analytics/raw_output.v1.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Action-specific Bluesky analytics JSON returned by the public AT Protocol AppView."
+}

--- a/tools/bluesky-analytics/src/lib.rs
+++ b/tools/bluesky-analytics/src/lib.rs
@@ -642,6 +642,16 @@ mod tests {
     }
 
     #[test]
+    fn published_input_schema_matches_guest_export() {
+        let exported: Value = serde_json::from_str(SCHEMA).expect("guest schema");
+        let published: Value = serde_json::from_str(include_str!(
+            "../schemas/bluesky-analytics/invoke.input.v1.json"
+        ))
+        .expect("published schema");
+        assert_eq!(published, exported);
+    }
+
+    #[test]
     fn action_deserializes_each_variant() {
         assert!(matches!(
             serde_json::from_str::<Action>(

--- a/tools/clickup/clickup-tool.capabilities.json
+++ b/tools/clickup/clickup-tool.capabilities.json
@@ -2,6 +2,7 @@
   "version": "0.1.0",
   "wit_version": "0.3.0",
   "description": "ClickUp integration via the v2 REST API. Workspaces (list), spaces (list, get), folders (list, get), lists (list, get, create, list folderless), tasks (list, list filtered cross-list, get, create, update, delete, tag, untag), task comments (list, create), comments (update, delete), time tracking (list, current running), goals (list, get), and the authenticated user. OAuth 2.0 user-context authentication against app.clickup.com with non-expiring tokens.",
+  "effects": ["external_write"],
   "http": {
     "allowlist": [
       {

--- a/tools/crypto-ta-engine/crypto-ta-engine-tool.capabilities.json
+++ b/tools/crypto-ta-engine/crypto-ta-engine-tool.capabilities.json
@@ -2,6 +2,7 @@
   "version": "0.1.0",
   "wit_version": "0.3.0",
   "description": "Deterministic technical-analysis engine. Fetches Binance Spot klines (public market data, no key) and computes indicators + multi-timeframe confluence scoring.",
+  "effects": [],
   "capabilities": {
     "http": {
       "allowlist": [

--- a/tools/crypto-ta-engine/schemas/crypto-ta-engine/invoke.input.v1.json
+++ b/tools/crypto-ta-engine/schemas/crypto-ta-engine/invoke.input.v1.json
@@ -1,0 +1,49 @@
+{
+    "type": "object",
+    "required": ["command"],
+    "oneOf": [
+        {
+            "properties": {
+                "command": {
+                    "const": "analyze",
+                    "description": "Weighted multi-timeframe confluence verdict"
+                },
+                "symbol": {
+                    "type": "string",
+                    "description": "Trading pair, e.g. BTCUSDT. Separators (/, -) are stripped automatically."
+                },
+                "intervals": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Timeframes top-down. Default ['4h','1h','15m']. Valid: 1m,3m,5m,15m,30m,1h,2h,4h,6h,8h,12h,1d,3d,1w,1M"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Candles per timeframe (default 300, max 1000). Use >=200 for reliable EMA200/ADX/ATR."
+                }
+            },
+            "required": ["command", "symbol"]
+        },
+        {
+            "properties": {
+                "command": {
+                    "const": "indicators",
+                    "description": "Single-timeframe raw indicator snapshot"
+                },
+                "symbol": {
+                    "type": "string",
+                    "description": "Trading pair, e.g. BTCUSDT. Separators (/, -) are stripped automatically."
+                },
+                "interval": {
+                    "type": "string",
+                    "description": "Single timeframe, e.g. '1h'. Valid: 1m,3m,5m,15m,30m,1h,2h,4h,6h,8h,12h,1d,3d,1w,1M"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Candles (default 300, max 1000). Use >=200 for reliable EMA200/ADX/ATR."
+                }
+            },
+            "required": ["command", "symbol", "interval"]
+        }
+    ]
+}

--- a/tools/crypto-ta-engine/schemas/crypto-ta-engine/raw_output.v1.json
+++ b/tools/crypto-ta-engine/schemas/crypto-ta-engine/raw_output.v1.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Action-specific technical-analysis JSON containing indicators or a multi-timeframe confluence report."
+}

--- a/tools/crypto-ta-engine/src/lib.rs
+++ b/tools/crypto-ta-engine/src/lib.rs
@@ -219,4 +219,14 @@ mod schema_tests {
             assert!(b["properties"]["command"]["const"].is_string());
         }
     }
+
+    #[test]
+    fn published_input_schema_matches_guest_export() {
+        let exported: Value = serde_json::from_str(SCHEMA).expect("guest schema");
+        let published: Value = serde_json::from_str(include_str!(
+            "../schemas/crypto-ta-engine/invoke.input.v1.json"
+        ))
+        .expect("published schema");
+        assert_eq!(published, exported);
+    }
 }

--- a/tools/evm-rpc/evm-rpc-tool.capabilities.json
+++ b/tools/evm-rpc/evm-rpc-tool.capabilities.json
@@ -2,6 +2,7 @@
   "version": "0.1.0",
   "wit_version": "0.3.0",
   "description": "EVM JSON-RPC integration. Read account balances, contract code and storage, call view functions, fetch blocks, transactions, receipts, and event logs. Built-in chain shortcuts for Ethereum mainnet, Polygon, Arbitrum, Optimism, Base, BNB Chain, and Avalanche; accepts custom RPC URLs for any EVM-compatible network. Read-only (no transaction signing).",
+  "effects": [],
   "http": {
     "allowlist": [
       { "host": "ethereum-rpc.publicnode.com", "path_prefix": "/", "methods": ["POST"] },

--- a/tools/firecrawl/firecrawl-tool.capabilities.json
+++ b/tools/firecrawl/firecrawl-tool.capabilities.json
@@ -2,6 +2,7 @@
   "version": "0.1.0",
   "wit_version": "0.3.0",
   "description": "Scrape, search, map, and crawl the web with Firecrawl (v2 API). 'scrape' returns clean markdown for one URL; 'search' finds pages by query; 'map' lists every URL on a site; 'crawl' + 'crawl_status' recursively scrape a whole site. Authentication uses the 'firecrawl_api_key' secret injected by the host as a Bearer token.",
+  "effects": ["external_write"],
   "capabilities": {
     "http": {
       "allowlist": [

--- a/tools/firecrawl/schemas/firecrawl/invoke.input.v1.json
+++ b/tools/firecrawl/schemas/firecrawl/invoke.input.v1.json
@@ -1,0 +1,60 @@
+{
+    "type": "object",
+    "required": ["action"],
+    "oneOf": [
+        {
+            "properties": {
+                "action": { "const": "scrape" },
+                "url": { "type": "string", "description": "Target URL (http/https) to scrape." },
+                "formats": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Output formats, e.g. [\"markdown\"], [\"markdown\",\"html\"]. Default [\"markdown\"]."
+                },
+                "only_main_content": { "type": "boolean", "description": "Strip nav/header/footer boilerplate (default true)." },
+                "wait_for": { "type": "integer", "minimum": 0, "maximum": 60000, "description": "Milliseconds to wait for JS before extracting (max 60000)." },
+                "timeout": { "type": "integer", "minimum": 1000, "maximum": 300000, "description": "Request timeout in milliseconds (1000-300000)." }
+            },
+            "required": ["action", "url"]
+        },
+        {
+            "properties": {
+                "action": { "const": "search" },
+                "query": { "type": "string", "description": "Search query (max 500 chars)." },
+                "limit": { "type": "integer", "minimum": 1, "maximum": 100, "description": "Max results (1-100, default 10)." },
+                "sources": {
+                    "type": "array",
+                    "items": { "type": "string", "enum": ["web", "news", "images"] },
+                    "description": "Which result types to return (default [\"web\"])."
+                }
+            },
+            "required": ["action", "query"]
+        },
+        {
+            "properties": {
+                "action": { "const": "map" },
+                "url": { "type": "string", "description": "Target site URL (http/https) to map." },
+                "search": { "type": "string", "description": "Optional query to order discovered URLs by relevance." },
+                "limit": { "type": "integer", "minimum": 1, "description": "Max URLs to return (default 1000)." },
+                "include_subdomains": { "type": "boolean", "description": "Include subdomains in discovered URLs (default true)." }
+            },
+            "required": ["action", "url"]
+        },
+        {
+            "properties": {
+                "action": { "const": "crawl" },
+                "url": { "type": "string", "description": "Start URL (http/https) for the recursive crawl." },
+                "limit": { "type": "integer", "minimum": 1, "description": "Max pages to crawl (default 100)." },
+                "max_depth": { "type": "integer", "minimum": 1, "description": "Maximum link-discovery depth from the start URL." }
+            },
+            "required": ["action", "url"]
+        },
+        {
+            "properties": {
+                "action": { "const": "crawl_status" },
+                "id": { "type": "string", "description": "The crawl_id returned by a 'crawl' call." }
+            },
+            "required": ["action", "id"]
+        }
+    ]
+}

--- a/tools/firecrawl/schemas/firecrawl/raw_output.v1.json
+++ b/tools/firecrawl/schemas/firecrawl/raw_output.v1.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Action-specific Firecrawl JSON for scrape, search, map, crawl, or crawl-status operations."
+}

--- a/tools/firecrawl/src/lib.rs
+++ b/tools/firecrawl/src/lib.rs
@@ -576,6 +576,15 @@ mod tests {
     }
 
     #[test]
+    fn published_input_schema_matches_guest_export() {
+        let exported: Value = serde_json::from_str(SCHEMA).expect("guest schema");
+        let published: Value =
+            serde_json::from_str(include_str!("../schemas/firecrawl/invoke.input.v1.json"))
+                .expect("published schema");
+        assert_eq!(published, exported);
+    }
+
+    #[test]
     fn action_deserializes_each_variant() {
         assert!(matches!(
             serde_json::from_str::<Action>(r#"{"action":"scrape","url":"https://x.com"}"#),

--- a/tools/gitlab/gitlab-tool.capabilities.json
+++ b/tools/gitlab/gitlab-tool.capabilities.json
@@ -2,6 +2,7 @@
   "version": "0.1.0",
   "wit_version": "0.3.0",
   "description": "GitLab integration via the v4 REST API. Projects (list, get, create), issues (list, get, create, update, comment), merge requests (list, get, create, update, comment, approve, merge), branches (list, get, create, delete), files (read, create or update, delete), search (projects, issues, blobs), pipelines (list, get, jobs), and current_user. OAuth 2.0 user-context authentication against gitlab.com with host-managed token refresh.",
+  "effects": ["external_write"],
   "http": {
     "allowlist": [
       {

--- a/tools/hubspot/hubspot-tool.capabilities.json
+++ b/tools/hubspot/hubspot-tool.capabilities.json
@@ -2,6 +2,7 @@
   "version": "0.1.0",
   "wit_version": "0.3.0",
   "description": "HubSpot CRM v3 read and write access. Lists, searches, fetches, creates, updates, and archives contacts, companies, deals, and tickets. Lists contact lists and members, CRM owners, and per-object properties. Exposes a raw hubspot_request action for any CRM v3 endpoint bounded by the same host allowlist. Authenticated with a HubSpot access token (Private App or Service Key) presented as a Bearer header against api.hubapi.com.",
+  "effects": ["external_write"],
   "http": {
     "allowlist": [
       {

--- a/tools/microsoft-365/microsoft-365-tool.capabilities.json
+++ b/tools/microsoft-365/microsoft-365-tool.capabilities.json
@@ -2,6 +2,7 @@
   "version": "0.1.0",
   "wit_version": "0.3.0",
   "description": "Microsoft 365 integration via Microsoft Graph. Outlook mail, Teams channel messaging, Excel cell and range operations, Word and PowerPoint document generation, SharePoint and OneDrive file management, Outlook Calendar scheduling. OAuth 2.0 user-context authentication against Microsoft Entra ID with host-managed token refresh.",
+  "effects": ["external_write"],
   "http": {
     "allowlist": [
       {

--- a/tools/monday/monday-tool.capabilities.json
+++ b/tools/monday/monday-tool.capabilities.json
@@ -2,6 +2,7 @@
   "version": "0.1.0",
   "wit_version": "0.3.0",
   "description": "monday.com API v2 (GraphQL) read and write access. Reads the current account, boards (list/get/groups), items (paginated by board, single get, search by column value, updates), users, and workspaces. Writes: create_item, update_item_column_values (change_multiple_column_values), archive_item, delete_item, move_item_to_group, create_group, create_subitem, create_update. Exposes a raw monday_graphql_query action for any query or mutation against api.monday.com/v2. Authenticated with a personal API v2 token sent as the raw value of an Authorization header (NO Bearer prefix per the monday.com convention).",
+  "effects": ["external_write"],
   "http": {
     "allowlist": [
       {

--- a/tools/near-rpc/near-rpc-tool.capabilities.json
+++ b/tools/near-rpc/near-rpc-tool.capabilities.json
@@ -2,6 +2,7 @@
   "version": "0.1.0",
   "wit_version": "0.3.0",
   "description": "NEAR Protocol JSON-RPC integration. Read account state, access keys, contract storage and code. Call view functions on smart contracts. Read blocks, chunks, validators, transactions, and state changes. Check gas prices and protocol config. Submit signed transactions with finality control. Query node status, health, and network info. Light-client proofs and next-block lookup. Supports mainnet, testnet, archival, and custom RPC endpoints.",
+  "effects": ["external_write", "financial"],
   "http": {
     "allowlist": [
       {

--- a/tools/nearcatalog/nearcatalog-tool.capabilities.json
+++ b/tools/nearcatalog/nearcatalog-tool.capabilities.json
@@ -2,6 +2,7 @@
   "version": "0.1.0",
   "wit_version": "0.3.0",
   "description": "Explore the NEAR ecosystem: keyword-search projects, browse/filter the catalog by status and phase, look up full project profiles, find related projects, browse categories and groupings like trending, find people building on NEAR, and list awesome-near OSS libraries. All data sources are public; no authentication required.",
+  "effects": [],
   "capabilities": {
     "http": {
       "allowlist": [

--- a/tools/nearcatalog/schemas/nearcatalog/invoke.input.v1.json
+++ b/tools/nearcatalog/schemas/nearcatalog/invoke.input.v1.json
@@ -1,0 +1,140 @@
+{
+    "type": "object",
+    "required": ["action"],
+    "oneOf": [
+        {
+            "properties": {
+                "action": { "const": "list_projects" },
+                "query": {
+                    "type": "string",
+                    "description": "Client-side filter over project name/tagline/tags."
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["active", "inactive"],
+                    "description": "Optional server-side filter for 'list_projects': operational status."
+                },
+                "phase": {
+                    "type": "string",
+                    "enum": ["mainnet", "testnet"],
+                    "description": "Optional server-side filter for 'list_projects': ecosystem phase."
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 25,
+                    "description": "Maximum results to return (1-100, default 25)."
+                }
+            },
+            "required": ["action"]
+        },
+        {
+            "properties": {
+                "action": { "const": "search" },
+                "query": {
+                    "type": "string",
+                    "description": "Server-side keyword match across project profiles (name/tagline/tags). Best for finding projects by topic."
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 25,
+                    "description": "Maximum results to return (1-100, default 25)."
+                }
+            },
+            "required": ["action", "query"]
+        },
+        {
+            "properties": {
+                "action": { "const": "get_project" },
+                "slug": {
+                    "type": "string",
+                    "description": "Project slug (e.g. 'ref-finance'). Lowercase letters, digits, '-', '_', '.'. Discover slugs with 'list_projects' or 'search'."
+                }
+            },
+            "required": ["action", "slug"]
+        },
+        {
+            "properties": {
+                "action": { "const": "related_projects" },
+                "slug": {
+                    "type": "string",
+                    "description": "Project slug (e.g. 'ref-finance'). Lowercase letters, digits, '-', '_', '.'. Discover slugs with 'list_projects' or 'search'."
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 25,
+                    "description": "Maximum results to return (1-100, default 25)."
+                }
+            },
+            "required": ["action", "slug"]
+        },
+        {
+            "properties": {
+                "action": { "const": "list_categories" }
+            },
+            "required": ["action"]
+        },
+        {
+            "properties": {
+                "action": { "const": "projects_by_category" },
+                "category": {
+                    "type": "string",
+                    "description": "A category slug (e.g. 'ai', 'defi', 'infrastructure') discovered via 'list_categories'. For trending projects use the 'trending' action instead."
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 25,
+                    "description": "Maximum results to return (1-100, default 25)."
+                }
+            },
+            "required": ["action", "category"]
+        },
+        {
+            "properties": {
+                "action": { "const": "trending" },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 25,
+                    "description": "Maximum results to return (1-100, default 25)."
+                }
+            },
+            "required": ["action"]
+        },
+        {
+            "properties": {
+                "action": { "const": "search_people" },
+                "query": {
+                    "type": "string",
+                    "description": "Filter matching name/organization/job title/description."
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 25,
+                    "description": "Maximum results to return (1-100, default 25)."
+                }
+            },
+            "required": ["action"]
+        },
+        {
+            "properties": {
+                "action": { "const": "list_oss" },
+                "query": {
+                    "type": "string",
+                    "description": "Filter keeping matching library lines plus section headers."
+                }
+            },
+            "required": ["action"]
+        }
+    ]
+}

--- a/tools/nearcatalog/schemas/nearcatalog/raw_output.v1.json
+++ b/tools/nearcatalog/schemas/nearcatalog/raw_output.v1.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Action-specific NEAR ecosystem catalog JSON or curated text output."
+}

--- a/tools/nearcatalog/src/lib.rs
+++ b/tools/nearcatalog/src/lib.rs
@@ -743,6 +743,15 @@ mod tests {
     }
 
     #[test]
+    fn published_input_schema_matches_guest_export() {
+        let exported: Value = serde_json::from_str(SCHEMA).expect("guest schema");
+        let published: Value =
+            serde_json::from_str(include_str!("../schemas/nearcatalog/invoke.input.v1.json"))
+                .expect("published schema");
+        assert_eq!(published, exported);
+    }
+
+    #[test]
     fn action_deserializes_each_variant() {
         assert!(matches!(
             serde_json::from_str::<Action>(r#"{"action":"list_projects"}"#),

--- a/tools/nova-submit/README.md
+++ b/tools/nova-submit/README.md
@@ -21,7 +21,6 @@ The agent calls the tool once with a JSON parameter object and gets back a JSON 
 | Parameter | Type | Notes |
 |---|---|---|
 | `account_id` | string | The caller's NOVA account, e.g. `alice.nova-sdk.near`. Not secret. |
-| `api_key` | string | The caller's NOVA API key (from nova-sdk.com). Secret — see the note below. |
 | `group_id` | string | The NOVA group to upload into. The caller's account must already be a member. |
 | `filename` | string | The filename to record for the upload, e.g. `submission.md`. |
 | `file_content` | string | The full UTF-8 text to encrypt and upload. |
@@ -36,7 +35,7 @@ Returns:
 
 Once installed, the agent calls the tool when a task needs it. For example, in the agent chat:
 
-> Use the nova-submit tool. account_id is `alice.nova-sdk.near`, api_key is `<key>`, group_id is `my-group`, filename is `report.md`, and file_content is `...`.
+> Use the nova-submit tool. account_id is `alice.nova-sdk.near`, group_id is `my-group`, filename is `report.md`, and file_content is `...`.
 
 The tool returns the CID, which is the permanent reference to the encrypted file in the group.
 
@@ -47,12 +46,12 @@ The tool's `capabilities.json` grants it network access to exactly two hosts and
 - `nova-sdk.com` — for the session-token exchange
 - the NOVA MCP server on Phala — for `prepare_upload` and `finalize_upload` (the hostname embeds a Phala dstack verification hash and changes on redeploy — see *Security notes*)
 
-It declares no host-injected credentials: the NOVA API key is passed as a call parameter (NOVA's session-token endpoint authenticates with a custom `X-API-Key` header, not a bearer token, so the host's bearer-only injection cannot be used).
+It declares `nova_api_key` as a host-managed credential. IronClaw injects the key as `X-API-Key` only for requests to `nova-sdk.com`; this guest uses that host only for `/api/auth/session-token`. The key is absent from the model-visible input schema and the guest's request headers.
 
 ## Security notes
 
-- **API key handling.** The `api_key` is passed as a tool parameter. If your agent's caller types it into a chat, treat it as exposed and rotate it at nova-sdk.com afterward. The cleaner pattern is to supply it from the agent's `~/.ironclaw/.env` rather than chat.
-- **Nonce.** The WASI p2 sandbox exposes no random number generator, so the 12-byte AES-GCM nonce is derived from the host millisecond clock. This is sufficient for unique-per-upload nonces in a low-frequency submission flow, but it is not a cryptographically strong RNG. For high-volume or adversarial use, have NOVA's `prepare_upload` return a server-generated nonce instead.
+- **API key handling.** Store the key through IronClaw's NOVA credential setup (or the `NOVA_API_KEY` deployment environment variable). The host keeps it outside model parameters and limits injection to `nova-sdk.com`. The source capabilities further declare `/api/auth/session-token`, but Reborn manifest v3 currently represents credential audiences at host granularity; path-level credential audiences require a future IronClaw contract change.
+- **Nonce.** The WASI p2 sandbox exposes no random number generator, so the 12-byte AES-GCM nonce is derived as `SHA-256(upload_id)[..12]`. NOVA mints a unique `upload_id` for every `prepare_upload` call, keeping the `(key, nonce)` pair fresh even when a group encryption key is reused.
 - **Encryption layout.** Output is `nonce(12) ‖ ciphertext ‖ tag(16)`, base64-encoded — byte-compatible with the NOVA SDK's `encrypt`/`decrypt` (`iv = bytes[:12]`). A file uploaded by this tool retrieves and decrypts correctly via the NOVA JS SDK and vice versa.
 - **NOVA MCP hostname.** The capabilities file allowlists the NOVA MCP host at `5a5223f7d1bfe777433c496b9d52ff851e927259-8000.dstack-prod5.phala.network`. This is a [Phala dstack](https://docs.phala.network/) deployment, and the hostname embeds the dstack instance's verification hash — proof the MCP server is the exact build NOVA published. If NOVA redeploys the MCP server, the hash changes and so does the hostname; this tool then stops working until `nova-submit-tool.capabilities.json` is bumped and a new release is cut. The live hostname is tracked at [`github.com/jcarbonnell/nova`](https://github.com/jcarbonnell/nova).
 
@@ -73,7 +72,7 @@ ironhub/
     README.md
 ```
 
-The WIT interface (`near:agent@0.3.0`) is identical for v1 and Reborn, so the same `.wasm` binary works in both runtimes. The Reborn manifest declares a single capability (`nova-submit.invoke`) with `effects = ["network"]` — no host-injected credentials since the NOVA API key is passed as a tool parameter.
+The WIT interface (`near:agent@0.3.0`) is identical for v1 and Reborn, so the same `.wasm` binary works in both runtimes. The Reborn manifest declares a single capability (`nova-submit.invoke`) with `effects = ["network", "use_secret", "external_write"]` and a host-bounded credential for the NOVA API key.
 
 ## Layout
 

--- a/tools/nova-submit/nova-submit-tool.capabilities.json
+++ b/tools/nova-submit/nova-submit-tool.capabilities.json
@@ -1,7 +1,8 @@
 {
   "version": "0.1.0",
   "wit_version": "0.3.0",
-  "description": "Encrypt a file with AES-256-GCM and upload it to a NOVA group on NEAR. Self-contained NOVA submission tool for the NEAR Legion IronClaw Hackathon: performs session-token, prepare_upload, client-side encryption, and finalize_upload in a single call. The NOVA account ID and API key are passed as call parameters; no host-injected credentials.",
+  "description": "Encrypt a file with AES-256-GCM and upload it to a NOVA group on NEAR. Self-contained NOVA submission tool for the NEAR Legion IronClaw Hackathon: performs session-token, prepare_upload, client-side encryption, and finalize_upload in a single call. The NOVA API key is stored by the host and injected only into requests to nova-sdk.com.",
+  "effects": ["external_write"],
   "http": {
     "allowlist": [
       {
@@ -15,7 +16,21 @@
         "methods": ["POST"]
       }
     ],
-    "credentials": {},
+    "credentials": {
+      "nova_api_key": {
+        "secret_name": "nova_api_key",
+        "location": {
+          "type": "header",
+          "name": "X-API-Key"
+        },
+        "host_patterns": [
+          "nova-sdk.com"
+        ],
+        "path_patterns": [
+          "/api/auth/session-token"
+        ]
+      }
+    },
     "rate_limit": {
       "requests_per_minute": 30,
       "requests_per_hour": 200
@@ -23,9 +38,23 @@
     "timeout_secs": 60
   },
   "secrets": {
-    "allowed_names": []
+    "allowed_names": [
+      "nova_api_key"
+    ]
   },
   "setup": {
-    "required_secrets": []
+    "required_secrets": [
+      {
+        "name": "nova_api_key",
+        "prompt": "NOVA API key from nova-sdk.com"
+      }
+    ]
+  },
+  "auth": {
+    "secret_name": "nova_api_key",
+    "display_name": "NOVA",
+    "instructions": "Sign in to NOVA, obtain the API key for your account, and store it as the secret below. IronClaw injects it only into the X-API-Key header for requests to nova-sdk.com; the tool uses that host only for the session-token exchange.",
+    "setup_url": "https://nova-sdk.com",
+    "env_var": "NOVA_API_KEY"
   }
 }

--- a/tools/nova-submit/prompts/nova-submit/submit_file.md
+++ b/tools/nova-submit/prompts/nova-submit/submit_file.md
@@ -2,10 +2,11 @@ Use this capability when the user asks to submit a hackathon entry, upload a fil
 
 Parameters:
 - account_id: The participant's NOVA account ID (e.g. alice.nova-sdk.near)
-- api_key: The participant's NOVA API key (from nova-sdk.com, treat as sensitive)
 - group_id: The NOVA group to upload into (e.g. ironclaw-hackathon-260618)
 - filename: A filename to record for the upload (e.g. submission.md)
 - file_content: The full text content to encrypt and upload
+
+The NOVA API key is a host-managed credential. Never ask the user to place it in tool parameters or chat.
 
 The tool performs the entire NOVA upload sequence internally: obtains a session token, calls prepare_upload for the encryption key, encrypts the file with AES-256-GCM, then calls finalize_upload to pin to IPFS and record on NEAR.
 

--- a/tools/nova-submit/schemas/nova-submit/invoke.input.v1.json
+++ b/tools/nova-submit/schemas/nova-submit/invoke.input.v1.json
@@ -5,15 +5,15 @@
   "properties": {
     "account_id": {
       "type": "string",
-      "description": "The participant's NOVA account ID, e.g. alice.nova-sdk.near."
+      "description": "The participant's NOVA account ID, e.g. `alice.nova-sdk.near`.\nUsed in the x-account-id / x-wallet-id headers and the auth body."
     },
     "group_id": {
       "type": "string",
-      "description": "The NOVA group to upload into, e.g. ironclaw-hackathon-barcelona."
+      "description": "The NOVA group to upload into, e.g. `ironclaw-hackathon-barcelona`."
     },
     "filename": {
       "type": "string",
-      "description": "The filename to record for this upload, e.g. submission.md."
+      "description": "The filename to record for this upload, e.g. `submission.md`."
     },
     "file_content": {
       "type": "string",

--- a/tools/nova-submit/schemas/nova-submit/submit_file.input.v1.json
+++ b/tools/nova-submit/schemas/nova-submit/submit_file.input.v1.json
@@ -7,10 +7,6 @@
       "type": "string",
       "description": "The participant's NOVA account ID, e.g. alice.nova-sdk.near."
     },
-    "api_key": {
-      "type": "string",
-      "description": "The participant's NOVA API key from nova-sdk.com."
-    },
     "group_id": {
       "type": "string",
       "description": "The NOVA group to upload into, e.g. ironclaw-hackathon-barcelona."
@@ -24,5 +20,5 @@
       "description": "The full file content to encrypt and upload (UTF-8 text)."
     }
   },
-  "required": ["account_id", "api_key", "group_id", "filename", "file_content"]
+  "required": ["account_id", "group_id", "filename", "file_content"]
 }

--- a/tools/nova-submit/src/lib.rs
+++ b/tools/nova-submit/src/lib.rs
@@ -444,6 +444,17 @@ mod tests {
     }
 
     #[test]
+    fn published_input_schema_matches_guest_parameters() {
+        let exported = serde_json::to_value(schemars::schema_for!(SubmitParams))
+            .expect("serialize submit schema");
+        let published: serde_json::Value =
+            serde_json::from_str(include_str!("../schemas/nova-submit/invoke.input.v1.json"))
+                .expect("published schema");
+        assert_eq!(published["properties"], exported["properties"]);
+        assert_eq!(published["required"], exported["required"]);
+    }
+
+    #[test]
     fn guest_session_headers_do_not_contain_api_key() {
         let headers: serde_json::Value =
             serde_json::from_str(&session_headers()).expect("parse session headers");

--- a/tools/nova-submit/src/lib.rs
+++ b/tools/nova-submit/src/lib.rs
@@ -45,12 +45,6 @@ struct SubmitParams {
     /// The participant's NOVA account ID, e.g. `alice.nova-sdk.near`.
     /// Used in the x-account-id / x-wallet-id headers and the auth body.
     account_id: String,
-    /// The participant's NOVA API key (from nova-sdk.com). Sent as the
-    /// `X-API-Key` header to the session-token endpoint. The IronClaw
-    /// agent reads this from its own configuration and passes it in;
-    /// it is not host-injected because NOVA uses a custom auth header,
-    /// not a bearer token.
-    api_key: String,
     /// The NOVA group to upload into, e.g. `ironclaw-hackathon-barcelona`.
     group_id: String,
     /// The filename to record for this upload, e.g. `submission.md`.
@@ -104,10 +98,10 @@ impl exports::near::agent::tool::Guest for NovaSubmitTool {
          Performs the full NOVA sequence (session token, prepare_upload, \
          client-side encryption, finalize_upload) internally and returns the \
          IPFS CID. Parameters: account_id (the participant's NOVA account, e.g. \
-         alice.nova-sdk.near), api_key (the participant's NOVA API key from \
-         nova-sdk.com), group_id (the NOVA group, e.g. \
+         alice.nova-sdk.near), group_id (the NOVA group, e.g. \
          ironclaw-hackathon-barcelona), filename (e.g. submission.md), and \
-         file_content (the full text to encrypt and upload)."
+         file_content (the full text to encrypt and upload). The NOVA API key \
+         is a host-managed credential and must not be supplied in parameters."
             .to_string()
     }
 }
@@ -116,12 +110,12 @@ fn execute_inner(params: &str) -> Result<String, String> {
     let p: SubmitParams = serde_json::from_str(params).map_err(|e| {
         host::log(
             host::LogLevel::Warn,
-            &format!("nova-submit parameter parse failed: {} | raw={}", e, params),
+            &format!("nova-submit parameter parse failed: {}", e),
         );
         format!(
             "Invalid parameters for nova-submit: {}. Expected: \
-             {{\"account_id\": \"<acct>.nova-sdk.near\", \"api_key\": \"<nova-api-key>\", \
-             \"group_id\": \"<group>\", \"filename\": \"<name>\", \
+             {{\"account_id\": \"<acct>.nova-sdk.near\", \"group_id\": \"<group>\", \
+             \"filename\": \"<name>\", \
              \"file_content\": \"<text>\"}}.",
             e
         )
@@ -136,7 +130,7 @@ fn execute_inner(params: &str) -> Result<String, String> {
     );
 
     // Step 1 — session token.
-    let token = get_session_token(&p.account_id, &p.api_key)?;
+    let token = get_session_token(&p.account_id)?;
 
     // Step 2 — prepare_upload: get encryption key + upload_id.
     let (upload_id, key_b64) = prepare_upload(&token, &p.account_id, &p.group_id, &p.filename)?;
@@ -242,20 +236,15 @@ fn derive_nonce_from_upload_id(upload_id: &str) -> [u8; 12] {
 /// Step 1: exchange the API key for a short-lived session token.
 ///
 /// NOVA's /api/auth/session-token requires the `X-API-Key` header plus
-/// `account_id` in the body (see nova-landing route.ts, Path 0). NOVA does
-/// not accept the key as a bearer token, so the host credential-injection
-/// mechanism (bearer-only across all known IronClaw tools) cannot be used —
-/// the key is passed in as a tool parameter and set as a header here.
-fn get_session_token(account_id: &str, api_key: &str) -> Result<String, String> {
+/// `account_id` in the body (see nova-landing route.ts, Path 0). The extension
+/// manifest binds the host-managed `nova_api_key` secret to `nova-sdk.com`, so
+/// the guest deliberately omits the secret header.
+fn get_session_token(account_id: &str) -> Result<String, String> {
     let body = serde_json::json!({ "account_id": account_id })
         .to_string()
         .into_bytes();
 
-    let headers = serde_json::json!({
-        "Content-Type": "application/json",
-        "X-API-Key": api_key,
-    })
-    .to_string();
+    let headers = session_headers();
 
     let resp = host::http_request("POST", NOVA_AUTH_URL, &headers, Some(&body), Some(30_000))
         .map_err(|e| format!("session-token request failed: {}", e))?;
@@ -274,6 +263,16 @@ fn get_session_token(account_id: &str, api_key: &str) -> Result<String, String> 
         .and_then(|t| t.as_str())
         .map(|s| s.to_string())
         .ok_or_else(|| "session-token response had no `token` field".to_string())
+}
+
+/// Guest-provided headers for the session exchange.
+///
+/// The host adds `X-API-Key` after the request crosses the credential boundary.
+fn session_headers() -> String {
+    serde_json::json!({
+        "Content-Type": "application/json",
+    })
+    .to_string()
 }
 
 /// Step 2: prepare_upload — returns (upload_id, key_b64).
@@ -434,5 +433,22 @@ mod tests {
         // so each encryption gets a fresh nonce even when the per-group key is reused.
         let c = derive_nonce_from_upload_id("upload-bbb");
         assert_ne!(a, c);
+    }
+
+    #[test]
+    fn model_schema_does_not_expose_api_key() {
+        let schema = serde_json::to_value(schemars::schema_for!(SubmitParams))
+            .expect("serialize submit schema");
+        let properties = schema["properties"].as_object().expect("schema properties");
+        assert!(!properties.contains_key("api_key"));
+    }
+
+    #[test]
+    fn guest_session_headers_do_not_contain_api_key() {
+        let headers: serde_json::Value =
+            serde_json::from_str(&session_headers()).expect("parse session headers");
+        assert_eq!(headers["Content-Type"], "application/json");
+        assert!(headers.get("X-API-Key").is_none());
+        assert!(headers.get("x-api-key").is_none());
     }
 }

--- a/tools/polymarket/polymarket-tool.capabilities.json
+++ b/tools/polymarket/polymarket-tool.capabilities.json
@@ -2,6 +2,7 @@
   "version": "0.1.0",
   "wit_version": "0.3.0",
   "description": "Polymarket public market intelligence integration. Reads markets, events, tags, series, sports, orderbooks, prices, positions, leaderboards, profiles, comments, and rewards configurations across the Polymarket prediction-market platform. No authentication required.",
+  "effects": [],
   "http": {
     "allowlist": [
       {

--- a/tools/wazuh/wazuh-tool.capabilities.json
+++ b/tools/wazuh/wazuh-tool.capabilities.json
@@ -1,7 +1,8 @@
 {
-  "version": "0.2.0",
+  "version": "0.1.0",
   "wit_version": "0.3.0",
   "description": "Wazuh SIEM/XDR read and control. Queries alerts, vulnerabilities, and top rule aggregations from the Wazuh Indexer (OpenSearch) over HTTP Basic auth, and exchanges Basic credentials for a short-lived JWT at /security/user/authenticate to drive the Wazuh Server API. Read actions: search_alerts, search_vulnerabilities, top_alert_rules, cluster_health, list_indices, list_agents, agent_summary. Control actions: restart_agent, add_agent, remove_agent, move_agent_to_group, trigger_active_response (push commands like firewall-drop to one agent or the entire fleet), restart_manager, update_cdb_list (push to CDB block/allow lists that drive the rule engine). Default hostnames assume the operator places `wazuh-indexer.local` and `wazuh-api.local` in /etc/hosts (or behind a local TLS reverse proxy with an mkcert certificate).",
+  "effects": ["external_write"],
   "http": {
     "allowlist": [
       {

--- a/tools/whatsapp/whatsapp-tool.capabilities.json
+++ b/tools/whatsapp/whatsapp-tool.capabilities.json
@@ -2,6 +2,7 @@
   "version": "0.1.0",
   "wit_version": "0.3.0",
   "description": "WhatsApp Cloud API via the Meta Graph API. Send messages (text, template, image, video, document, audio, location, contacts, interactive buttons and lists, reactions, and read receipts), manage the business profile, read phone number metadata, and manage message templates per WhatsApp Business Account. Authenticated with a permanent System User access token provisioned at deployment time; the exec does not OAuth into WhatsApp.",
+  "effects": ["external_write"],
   "http": {
     "allowlist": [
       {

--- a/tools/wordpress/wordpress-tool.capabilities.json
+++ b/tools/wordpress/wordpress-tool.capabilities.json
@@ -1,7 +1,8 @@
 {
-  "version": "0.1.0",
+  "version": "0.1.2",
   "wit_version": "0.3.0",
   "description": "Read and write a self-hosted WordPress + WooCommerce site over REST. Commands: 'wp_request' (raw passthrough to any /wp-json/* path) plus typed wrappers for posts (list/get/create/update/delete_post), products (list/get/create/update/delete_product), orders (list/get/update_order), and customers (list_customers). Every command takes a 'site_url' (your site host, e.g. 'mystore.com') that MUST match the host baked into 'allowlist' below at install. WordPress-core routes (/wp-json/wp/) authenticate with an Application Password (Basic, secret 'wp_app_password', username baked below); WooCommerce routes (/wp-json/wc/) authenticate with 'woo_consumer_key'/'woo_consumer_secret' sent as query params. The host injects all credentials; the tool never sees them. Requires HTTPS and pretty permalinks. INSTALL EDIT REQUIRED: replace YOUR_WP_HOST (2 places: allowlist.host and each host_patterns) and YOUR_WP_USERNAME (the Basic username) before installing.",
+  "effects": ["external_write"],
   "capabilities": {
     "http": {
       "allowlist": [

--- a/tools/xero/xero-tool.capabilities.json
+++ b/tools/xero/xero-tool.capabilities.json
@@ -2,6 +2,7 @@
   "version": "0.1.0",
   "wit_version": "0.3.0",
   "description": "Xero Accounting API integration. Reads contacts, invoices, accounts, payments, bank transactions, items, credit notes, the organisation, and financial reports; creates and updates contacts, invoices, and payments. Multi-tenant: every action except list_connections takes a tenant_id (discover ids via list_connections). Created invoices default to DRAFT and create actions accept an idempotency key. Authenticated with a user-authorized Xero OAuth2 token presented as a Bearer header against api.xero.com, with the Xero-tenant-id header set per call.",
+  "effects": ["external_write", "financial"],
   "http": {
     "allowlist": [
       {


### PR DESCRIPTION
## Summary

Follow-up to #257 that completes the security-relevant capabilities.json → Reborn manifest v3 translation. Published manifests now preserve explicit external-write/financial effects and OAuth scopes, fail closed when catalog versions or secret handles disagree, and semantically verify credential audiences, injection, requiredness, and scopes. Nova now keeps its API key out of model-visible parameters and guest logs/headers, relying on host injection bounded to `nova-sdk.com`.

Compatibility: all current catalog tools now declare effects explicitly; Wazuh and WordPress remain intentionally exempt from v3 publication because v3 cannot express HTTP Basic auth. Reborn v3 credential audiences are host-granular, so Nova retains its source path pattern but documents that path-level injection enforcement requires an IronClaw contract follow-up. Rolling back this PR restores the previous generated manifests and Nova parameter contract.

## Closes

N/A — follow-up to #257 and nearai/ironclaw#6780.

## Type

- [ ] Use case
- [ ] New tool
- [ ] New skill
- [x] Bug fix
- [x] Documentation / process
- [x] Infrastructure

## Artifact checklist

Use case PRs:

- [ ] Adds or updates `use-cases/<slug>/USE_CASE.md`
- [ ] Uses the exact seven-section `USE_CASE.md` template
- [ ] Uses strict skill/tool rows: `- name — description`
- [ ] Selects at least one category
- [x] Passes `node scripts/validate-use-cases.mjs`

Skill PRs:

- [ ] Adds or updates `skills/<skill-name>/SKILL.md`
- [ ] Documents required tool dependencies
- [ ] Includes activation behavior in `SKILL.md`
- [ ] Tests at least one prompt that should activate the skill

Tool PRs:

- [x] Adds or updates `tools/<tool-name>/README.md`
- [x] Adds or updates `tools/<tool-name>/<tool-name>-tool.capabilities.json`
- [x] Documents auth, scopes, limits, and target use cases
- [x] Tests representative action calls and records the results below

Docs/process PRs:

- [x] No `tracking.md` or README shipped-catalog change is needed
- [ ] Or, shipped catalog changes are reflected in both `tracking.md` and README

## Testing

- `PYTHONDONTWRITEBYTECODE=1 python3.11 scripts/test_generate_extension_manifest.py` — 13 passed, including TOML semantic checks for every supported tool.
- `PYTHONDONTWRITEBYTECODE=1 bash scripts/check-extension-manifests.sh` — 16 generated, 2 documented HTTP Basic exemptions, 0 failures.
- `cargo test --manifest-path tools/nova-submit/Cargo.toml` — 6 passed; verifies crypto behavior, model schema exclusion, and guest-header exclusion of the API key.
- `cargo clippy --manifest-path tools/nova-submit/Cargo.toml --tests --release -- -D warnings`
- `cargo clippy --manifest-path tools/nova-submit/Cargo.toml --target wasm32-wasip2 --release -- -D warnings`
- `cargo build --manifest-path tools/nova-submit/Cargo.toml --release --target wasm32-wasip2`
- `cargo fmt --manifest-path tools/nova-submit/Cargo.toml -- --check`
- `node scripts/validate-use-cases.mjs` — validated 107 use cases.
- Live Nova submission not run: it requires a real credential and performs an external write. The credential boundary is covered deterministically in unit and generated-manifest tests.



## Signed schema artifact delivery

This PR now includes the IronHub producer half of nearai/ironclaw#6780's verified-schema contract:

- Release generation requires every generated v3 manifest schema reference to exactly match a committed JSON schema asset.
- Referenced schemas are staged under deterministic path-addressed release filenames.
- The signed catalog records each manifest path with its release URL, byte size, and SHA-256 digest in the tool's `schemas` map.
- Missing, extra, invalid, oversized, or symlinked schemas fail release generation.
- Bluesky Analytics, Crypto TA Engine, Firecrawl, and NEAR Catalog now publish their previously missing schemas; Nova's input schema filename and live guest parameters are synchronized.
- Tool tests pin committed input schemas to the schema returned by the WASM guest.

Rollout order: merge #258 and allow its `main` release/catalog publication to complete before deploying the schema-consuming Ironclaw #6780 build. Older Ironclaw clients ignore the additive catalog field; the new client intentionally refuses installs from a stale catalog that lacks referenced schemas.

Additional validation:

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts -p 'test_*.py'` — 16 passed.
- `PYTHONDONTWRITEBYTECODE=1 bash scripts/check-extension-manifests.sh` — 16 generated, 2 documented exemptions, 0 failures.
- Real `scripts/generate-manifest.sh` EVM-RPC fixture — produced two staged schema assets and the exact signed-catalog path/URL/size/SHA-256 map.
- Native tests passed for Bluesky Analytics (5), Crypto TA Engine (30), Firecrawl (15), NEAR Catalog (17), and Nova Submit (7).
- Release-mode zero-warning test clippy passed for all five affected tool crates.
- Formatting, shell syntax, JSON-object validation, and `git diff --check` passed.

