### PR TITLE
fix(web): preserve tool schemas in signed catalog

### DIFF
--- a/web/lib/catalog/manifest-types.ts
+++ b/web/lib/catalog/manifest-types.ts
@@ -20,6 +20,7 @@ export type HubToolEntry = {
   wasm: HubArtifact
   capabilities: HubArtifact
   manifest?: HubArtifact
+  schemas?: Record<string, HubArtifact>
 }
 
 export type HubSkillFile = HubArtifact & {

--- a/web/lib/catalog/manifest.server.ts
+++ b/web/lib/catalog/manifest.server.ts
@@ -10,6 +10,12 @@ import type {
   Provenance,
 } from "@/lib/catalog/manifest-types"
 import {
+  isPublishableArtifactPath,
+  officialToolEntry,
+  type GithubArtifact,
+  type GithubTool,
+} from "@/lib/catalog/official-tools"
+import {
   fetchIliadPublicSkill,
   fetchIliadPublicSkillsList,
 } from "@/lib/iliad/public-skills.server"
@@ -46,16 +52,6 @@ export class CatalogManifestError extends Error {
   }
 }
 
-type GithubArtifact = { url: string; size_bytes: number; sha256: string }
-type GithubTool = {
-  name: string
-  crate_name?: string | null
-  version: string
-  description?: string | null
-  wasm: GithubArtifact
-  capabilities: GithubArtifact
-  manifest?: GithubArtifact | null
-}
 type GithubSkillFile = GithubArtifact & { path: string }
 type GithubSkill = {
   name: string
@@ -125,18 +121,9 @@ async function fetchOfficialManifest(): Promise<{
     )
   }
   const manifest = (await response.json()) as GithubManifest
