### PR TITLE
Add a signed catalog version index and publish skill files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,3 +108,9 @@ jobs:
 
       - name: Typecheck
         run: pnpm --filter web typecheck
+
+      - name: Catalog tests
+        run: pnpm --filter web test:catalog
+
+      - name: Signing parity
+        run: pnpm --filter web signing:check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,11 +43,19 @@ jobs:
             cp "${dir}${name}-tool.capabilities.json" "staging/${name}.capabilities.json"
           done
 
+          . scripts/lib/skill-files.sh
+
           if [ -d skills ]; then
             for dir in skills/*/; do
               name="$(basename "$dir")"
               if [ -f "${dir}SKILL.md" ]; then
                 cp "${dir}SKILL.md" "staging/${name}.SKILL.md"
+
+                while IFS= read -r -d '' file; do
+                  rel="${file#"$dir"}"
+                  asset="$(skill_file_asset_name "$name" "$rel")"
+                  cp "$file" "staging/${asset}"
+                done < <(find "$dir" -type f ! -name SKILL.md -print0 | sort -z)
               fi
             done
           fi

--- a/scripts/generate-manifest.sh
+++ b/scripts/generate-manifest.sh
@@ -31,6 +31,9 @@ TAG="$2"
 REPO="$3"
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
+# shellcheck source=lib/skill-files.sh
+. "$ROOT/scripts/lib/skill-files.sh"
+
 base_url="https://github.com/${REPO}/releases/download/${TAG}"
 generated_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
@@ -132,6 +135,26 @@ if [ -d "$ROOT/skills" ]; then
     skill_size="$(stat -c '%s' "$skill_staged")"
     skill_sha="$(sha256sum "$skill_staged" | awk '{print $1}')"
 
+    files_json="[]"
+    while IFS= read -r -d '' file; do
+      rel="${file#"$dir"}"
+      asset="$(skill_file_asset_name "$name" "$rel")"
+      file_staged="${STAGING}/${asset}"
+
+      if [ ! -f "$file_staged" ]; then
+        echo "error: $name ships '$rel' but ${asset} was never staged" >&2
+        exit 1
+      fi
+
+      files_json="$(jq -n \
+        --argjson acc "$files_json" \
+        --arg path "$rel" \
+        --arg url "${base_url}/${asset}" \
+        --argjson size "$(stat -c '%s' "$file_staged")" \
+        --arg sha "$(sha256sum "$file_staged" | awk '{print $1}')" \
+        '$acc + [{ path: $path, url: $url, size_bytes: $size, sha256: $sha }]')"
+    done < <(find "$dir" -type f ! -name SKILL.md -print0 | sort -z)
+
     if [ $first -eq 0 ]; then
       skills_json+=","
     fi
@@ -145,13 +168,15 @@ if [ -d "$ROOT/skills" ]; then
       --arg skill_url "${base_url}/${name}.SKILL.md" \
       --argjson skill_size "$skill_size" \
       --arg skill_sha "$skill_sha" \
+      --argjson files "$files_json" \
       '{
         name: $name,
         trunk: $trunk,
         version: $version,
         description: $desc,
         skill_md: { url: $skill_url, size_bytes: $skill_size, sha256: $skill_sha }
-      }')
+      }
+      + (if ($files | length) == 0 then {} else { files: $files } end)')
   done
 fi
 skills_json+="]"

--- a/scripts/lib/skill-files.sh
+++ b/scripts/lib/skill-files.sh
@@ -1,0 +1,34 @@
+SKILL_FILE_PREFIX="files"
+SKILL_FILE_SEPARATOR="~"
+
+skill_file_asset_name() {
+  local skill="$1"
+  local rel="$2"
+
+  if [ -z "$rel" ]; then
+    echo "error: $skill has a skill file with an empty path" >&2
+    return 1
+  fi
+
+  case "$rel" in
+    /*)
+      echo "error: $skill ships '$rel', which is an absolute path" >&2
+      return 1
+      ;;
+    *..*)
+      echo "error: $skill ships '$rel', which escapes the skill directory" >&2
+      return 1
+      ;;
+    *"$SKILL_FILE_SEPARATOR"*)
+      echo "error: $skill ships '$rel', which contains the reserved '$SKILL_FILE_SEPARATOR' separator" >&2
+      return 1
+      ;;
+  esac
+
+  if printf '%s' "$rel" | grep -qv '^[A-Za-z0-9._/-]\+$'; then
+    echo "error: $skill ships '$rel', which is not a portable release-asset path" >&2
+    return 1
+  fi
+
+  printf '%s.%s.%s' "$skill" "$SKILL_FILE_PREFIX" "$(printf '%s' "$rel" | tr '/' "$SKILL_FILE_SEPARATOR")"
+}

--- a/web/app/api/catalog/manifest.json/route.ts
+++ b/web/app/api/catalog/manifest.json/route.ts
@@ -4,14 +4,14 @@ import {
   buildUnifiedManifest,
   CatalogManifestError,
 } from "@/lib/catalog/manifest.server"
-import { signManifest } from "@/lib/catalog/manifest-signing.server"
+import { signDocument } from "@/lib/catalog/manifest-signing.server"
 
 export const dynamic = "force-dynamic"
 
 export async function GET() {
   try {
     const manifest = await buildUnifiedManifest()
-    const envelope = signManifest(manifest)
+    const envelope = signDocument(manifest)
 
     return NextResponse.json(envelope, {
       headers: { "Cache-Control": "no-store" },

--- a/web/app/api/catalog/versions.json/route.ts
+++ b/web/app/api/catalog/versions.json/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server"
+
+import { CatalogManifestError } from "@/lib/catalog/manifest.server"
+import { signDocument } from "@/lib/catalog/manifest-signing.server"
+import { resolveVersionDocument } from "@/lib/catalog/versions.server"
+
+export const dynamic = "force-dynamic"
+
+export async function GET(request: Request) {
+  try {
+    const since = new URL(request.url).searchParams.get("since")
+    const document = await resolveVersionDocument(since)
+
+    return NextResponse.json(signDocument(document), {
+      headers: { "Cache-Control": "no-store" },
+    })
+  } catch (error) {
+    const status = error instanceof CatalogManifestError ? error.status : 500
+
+    return NextResponse.json(
+      { error: "Unable to build the IronHub catalog version index." },
+      { status }
+    )
+  }
+}

--- a/web/app/api/private-artifacts/manifest/[token]/route.ts
+++ b/web/app/api/private-artifacts/manifest/[token]/route.ts
@@ -1,4 +1,4 @@
-import { signManifest } from "@/lib/catalog/manifest-signing.server"
+import { signDocument } from "@/lib/catalog/manifest-signing.server"
 import { handleApiError } from "@/lib/http/api"
 import { buildPrivateArtifactManifest } from "@/lib/private-artifacts/manifest"
 import { verifyArtifactToken } from "@/lib/private-artifacts/token"
@@ -27,7 +27,7 @@ export async function GET(_request: Request, { params }: Params) {
       generatedAt: new Date().toISOString(),
     })
 
-    return Response.json(signManifest(manifest), {
+    return Response.json(signDocument(manifest), {
       headers: { "Cache-Control": "no-store" },
     })
   } catch (error) {

--- a/web/lib/catalog/manifest-signing.server.ts
+++ b/web/lib/catalog/manifest-signing.server.ts
@@ -1,6 +1,6 @@
 import { createPrivateKey, sign } from "node:crypto"
 
-import type { HubManifest } from "@/lib/catalog/manifest-types"
+import type { SignableDocument } from "@/lib/catalog/manifest-types"
 
 // key_id of the Ed25519 keypair whose PUBLIC half is embedded in IronClaw
 // (MANIFEST_VERIFY_KEYS). The private half is read from the environment and
@@ -31,16 +31,18 @@ function loadSigningKey() {
   }
 }
 
-// Signs the exact manifest bytes and carries them verbatim in the envelope so the
+// Signs the exact document bytes and carries them verbatim in the envelope so the
 // verifier reconstructs precisely what was signed (no JSON canonicalization gap).
-export function signManifest(manifest: HubManifest): SignedManifestEnvelope {
-  const manifestBytes = Buffer.from(JSON.stringify(manifest), "utf8")
+export function signDocument(
+  document: SignableDocument
+): SignedManifestEnvelope {
+  const documentBytes = Buffer.from(JSON.stringify(document), "utf8")
   const key = loadSigningKey()
-  const signature = sign(null, manifestBytes, key)
+  const signature = sign(null, documentBytes, key)
   return {
     v: 1,
     key_id: MANIFEST_SIGNING_KEY_ID,
-    manifest_b64: manifestBytes.toString("base64url"),
+    manifest_b64: documentBytes.toString("base64url"),
     sig: signature.toString("base64url"),
   }
 }

--- a/web/lib/catalog/manifest-types.ts
+++ b/web/lib/catalog/manifest-types.ts
@@ -22,6 +22,10 @@ export type HubToolEntry = {
   manifest?: HubArtifact
 }
 
+export type HubSkillFile = HubArtifact & {
+  path: string
+}
+
 export type HubSkillEntry = {
   name: string
   trunk: string
@@ -29,6 +33,7 @@ export type HubSkillEntry = {
   description: string
   provenance: Provenance
   skill_md: HubArtifact
+  files?: HubSkillFile[]
 }
 
 export type HubManifest = {
@@ -39,3 +44,30 @@ export type HubManifest = {
   tools: HubToolEntry[]
   skills: HubSkillEntry[]
 }
+
+export type VersionEntry = {
+  kind: "tool" | "skill"
+  name: string
+  version: string
+  digest: string
+}
+
+type VersionDocumentHeader = {
+  version: "1"
+  generated_at: string
+  release_tag: string
+  repo: string
+}
+
+export type VersionIndex = VersionDocumentHeader & {
+  entries: VersionEntry[]
+}
+
+export type VersionIndexUnchanged = VersionDocumentHeader & {
+  unchanged: true
+}
+
+export type SignableDocument =
+  | HubManifest
+  | VersionIndex
+  | VersionIndexUnchanged

--- a/web/lib/catalog/manifest.server.ts
+++ b/web/lib/catalog/manifest.server.ts
@@ -56,12 +56,14 @@ type GithubTool = {
   capabilities: GithubArtifact
   manifest?: GithubArtifact | null
 }
+type GithubSkillFile = GithubArtifact & { path: string }
 type GithubSkill = {
   name: string
   trunk?: string | null
   version: string
   description?: string | null
   skill_md: GithubArtifact
+  files?: GithubSkillFile[] | null
 }
 type GithubManifest = {
   release_tag?: string
@@ -142,8 +144,35 @@ async function fetchOfficialManifest(): Promise<{
     description: skill.description ?? "",
     provenance: "official" as const,
     skill_md: rewriteGithubArtifact(skill.skill_md),
+    ...(skill.files?.length
+      ? {
+          files: skill.files
+            .filter((file) => {
+              if (isPublishableSkillPath(file.path)) {
+                return true
+              }
+              console.error(
+                `Skipping skill file with an unpublishable path: ${skill.name}/${file.path}`
+              )
+              return false
+            })
+            .map((file) => ({
+              path: file.path,
+              ...rewriteGithubArtifact(file),
+            })),
+        }
+      : {}),
   }))
   return { releaseTag: manifest.release_tag ?? "live", tools, skills }
+}
+
+const PUBLISHABLE_SKILL_PATH = /^[A-Za-z0-9._/-]+$/
+
+function isPublishableSkillPath(path: string) {
+  if (!path || path.startsWith("/") || !PUBLISHABLE_SKILL_PATH.test(path)) {
+    return false
+  }
+  return !path.split("/").includes("..")
 }
 
 function rewriteGithubArtifact(artifact: GithubArtifact) {

--- a/web/lib/catalog/versions.server.ts
+++ b/web/lib/catalog/versions.server.ts
@@ -1,0 +1,17 @@
+import { buildUnifiedManifest } from "@/lib/catalog/manifest.server"
+import { createVersionResolver, toVersionIndex } from "@/lib/catalog/versions"
+
+const INDEX_CACHE_TTL_MS = 30_000
+const INDEX_STALE_LIMIT_MS = 10 * 60_000
+
+export const resolveVersionDocument = createVersionResolver({
+  load: async () => toVersionIndex(await buildUnifiedManifest()),
+  ttlMs: INDEX_CACHE_TTL_MS,
+  staleMs: INDEX_STALE_LIMIT_MS,
+  onStale: (error, ageMs) => {
+    console.error(
+      `Serving a ${Math.round(ageMs / 1000)}s stale catalog version index after a rebuild failure`,
+      error
+    )
+  },
+})

--- a/web/lib/catalog/versions.test.mjs
+++ b/web/lib/catalog/versions.test.mjs
@@ -1,0 +1,330 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  createVersionResolver,
+  entryDigest,
+  toUnchanged,
+  toVersionIndex,
+} from "./versions.ts"
+
+const artifact = (sha256) => ({
+  url: `https://hub.ironclaw.com/${sha256}`,
+  size_bytes: 1,
+  sha256,
+})
+
+const manifest = (overrides = {}) => ({
+  version: "1",
+  generated_at: "2026-07-31T00:00:00.000Z",
+  release_tag: "release-2026-07-31-1",
+  repo: "nearai/ironhub",
+  tools: [],
+  skills: [],
+  ...overrides,
+})
+
+const tool = (overrides = {}) => ({
+  name: "attio",
+  crate_name: "attio-tool",
+  version: "0.1.0",
+  description: "",
+  provenance: "official",
+  wasm: artifact("a".repeat(64)),
+  capabilities: artifact("b".repeat(64)),
+  ...overrides,
+})
+
+const skill = (overrides = {}) => ({
+  name: "chief-of-staff",
+  trunk: "",
+  version: "1.0.0",
+  description: "",
+  provenance: "official",
+  skill_md: artifact("c".repeat(64)),
+  ...overrides,
+})
+
+const digestOf = (entries, kind, name) =>
+  entries.find((entry) => entry.kind === kind && entry.name === name).digest
+
+test("a manifest-only change moves the tool digest", () => {
+  const before = toVersionIndex(manifest({ tools: [tool()] })).entries
+  const after = toVersionIndex(
+    manifest({ tools: [tool({ manifest: artifact("d".repeat(64)) })] })
+  ).entries
+
+  assert.notEqual(
+    digestOf(before, "tool", "attio"),
+    digestOf(after, "tool", "attio")
+  )
+})
+
+test("a script change moves the skill digest while SKILL.md is untouched", () => {
+  const files = [{ path: "python_scripts/run.py", ...artifact("1".repeat(64)) }]
+  const changed = [
+    { path: "python_scripts/run.py", ...artifact("2".repeat(64)) },
+  ]
+
+  const before = toVersionIndex(manifest({ skills: [skill({ files })] })).entries
+  const after = toVersionIndex(
+    manifest({ skills: [skill({ files: changed })] })
+  ).entries
+
+  assert.notEqual(
+    digestOf(before, "skill", "chief-of-staff"),
+    digestOf(after, "skill", "chief-of-staff")
+  )
+})
+
+test("adding or removing a skill file moves the digest", () => {
+  const one = [{ path: "a.py", ...artifact("1".repeat(64)) }]
+  const two = [...one, { path: "b.py", ...artifact("2".repeat(64)) }]
+
+  const before = toVersionIndex(
+    manifest({ skills: [skill({ files: one })] })
+  ).entries
+  const after = toVersionIndex(
+    manifest({ skills: [skill({ files: two })] })
+  ).entries
+
+  assert.notEqual(
+    digestOf(before, "skill", "chief-of-staff"),
+    digestOf(after, "skill", "chief-of-staff")
+  )
+})
+
+test("skill file ordering does not change the digest", () => {
+  const ordered = [
+    { path: "a.py", ...artifact("1".repeat(64)) },
+    { path: "b.py", ...artifact("2".repeat(64)) },
+  ]
+  const reversed = [...ordered].reverse()
+
+  const first = toVersionIndex(
+    manifest({ skills: [skill({ files: ordered })] })
+  ).entries
+  const second = toVersionIndex(
+    manifest({ skills: [skill({ files: reversed })] })
+  ).entries
+
+  assert.equal(
+    digestOf(first, "skill", "chief-of-staff"),
+    digestOf(second, "skill", "chief-of-staff")
+  )
+})
+
+test("the encoding stays injective if an artifact identity is ever variable-width", () => {
+  assert.notEqual(
+    entryDigest([artifact("ab"), artifact("c")]),
+    entryDigest([artifact("a"), artifact("bc")])
+  )
+})
+
+test("two real fixed-width digests do not collide when their order swaps", () => {
+  const first = artifact("1".repeat(64))
+  const second = artifact("2".repeat(64))
+
+  assert.notEqual(
+    entryDigest([first, second]),
+    entryDigest([second, first])
+  )
+})
+
+test("an absent artifact is distinct from an empty one", () => {
+  assert.notEqual(entryDigest([undefined]), entryDigest([undefined, undefined]))
+})
+
+test("entries are ordered independently of manifest order", () => {
+  const forward = toVersionIndex(
+    manifest({ tools: [tool({ name: "zeta" }), tool({ name: "alpha" })] })
+  ).entries
+  const backward = toVersionIndex(
+    manifest({ tools: [tool({ name: "alpha" }), tool({ name: "zeta" })] })
+  ).entries
+
+  assert.deepEqual(
+    forward.map((entry) => entry.name),
+    backward.map((entry) => entry.name)
+  )
+})
+
+test("the unchanged reply keeps identity and drops entries", () => {
+  const index = toVersionIndex(manifest({ tools: [tool()] }))
+  const unchanged = toUnchanged(index)
+
+  assert.deepEqual(unchanged, {
+    version: "1",
+    generated_at: index.generated_at,
+    release_tag: index.release_tag,
+    repo: index.repo,
+    unchanged: true,
+  })
+  assert.equal("entries" in unchanged, false)
+})
+
+const resolverFixture = () => {
+  let calls = 0
+  let clock = 0
+  const resolve = createVersionResolver({
+    load: async () => {
+      calls += 1
+      return toVersionIndex(
+        manifest({ release_tag: `release-${calls}`, tools: [tool()] })
+      )
+    },
+    ttlMs: 1000,
+    staleMs: 60_000,
+    now: () => clock,
+  })
+  return {
+    resolve,
+    calls: () => calls,
+    advance: (ms) => {
+      clock += ms
+    },
+  }
+}
+
+test("a cached index is reused inside the ttl and rebuilt after it", async () => {
+  const fixture = resolverFixture()
+
+  await fixture.resolve()
+  await fixture.resolve()
+  assert.equal(fixture.calls(), 1)
+
+  fixture.advance(1001)
+  await fixture.resolve()
+  assert.equal(fixture.calls(), 2)
+})
+
+test("a matching since returns unchanged, a stale one returns the full index", async () => {
+  const fixture = resolverFixture()
+
+  const full = await fixture.resolve()
+  const unchanged = await fixture.resolve(full.release_tag)
+  const stale = await fixture.resolve("release-from-last-week")
+
+  assert.equal(unchanged.unchanged, true)
+  assert.equal("entries" in unchanged, false)
+  assert.deepEqual(stale.entries, full.entries)
+})
+
+test("an absent since always returns the full index", async () => {
+  const fixture = resolverFixture()
+
+  assert.ok((await fixture.resolve()).entries)
+  assert.ok((await fixture.resolve(null)).entries)
+  assert.ok((await fixture.resolve("")).entries)
+})
+
+test("concurrent misses collapse into a single build", async () => {
+  const fixture = resolverFixture()
+
+  const results = await Promise.all([
+    fixture.resolve(),
+    fixture.resolve(),
+    fixture.resolve(),
+  ])
+
+  assert.equal(fixture.calls(), 1)
+  assert.equal(new Set(results.map((r) => r.release_tag)).size, 1)
+})
+
+test("unchanged is never served for a release the caller has not seen", async () => {
+  const fixture = resolverFixture()
+
+  const first = await fixture.resolve()
+  fixture.advance(1001)
+  const afterRelease = await fixture.resolve(first.release_tag)
+
+  assert.equal(afterRelease.unchanged, undefined)
+  assert.notEqual(afterRelease.release_tag, first.release_tag)
+})
+
+const failingResolverFixture = ({ staleMs }) => {
+  let fail = false
+  let clock = 0
+  let staleCalls = 0
+  const resolve = createVersionResolver({
+    load: async () => {
+      if (fail) {
+        throw new Error("upstream unavailable")
+      }
+      return toVersionIndex(manifest({ tools: [tool()] }))
+    },
+    ttlMs: 1000,
+    staleMs,
+    now: () => clock,
+    onStale: () => {
+      staleCalls += 1
+    },
+  })
+  return {
+    resolve,
+    breakUpstream: () => {
+      fail = true
+    },
+    advance: (ms) => {
+      clock += ms
+    },
+    staleCalls: () => staleCalls,
+  }
+}
+
+test("a rebuild failure serves the cached index rather than failing the request", async () => {
+  const fixture = failingResolverFixture({ staleMs: 60_000 })
+
+  const fresh = await fixture.resolve()
+  fixture.breakUpstream()
+  fixture.advance(1001)
+  const served = await fixture.resolve()
+
+  assert.equal(served.release_tag, fresh.release_tag)
+  assert.equal(fixture.staleCalls(), 1)
+})
+
+test("a cached index past the stale limit fails rather than being served", async () => {
+  const fixture = failingResolverFixture({ staleMs: 5000 })
+
+  await fixture.resolve()
+  fixture.breakUpstream()
+  fixture.advance(5001)
+
+  await assert.rejects(() => fixture.resolve(), /upstream unavailable/)
+})
+
+test("a first-ever load failure has nothing to fall back to and throws", async () => {
+  const fixture = failingResolverFixture({ staleMs: 60_000 })
+
+  fixture.breakUpstream()
+  await assert.rejects(() => fixture.resolve(), /upstream unavailable/)
+  assert.equal(fixture.staleCalls(), 0)
+})
+
+test("a recovered upstream replaces the stale index", async () => {
+  let fail = false
+  let clock = 0
+  let tag = 1
+  const resolve = createVersionResolver({
+    load: async () => {
+      if (fail) {
+        throw new Error("upstream unavailable")
+      }
+      return toVersionIndex(manifest({ release_tag: `release-${tag}` }))
+    },
+    ttlMs: 1000,
+    staleMs: 60_000,
+    now: () => clock,
+  })
+
+  await resolve()
+  fail = true
+  clock += 1001
+  assert.equal((await resolve()).release_tag, "release-1")
+
+  fail = false
+  tag = 2
+  clock += 1001
+  assert.equal((await resolve()).release_tag, "release-2")
+})

--- a/web/lib/catalog/versions.ts
+++ b/web/lib/catalog/versions.ts
@@ -1,0 +1,127 @@
+import { createHash } from "node:crypto"
+
+import type {
+  HubArtifact,
+  HubManifest,
+  VersionEntry,
+  VersionIndex,
+  VersionIndexUnchanged,
+} from "@/lib/catalog/manifest-types"
+
+export function entryDigest(artifacts: (HubArtifact | undefined)[]) {
+  const hash = createHash("sha256")
+  for (const artifact of artifacts) {
+    const value = artifact?.sha256 ?? ""
+    hash.update(String(Buffer.byteLength(value, "utf8")))
+    hash.update(":")
+    hash.update(value)
+    hash.update(":")
+  }
+  return `sha256:${hash.digest("hex")}`
+}
+
+function byPath(left: { path: string }, right: { path: string }) {
+  return left.path.localeCompare(right.path)
+}
+
+export function toVersionEntries(manifest: HubManifest): VersionEntry[] {
+  const entries: VersionEntry[] = [
+    ...manifest.tools.map((tool) => ({
+      kind: "tool" as const,
+      name: tool.name,
+      version: tool.version,
+      digest: entryDigest([tool.wasm, tool.capabilities, tool.manifest]),
+    })),
+    ...manifest.skills.map((skill) => ({
+      kind: "skill" as const,
+      name: skill.name,
+      version: skill.version,
+      digest: entryDigest([
+        skill.skill_md,
+        ...[...(skill.files ?? [])].sort(byPath),
+      ]),
+    })),
+  ]
+
+  return entries.sort((left, right) =>
+    left.kind === right.kind
+      ? left.name.localeCompare(right.name)
+      : left.kind.localeCompare(right.kind)
+  )
+}
+
+export function toVersionIndex(manifest: HubManifest): VersionIndex {
+  return {
+    version: "1",
+    generated_at: manifest.generated_at,
+    release_tag: manifest.release_tag,
+    repo: manifest.repo,
+    entries: toVersionEntries(manifest),
+  }
+}
+
+export function toUnchanged(index: VersionIndex): VersionIndexUnchanged {
+  return {
+    version: index.version,
+    generated_at: index.generated_at,
+    release_tag: index.release_tag,
+    repo: index.repo,
+    unchanged: true,
+  }
+}
+
+export type VersionResolverOptions = {
+  load: () => Promise<VersionIndex>
+  ttlMs: number
+  staleMs: number
+  now?: () => number
+  onStale?: (error: unknown, ageMs: number) => void
+}
+
+export function createVersionResolver({
+  load,
+  ttlMs,
+  staleMs,
+  now = Date.now,
+  onStale,
+}: VersionResolverOptions) {
+  let cached: { builtAtMs: number; index: VersionIndex } | null = null
+  let inFlight: Promise<VersionIndex> | null = null
+
+  async function currentIndex(): Promise<VersionIndex> {
+    if (cached && now() - cached.builtAtMs < ttlMs) {
+      return cached.index
+    }
+    if (!inFlight) {
+      inFlight = load()
+        .then((index) => {
+          cached = { builtAtMs: now(), index }
+          return index
+        })
+        .finally(() => {
+          inFlight = null
+        })
+    }
+
+    try {
+      return await inFlight
+    } catch (error) {
+      if (!cached) {
+        throw error
+      }
+      const ageMs = now() - cached.builtAtMs
+      if (ageMs > staleMs) {
+        throw error
+      }
+      onStale?.(error, ageMs)
+      return cached.index
+    }
+  }
+
+  return async function resolve(
+    since?: string | null
+  ): Promise<VersionIndex | VersionIndexUnchanged> {
+    const index = await currentIndex()
+    return since && since === index.release_tag ? toUnchanged(index) : index
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "eslint",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
-    "test:catalog": "node --experimental-strip-types --test lib/catalog/parsers.test.mjs",
+    "test:catalog": "node --experimental-strip-types --test \"lib/catalog/*.test.mjs\"",
     "typecheck": "tsc --noEmit",
     "signing:check": "node scripts/check-manifest-signing.mjs && node scripts/check-install-payload-signing.mjs",
     "db:migrate": "prisma migrate dev",


### PR DESCRIPTION
Agents had no way to ask what changed without pulling the whole catalog. The
version index answers that from a signed document that stays flat when the
caller is already current, and its per-entry digest covers every artifact so a
manifest-only change cannot hide behind an unchanged wasm. Skills also publish
the files they ship as digested artifacts.