### PR TITLE
Match the client's schema path and artifact limits

### DIFF
--- a/web/lib/catalog/official-tools.test.mjs
+++ b/web/lib/catalog/official-tools.test.mjs
@@ -46,4 +46,48 @@ test("only relative package asset paths are publishable", () => {
   assert.equal(isPublishableArtifactPath("../secret.json"), false)
   assert.equal(isPublishableArtifactPath("/schemas/input.json"), false)
   assert.equal(isPublishableArtifactPath("schemas/input file.json"), false)
+  assert.equal(isPublishableArtifactPath("schemas/./input.json"), false)
+  assert.equal(isPublishableArtifactPath("schemas//input.json"), false)
+})
+
+test("schema artifacts past the client cap are dropped, not published", () => {
+  const schemas = {}
+  for (let index = 0; index < 40; index += 1) {
+    schemas[`schemas/attio/field${String(index).padStart(2, "0")}.json`] =
+      artifact(`field${index}`)
+  }
+  const tool = officialToolEntry(
+    {
+      name: "attio",
+      version: "0.1.0",
+      wasm: artifact("wasm"),
+      capabilities: artifact("capabilities"),
+      schemas,
+    },
+    (url) => url
+  )
+
+  const published = Object.keys(tool.schemas ?? {})
+  assert.equal(published.length, 32)
+  assert.deepEqual(published, [...published].sort())
+  assert.equal(published[0], "schemas/attio/field00.json")
+})
+
+test("a tool whose schema paths are all unpublishable omits the field", () => {
+  const tool = officialToolEntry(
+    {
+      name: "attio",
+      version: "0.1.0",
+      wasm: artifact("wasm"),
+      capabilities: artifact("capabilities"),
+      schemas: {
+        "../escape.json": artifact("escape"),
+        "schemas/./input.json": artifact("dot"),
+        "schemas//input.json": artifact("empty"),
+      },
+    },
+    (url) => url
+  )
+
+  assert.equal("schemas" in tool, false)
 })

--- a/web/lib/catalog/official-tools.ts
+++ b/web/lib/catalog/official-tools.ts
@@ -18,12 +18,15 @@ export type GithubTool = {
 }
 
 const PUBLISHABLE_ARTIFACT_PATH = /^[A-Za-z0-9._/-]+$/
+const MAX_TOOL_SCHEMA_ARTIFACTS = 32
 
 export function isPublishableArtifactPath(path: string) {
   if (!path || path.startsWith("/") || !PUBLISHABLE_ARTIFACT_PATH.test(path)) {
     return false
   }
-  return !path.split("/").includes("..")
+  return path
+    .split("/")
+    .every((segment) => segment !== "" && segment !== "." && segment !== "..")
 }
 
 export function officialToolEntry(
@@ -35,17 +38,25 @@ export function officialToolEntry(
     size_bytes: artifact.size_bytes,
     sha256: artifact.sha256,
   })
+  const publishable = Object.entries(tool.schemas ?? {})
+    .filter(([path]) => {
+      if (isPublishableArtifactPath(path)) {
+        return true
+      }
+      console.error(
+        `Skipping tool schema with an unpublishable path: ${tool.name}/${path}`
+      )
+      return false
+    })
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+  if (publishable.length > MAX_TOOL_SCHEMA_ARTIFACTS) {
+    console.error(
+      `Dropping ${publishable.length - MAX_TOOL_SCHEMA_ARTIFACTS} schema artifact(s) past the ${MAX_TOOL_SCHEMA_ARTIFACTS} cap: ${tool.name}`
+    )
+  }
   const schemas = Object.fromEntries(
-    Object.entries(tool.schemas ?? {})
-      .filter(([path]) => {
-        if (isPublishableArtifactPath(path)) {
-          return true
-        }
-        console.error(
-          `Skipping tool schema with an unpublishable path: ${tool.name}/${path}`
-        )
-        return false
-      })
+    publishable
+      .slice(0, MAX_TOOL_SCHEMA_ARTIFACTS)
       .map(([path, artifact]) => [path, rewriteArtifact(artifact)])
   )
 