-  const tools = (manifest.tools ?? []).map((tool) => ({
-    name: tool.name,
-    crate_name: tool.crate_name ?? tool.name,
-    version: tool.version,
-    description: tool.description ?? "",
-    provenance: "official" as const,
-    wasm: rewriteGithubArtifact(tool.wasm),
-    capabilities: rewriteGithubArtifact(tool.capabilities),
-    ...(tool.manifest
-      ? { manifest: rewriteGithubArtifact(tool.manifest) }
-      : {}),
-  }))
+  const tools = (manifest.tools ?? []).map((tool) =>
+    officialToolEntry(tool, (url) => hubArtifactUrl(["g", url]))
+  )
   const skills = (manifest.skills ?? []).map((skill) => ({
     name: skill.name,
     trunk: skill.trunk ?? "",
@@ -148,7 +135,7 @@ async function fetchOfficialManifest(): Promise<{
       ? {
           files: skill.files
             .filter((file) => {
-              if (isPublishableSkillPath(file.path)) {
+              if (isPublishableArtifactPath(file.path)) {
                 return true
               }
               console.error(
@@ -164,15 +151,6 @@ async function fetchOfficialManifest(): Promise<{
       : {}),
   }))
   return { releaseTag: manifest.release_tag ?? "live", tools, skills }
-}
-
-const PUBLISHABLE_SKILL_PATH = /^[A-Za-z0-9._/-]+$/
-
-function isPublishableSkillPath(path: string) {
-  if (!path || path.startsWith("/") || !PUBLISHABLE_SKILL_PATH.test(path)) {
-    return false
-  }
-  return !path.split("/").includes("..")
 }
 
 function rewriteGithubArtifact(artifact: GithubArtifact) {

--- a/web/lib/catalog/official-tools.test.mjs
+++ b/web/lib/catalog/official-tools.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  isPublishableArtifactPath,
+  officialToolEntry,
+} from "./official-tools.ts"
+
+const artifact = (name) => ({
+  url: `https://github.com/nearai/ironhub/releases/download/test/${name}`,
+  size_bytes: 1,
+  sha256: name.padEnd(64, "0"),
+})
+
+test("official tool schemas retain their manifest paths and use proxy URLs", () => {
+  const tool = officialToolEntry(
+    {
+      name: "firecrawl",
+      version: "0.1.0",
+      wasm: artifact("wasm"),
+      capabilities: artifact("capabilities"),
+      manifest: artifact("manifest"),
+      schemas: {
+        "schemas/firecrawl/invoke.input.v1.json": artifact("input"),
+        "schemas/firecrawl/raw_output.v1.json": artifact("output"),
+      },
+    },
+    (url) => `https://hub.ironclaw.com/artifact/${encodeURIComponent(url)}`
+  )
+
+  assert.deepEqual(Object.keys(tool.schemas ?? {}).sort(), [
+    "schemas/firecrawl/invoke.input.v1.json",
+    "schemas/firecrawl/raw_output.v1.json",
+  ])
+  assert.match(
+    tool.schemas["schemas/firecrawl/invoke.input.v1.json"].url,
+    /^https:\/\/hub\.ironclaw\.com\/artifact\//
+  )
+})
+
+test("only relative package asset paths are publishable", () => {
+  assert.equal(
+    isPublishableArtifactPath("schemas/firecrawl/invoke.input.v1.json"),
+    true
+  )
+  assert.equal(isPublishableArtifactPath("../secret.json"), false)
+  assert.equal(isPublishableArtifactPath("/schemas/input.json"), false)
+  assert.equal(isPublishableArtifactPath("schemas/input file.json"), false)
+})

--- a/web/lib/catalog/official-tools.ts
+++ b/web/lib/catalog/official-tools.ts
@@ -1,0 +1,63 @@
+import type { HubArtifact, HubToolEntry } from "@/lib/catalog/manifest-types"
+
+export type GithubArtifact = {
+  url: string
+  size_bytes: number
+  sha256: string
+}
+
+export type GithubTool = {
+  name: string
+  crate_name?: string | null
+  version: string
+  description?: string | null
+  wasm: GithubArtifact
+  capabilities: GithubArtifact
+  manifest?: GithubArtifact | null
+  schemas?: Record<string, GithubArtifact> | null
+}
+
+const PUBLISHABLE_ARTIFACT_PATH = /^[A-Za-z0-9._/-]+$/
+
+export function isPublishableArtifactPath(path: string) {
+  if (!path || path.startsWith("/") || !PUBLISHABLE_ARTIFACT_PATH.test(path)) {
+    return false
+  }
+  return !path.split("/").includes("..")
+}
+
+export function officialToolEntry(
+  tool: GithubTool,
+  artifactUrl: (upstreamUrl: string) => string
+): HubToolEntry {
+  const rewriteArtifact = (artifact: GithubArtifact): HubArtifact => ({
+    url: artifactUrl(artifact.url),
+    size_bytes: artifact.size_bytes,
+    sha256: artifact.sha256,
+  })
+  const schemas = Object.fromEntries(
+    Object.entries(tool.schemas ?? {})
+      .filter(([path]) => {
+        if (isPublishableArtifactPath(path)) {
+          return true
+        }
+        console.error(
+          `Skipping tool schema with an unpublishable path: ${tool.name}/${path}`
+        )
+        return false
+      })
+      .map(([path, artifact]) => [path, rewriteArtifact(artifact)])
+  )
+
+  return {
+    name: tool.name,
+    crate_name: tool.crate_name ?? tool.name,
+    version: tool.version,
+    description: tool.description ?? "",
+    provenance: "official",
+    wasm: rewriteArtifact(tool.wasm),
+    capabilities: rewriteArtifact(tool.capabilities),
+    ...(tool.manifest ? { manifest: rewriteArtifact(tool.manifest) } : {}),
+    ...(tool.schemas ? { schemas } : {}),
+  }
+}

--- a/web/lib/catalog/versions.test.mjs
+++ b/web/lib/catalog/versions.test.mjs
@@ -60,6 +60,48 @@ test("a manifest-only change moves the tool digest", () => {
   )
 })
 
+test("a schema-only change moves the tool digest", () => {
+  const path = "schemas/attio/invoke.input.v1.json"
+  const before = toVersionIndex(
+    manifest({
+      tools: [tool({ schemas: { [path]: artifact("1".repeat(64)) } })],
+    })
+  ).entries
+  const after = toVersionIndex(
+    manifest({
+      tools: [tool({ schemas: { [path]: artifact("2".repeat(64)) } })],
+    })
+  ).entries
+
+  assert.notEqual(
+    digestOf(before, "tool", "attio"),
+    digestOf(after, "tool", "attio")
+  )
+})
+
+test("tool schema ordering does not change the digest", () => {
+  const first = {
+    "schemas/attio/a.json": artifact("1".repeat(64)),
+    "schemas/attio/b.json": artifact("2".repeat(64)),
+  }
+  const second = {
+    "schemas/attio/b.json": artifact("2".repeat(64)),
+    "schemas/attio/a.json": artifact("1".repeat(64)),
+  }
+
+  const before = toVersionIndex(
+    manifest({ tools: [tool({ schemas: first })] })
+  ).entries
+  const after = toVersionIndex(
+    manifest({ tools: [tool({ schemas: second })] })
+  ).entries
+
+  assert.equal(
+    digestOf(before, "tool", "attio"),
+    digestOf(after, "tool", "attio")
+  )
+})
+
 test("a script change moves the skill digest while SKILL.md is untouched", () => {
   const files = [{ path: "python_scripts/run.py", ...artifact("1".repeat(64)) }]
   const changed = [

--- a/web/lib/catalog/versions.ts
+++ b/web/lib/catalog/versions.ts
@@ -24,13 +24,24 @@ function byPath(left: { path: string }, right: { path: string }) {
   return left.path.localeCompare(right.path)
 }
 
+function toolSchemaArtifacts(tool: HubManifest["tools"][number]) {
+  return Object.entries(tool.schemas ?? {})
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([, artifact]) => artifact)
+}
+
 export function toVersionEntries(manifest: HubManifest): VersionEntry[] {
   const entries: VersionEntry[] = [
     ...manifest.tools.map((tool) => ({
       kind: "tool" as const,
       name: tool.name,
       version: tool.version,
-      digest: entryDigest([tool.wasm, tool.capabilities, tool.manifest]),
+      digest: entryDigest([
+        tool.wasm,
+        tool.capabilities,
+        tool.manifest,
+        ...toolSchemaArtifacts(tool),
+      ]),
     })),
     ...manifest.skills.map((skill) => ({
       kind: "skill" as const,


### PR DESCRIPTION
## Summary

Preserve each official tool schema artifact while translating release `tools.json` into the signed unified catalog. Schema paths are validated and artifact URLs are rewritten through the IronHub proxy, and the signed version index now includes schema digests so schema-only updates are observable. This restores installation for v3 tools such as Firecrawl without weakening Ironclaw package validation.

## Closes

Follow-up to #258 and nearai/ironclaw#6780.

## Type

- [ ] Use case
- [ ] New tool
- [ ] New skill
- [x] Bug fix
- [ ] Documentation / process
- [x] Infrastructure

## Artifact checklist

Use case PRs:

- [ ] Not applicable: no use case changes.

Skill PRs:

- [ ] Not applicable: no skill changes.

Tool PRs:

- [ ] Not applicable: existing release schema artifacts are unchanged; this fixes their web delivery.

Docs/process PRs:

- [x] No `tracking.md` or README shipped-catalog change is needed.
- [ ] Or, shipped catalog changes are reflected in both `tracking.md` and README.

## Testing

- `pnpm --filter web test:catalog` — 25 passed, including schema delivery, path validation, schema-only digest changes, and ordering stability.
- `DATABASE_URL=postgresql://ironhub:ironhub@localhost:5432/ironhub pnpm --filter web db:generate`
- `pnpm --filter web typecheck`
- `pnpm --filter web signing:check`
- `pnpm --filter web lint` — 0 errors; one unrelated pre-existing unused import warning in `app/mvp/manage/[submissionId]/page.tsx`.
- Live release fixture check against `release-2026-07-31-99` preserved schema maps for all 16 v3 tools and both Firecrawl schema paths.

## Compatibility and rollout

The signed catalog field is additive; older clients ignore it. The current release already contains the schema files and digests, so deploying this web change is sufficient and no replacement tool release is required. Rolling back restores the incomplete catalog behavior and causes schema-consuming Ironclaw clients to reject v3 tool installation.