@@ -58,6 +69,6 @@ export function officialToolEntry(
     wasm: rewriteArtifact(tool.wasm),
     capabilities: rewriteArtifact(tool.capabilities),
     ...(tool.manifest ? { manifest: rewriteArtifact(tool.manifest) } : {}),
-    ...(tool.schemas ? { schemas } : {}),
+    ...(Object.keys(schemas).length > 0 ? { schemas } : {}),
   }
 }

--- a/web/lib/catalog/versions.test.mjs
+++ b/web/lib/catalog/versions.test.mjs
@@ -79,6 +79,39 @@ test("a schema-only change moves the tool digest", () => {
   )
 })
 
+test("renaming a schema moves the tool digest even when its bytes are identical", () => {
+  const bytes = artifact("1".repeat(64))
+  const before = toVersionIndex(
+    manifest({ tools: [tool({ schemas: { "schemas/attio/v1.json": bytes } })] })
+  ).entries
+  const after = toVersionIndex(
+    manifest({ tools: [tool({ schemas: { "schemas/attio/v2.json": bytes } })] })
+  ).entries
+
+  assert.notEqual(
+    digestOf(before, "tool", "attio"),
+    digestOf(after, "tool", "attio")
+  )
+})
+
+test("renaming a skill file moves the skill digest", () => {
+  const before = toVersionIndex(
+    manifest({
+      skills: [skill({ files: [{ path: "scripts/a.py", ...artifact("1".repeat(64)) }] })],
+    })
+  ).entries
+  const after = toVersionIndex(
+    manifest({
+      skills: [skill({ files: [{ path: "scripts/b.py", ...artifact("1".repeat(64)) }] })],
+    })
+  ).entries
+
+  assert.notEqual(
+    digestOf(before, "skill", "chief-of-staff"),
+    digestOf(after, "skill", "chief-of-staff")
+  )
+})
+
 test("tool schema ordering does not change the digest", () => {
   const first = {
     "schemas/attio/a.json": artifact("1".repeat(64)),

--- a/web/lib/catalog/versions.ts
+++ b/web/lib/catalog/versions.ts
@@ -8,26 +8,33 @@ import type {
   VersionIndexUnchanged,
 } from "@/lib/catalog/manifest-types"
 
-export function entryDigest(artifacts: (HubArtifact | undefined)[]) {
+type DigestArtifact = HubArtifact & { path?: string }
+
+export function entryDigest(artifacts: (DigestArtifact | undefined)[]) {
   const hash = createHash("sha256")
   for (const artifact of artifacts) {
-    const value = artifact?.sha256 ?? ""
-    hash.update(String(Buffer.byteLength(value, "utf8")))
-    hash.update(":")
-    hash.update(value)
-    hash.update(":")
+    for (const value of [artifact?.path ?? "", artifact?.sha256 ?? ""]) {
+      hash.update(String(Buffer.byteLength(value, "utf8")))
+      hash.update(":")
+      hash.update(value)
+      hash.update(":")
+    }
   }
   return `sha256:${hash.digest("hex")}`
 }
 
+function comparePath(left: string, right: string) {
+  return left < right ? -1 : left > right ? 1 : 0
+}
+
 function byPath(left: { path: string }, right: { path: string }) {
-  return left.path.localeCompare(right.path)
+  return comparePath(left.path, right.path)
 }
 
 function toolSchemaArtifacts(tool: HubManifest["tools"][number]) {
   return Object.entries(tool.schemas ?? {})
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([, artifact]) => artifact)
+    .sort(([left], [right]) => comparePath(left, right))
+    .map(([path, artifact]) => ({ ...artifact, path }))
 }
 
 export function toVersionEntries(manifest: HubManifest): VersionEntry[] {


### PR DESCRIPTION
The hub published schema paths and counts the client rejects, taking down the
whole catalog. It now enforces the same limits, and paths feed the version-index
digest so renames show up.
