### PR TITLE
Publish manifest prompt assets in the signed tool catalog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,9 @@ The committed input schema must describe the same parameters returned by
 `Guest::schema`. Release generation fails unless the generated extension
 manifest's input/output schema references exactly match the committed files
 under `schemas/`; those files are published as digest-pinned catalog artifacts.
+Native manifests may also declare `prompt_doc_ref` help documents under
+`prompts/`. Every referenced prompt must be committed, and release generation
+publishes it as a digest-pinned catalog artifact alongside the schemas.
 
 ## Adding a skill
 

--- a/scripts/generate-manifest.sh
+++ b/scripts/generate-manifest.sh
@@ -18,6 +18,8 @@
 #   <staging>/<tool-name>.manifest.toml    (generated from capabilities.json)
 #   <staging>/<tool-name>.schema.<path-sha256>.json
 #                                          (copied from manifest schema refs)
+#   <staging>/<tool-name>.prompt.<path-sha256>.md
+#                                          (copied from manifest prompt refs)
 
 set -euo pipefail
 
@@ -90,13 +92,16 @@ for dir in "$ROOT"/tools/*/; do
       --argjson size "$(stat -c '%s' "$manifest_staged")" \
       --arg sha "$(sha256sum "$manifest_staged" | awk '{print $1}')" \
       '{ url: $url, size_bytes: $size, sha256: $sha }')"
-    schemas_json="$(python3 "$ROOT/scripts/package_tool_schemas.py" \
+    assets_json="$(python3 "$ROOT/scripts/package_tool_schemas.py" \
       "$dir" "$manifest_staged" "$STAGING" "$base_url")"
+    schemas_json="$(jq -c '.schemas' <<<"$assets_json")"
+    prompts_json="$(jq -c '.prompts' <<<"$assets_json")"
   else
     echo "warning: $name publishes no extension manifest (see error above)" >&2
     rm -f "$manifest_staged"
     manifest_json="null"
     schemas_json="null"
+    prompts_json="null"
   fi
 
   if [ $first -eq 0 ]; then
@@ -117,6 +122,7 @@ for dir in "$ROOT"/tools/*/; do
     --arg caps_sha "$caps_sha" \
     --argjson manifest "$manifest_json" \
     --argjson schemas "$schemas_json" \
+    --argjson prompts "$prompts_json" \
     '{
       name: $name,
       crate_name: $crate,
@@ -125,7 +131,8 @@ for dir in "$ROOT"/tools/*/; do
       wasm: { url: $wasm_url, size_bytes: $wasm_size, sha256: $wasm_sha },
       capabilities: { url: $caps_url, size_bytes: $caps_size, sha256: $caps_sha }
     }
-    + (if $manifest == null then {} else { manifest: $manifest, schemas: $schemas } end)')
+    + (if $manifest == null then {} else { manifest: $manifest, schemas: $schemas } end)
+    + (if $prompts == null or ($prompts | length) == 0 then {} else { prompts: $prompts } end)')
 done
 tools_json+="]"
 

--- a/scripts/package_tool_schemas.py
+++ b/scripts/package_tool_schemas.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Stage manifest-referenced tool schemas and emit signed-catalog metadata."""
+"""Stage manifest-referenced tool assets and emit signed-catalog metadata."""
 
 from __future__ import annotations
 
@@ -14,11 +14,13 @@ import sys
 
 MAX_SCHEMA_ARTIFACTS = 32
 MAX_SCHEMA_BYTES = 1024 * 1024
+MAX_PROMPT_ARTIFACTS = 64
+MAX_PROMPT_BYTES = 1024 * 1024
 TOOL_NAME = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 
 
 class SchemaPackagingError(ValueError):
-    """The manifest and committed schema assets are inconsistent."""
+    """The manifest and committed tool assets are inconsistent."""
 
 
 def manifest_schema_refs(manifest_path: Path) -> set[str]:
@@ -37,6 +39,21 @@ def manifest_schema_refs(manifest_path: Path) -> set[str]:
     if not refs:
         raise SchemaPackagingError("generated manifest declares no tool schema refs")
     return refs
+
+
+def manifest_prompt_refs(manifest_path: Path) -> set[str]:
+    try:
+        manifest = manifest_path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise SchemaPackagingError(f"cannot read generated manifest: {error}") from error
+
+    return set(
+        re.findall(
+            r'^prompt_doc_ref\s*=\s*"([^"]+)"\s*$',
+            manifest,
+            re.MULTILINE,
+        )
+    )
 
 
 def validate_schema_path(path: str) -> PurePosixPath:
@@ -65,6 +82,35 @@ def committed_schema_paths(tool_dir: Path) -> set[str]:
                 f"schema assets must not be symlinks: {schema_path}"
             )
         paths.add(schema_path.relative_to(tool_dir).as_posix())
+    return paths
+
+
+def validate_prompt_path(path: str) -> PurePosixPath:
+    parsed = PurePosixPath(path)
+    if (
+        parsed.is_absolute()
+        or not parsed.parts
+        or any(part in ("", ".", "..") for part in parsed.parts)
+    ):
+        raise SchemaPackagingError(f"invalid manifest prompt path: {path!r}")
+    if parsed.suffix != ".md" or parsed.parts[0] != "prompts":
+        raise SchemaPackagingError(
+            f"prompt path must be a Markdown file below prompts/: {path!r}"
+        )
+    return parsed
+
+
+def committed_prompt_paths(tool_dir: Path) -> set[str]:
+    prompt_root = tool_dir / "prompts"
+    if not prompt_root.is_dir():
+        return set()
+    paths: set[str] = set()
+    for prompt_path in prompt_root.rglob("*.md"):
+        if prompt_path.is_symlink():
+            raise SchemaPackagingError(
+                f"prompt assets must not be symlinks: {prompt_path}"
+            )
+        paths.add(prompt_path.relative_to(tool_dir).as_posix())
     return paths
 
 
@@ -122,6 +168,52 @@ def package_tool_schemas(
     return catalog
 
 
+def package_tool_prompts(
+    tool_dir: Path,
+    manifest_path: Path,
+    staging_dir: Path,
+    base_url: str,
+) -> dict[str, dict[str, object]]:
+    name = tool_dir.name
+    if not TOOL_NAME.fullmatch(name):
+        raise SchemaPackagingError(f"invalid tool directory name: {name!r}")
+    referenced = manifest_prompt_refs(manifest_path)
+    if not referenced:
+        return {}
+    committed = committed_prompt_paths(tool_dir)
+    if referenced != committed:
+        missing = sorted(referenced - committed)
+        unreferenced = sorted(committed - referenced)
+        raise SchemaPackagingError(
+            f"{name}: prompt assets do not match generated manifest "
+            f"(missing={missing}, unreferenced={unreferenced})"
+        )
+    if len(referenced) > MAX_PROMPT_ARTIFACTS:
+        raise SchemaPackagingError(
+            f"{name}: more than {MAX_PROMPT_ARTIFACTS} prompt artifacts"
+        )
+
+    staging_dir.mkdir(parents=True, exist_ok=True)
+    catalog: dict[str, dict[str, object]] = {}
+    for relative in sorted(referenced):
+        prompt_path = tool_dir / validate_prompt_path(relative)
+        content = prompt_path.read_bytes()
+        if len(content) > MAX_PROMPT_BYTES:
+            raise SchemaPackagingError(
+                f"{name}: prompt {relative!r} exceeds {MAX_PROMPT_BYTES} bytes"
+            )
+
+        path_digest = hashlib.sha256(relative.encode()).hexdigest()
+        asset_name = f"{name}.prompt.{path_digest}.md"
+        shutil.copyfile(prompt_path, staging_dir / asset_name)
+        catalog[relative] = {
+            "url": f"{base_url}/{asset_name}",
+            "size_bytes": len(content),
+            "sha256": hashlib.sha256(content).hexdigest(),
+        }
+    return catalog
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("tool_dir", type=Path)
@@ -130,13 +222,16 @@ def main() -> int:
     parser.add_argument("base_url")
     args = parser.parse_args()
     try:
-        catalog = package_tool_schemas(
+        schemas = package_tool_schemas(
+            args.tool_dir, args.manifest, args.staging_dir, args.base_url.rstrip("/")
+        )
+        prompts = package_tool_prompts(
             args.tool_dir, args.manifest, args.staging_dir, args.base_url.rstrip("/")
         )
     except (OSError, SchemaPackagingError) as error:
         print(f"error: {error}", file=sys.stderr)
         return 1
-    json.dump(catalog, sys.stdout, sort_keys=True)
+    json.dump({"prompts": prompts, "schemas": schemas}, sys.stdout, sort_keys=True)
     print()
     return 0
 

--- a/scripts/test_package_tool_schemas.py
+++ b/scripts/test_package_tool_schemas.py
@@ -6,7 +6,11 @@ from pathlib import Path
 import tempfile
 import unittest
 
-from package_tool_schemas import SchemaPackagingError, package_tool_schemas
+from package_tool_schemas import (
+    SchemaPackagingError,
+    package_tool_prompts,
+    package_tool_schemas,
+)
 
 
 class PackageToolSchemasTests(unittest.TestCase):
@@ -17,6 +21,7 @@ class PackageToolSchemasTests(unittest.TestCase):
         self.staging = self.root / "staging"
         self.input_ref = "schemas/evm-rpc/invoke.input.v1.json"
         self.output_ref = "schemas/evm-rpc/raw_output.v1.json"
+        self.prompt_ref = "prompts/evm-rpc/invoke.md"
         for relative, content in (
             (self.input_ref, b'{"type":"object","required":["action"]}\n'),
             (self.output_ref, b'{"description":"raw output"}\n'),
@@ -24,11 +29,15 @@ class PackageToolSchemasTests(unittest.TestCase):
             target = self.tool / relative
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_bytes(content)
+        prompt = self.tool / self.prompt_ref
+        prompt.parent.mkdir(parents=True, exist_ok=True)
+        prompt.write_text("# Invoke\n", encoding="utf-8")
         self.manifest = self.root / "manifest.toml"
         self.manifest.write_text(
             "[[tools]]\n"
             f'input_schema_ref = "{self.input_ref}"\n'
-            f'output_schema_ref = "{self.output_ref}"\n',
+            f'output_schema_ref = "{self.output_ref}"\n'
+            f'prompt_doc_ref = "{self.prompt_ref}"\n',
             encoding="utf-8",
         )
 
@@ -58,6 +67,28 @@ class PackageToolSchemasTests(unittest.TestCase):
                 },
             )
 
+    def test_stages_path_addressed_prompts_and_emits_catalog_metadata(self) -> None:
+        catalog = package_tool_prompts(
+            self.tool,
+            self.manifest,
+            self.staging,
+            "https://example.test/release",
+        )
+
+        self.assertEqual(set(catalog), {self.prompt_ref})
+        path_digest = hashlib.sha256(self.prompt_ref.encode()).hexdigest()
+        asset_name = f"evm-rpc.prompt.{path_digest}.md"
+        staged = self.staging / asset_name
+        self.assertEqual(staged.read_bytes(), (self.tool / self.prompt_ref).read_bytes())
+        self.assertEqual(
+            catalog[self.prompt_ref],
+            {
+                "url": f"https://example.test/release/{asset_name}",
+                "size_bytes": staged.stat().st_size,
+                "sha256": hashlib.sha256(staged.read_bytes()).hexdigest(),
+            },
+        )
+
     def test_rejects_missing_or_unreferenced_schema_assets(self) -> None:
         (self.tool / self.output_ref).unlink()
         extra = self.tool / "schemas/evm-rpc/extra.json"
@@ -67,6 +98,21 @@ class PackageToolSchemasTests(unittest.TestCase):
             SchemaPackagingError, "missing=.*raw_output.*unreferenced=.*extra"
         ):
             package_tool_schemas(
+                self.tool,
+                self.manifest,
+                self.staging,
+                "https://example.test/release",
+            )
+
+    def test_rejects_missing_or_unreferenced_prompt_assets(self) -> None:
+        (self.tool / self.prompt_ref).unlink()
+        extra = self.tool / "prompts/evm-rpc/extra.md"
+        extra.write_text("# Extra\n", encoding="utf-8")
+
+        with self.assertRaisesRegex(
+            SchemaPackagingError, "missing=.*invoke.*unreferenced=.*extra"
+        ):
+            package_tool_prompts(
                 self.tool,
                 self.manifest,
                 self.staging,

--- a/web/lib/catalog/manifest-types.ts
+++ b/web/lib/catalog/manifest-types.ts
@@ -21,6 +21,7 @@ export type HubToolEntry = {
   capabilities: HubArtifact
   manifest?: HubArtifact
   schemas?: Record<string, HubArtifact>
+  prompts?: Record<string, HubArtifact>
 }
 
 export type HubSkillFile = HubArtifact & {

--- a/web/lib/catalog/official-tools.test.mjs
+++ b/web/lib/catalog/official-tools.test.mjs
@@ -12,7 +12,7 @@ const artifact = (name) => ({
   sha256: name.padEnd(64, "0"),
 })
 
-test("official tool schemas retain their manifest paths and use proxy URLs", () => {
+test("official tool assets retain their manifest paths and use proxy URLs", () => {
   const tool = officialToolEntry(
     {
       name: "firecrawl",
@@ -24,6 +24,9 @@ test("official tool schemas retain their manifest paths and use proxy URLs", () 
         "schemas/firecrawl/invoke.input.v1.json": artifact("input"),
         "schemas/firecrawl/raw_output.v1.json": artifact("output"),
       },
+      prompts: {
+        "prompts/firecrawl/invoke.md": artifact("prompt"),
+      },
     },
     (url) => `https://hub.ironclaw.com/artifact/${encodeURIComponent(url)}`
   )
@@ -34,6 +37,13 @@ test("official tool schemas retain their manifest paths and use proxy URLs", () 
   ])
   assert.match(
     tool.schemas["schemas/firecrawl/invoke.input.v1.json"].url,
+    /^https:\/\/hub\.ironclaw\.com\/artifact\//
+  )
+  assert.deepEqual(Object.keys(tool.prompts ?? {}), [
+    "prompts/firecrawl/invoke.md",
+  ])
+  assert.match(
+    tool.prompts["prompts/firecrawl/invoke.md"].url,
     /^https:\/\/hub\.ironclaw\.com\/artifact\//
   )
 })
@@ -90,4 +100,23 @@ test("a tool whose schema paths are all unpublishable omits the field", () => {
   )
 
   assert.equal("schemas" in tool, false)
+})
+
+test("a tool whose prompt paths are all unpublishable omits the field", () => {
+  const tool = officialToolEntry(
+    {
+      name: "youtube",
+      version: "0.2.0",
+      wasm: artifact("wasm"),
+      capabilities: artifact("capabilities"),
+      prompts: {
+        "../escape.md": artifact("escape"),
+        "prompts/./invoke.md": artifact("dot"),
+        "prompts//invoke.md": artifact("empty"),
+      },
+    },
+    (url) => url
+  )
+
+  assert.equal("prompts" in tool, false)
 })

--- a/web/lib/catalog/official-tools.ts
+++ b/web/lib/catalog/official-tools.ts
@@ -15,10 +15,12 @@ export type GithubTool = {
   capabilities: GithubArtifact
   manifest?: GithubArtifact | null
   schemas?: Record<string, GithubArtifact> | null
+  prompts?: Record<string, GithubArtifact> | null
 }
 
 const PUBLISHABLE_ARTIFACT_PATH = /^[A-Za-z0-9._/-]+$/
 const MAX_TOOL_SCHEMA_ARTIFACTS = 32
+const MAX_TOOL_PROMPT_ARTIFACTS = 64
 
 export function isPublishableArtifactPath(path: string) {
   if (!path || path.startsWith("/") || !PUBLISHABLE_ARTIFACT_PATH.test(path)) {
@@ -38,26 +40,42 @@ export function officialToolEntry(
     size_bytes: artifact.size_bytes,
     sha256: artifact.sha256,
   })
-  const publishable = Object.entries(tool.schemas ?? {})
-    .filter(([path]) => {
-      if (isPublishableArtifactPath(path)) {
-        return true
-      }
+  const publishableArtifacts = (
+    kind: "prompt" | "schema",
+    artifacts: Record<string, GithubArtifact> | null | undefined,
+    limit: number
+  ) => {
+    const publishable = Object.entries(artifacts ?? {})
+      .filter(([path]) => {
+        if (isPublishableArtifactPath(path)) {
+          return true
+        }
+        console.error(
+          `Skipping tool ${kind} with an unpublishable path: ${tool.name}/${path}`
+        )
+        return false
+      })
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+    if (publishable.length > limit) {
       console.error(
-        `Skipping tool schema with an unpublishable path: ${tool.name}/${path}`
+        `Dropping ${publishable.length - limit} ${kind} artifact(s) past the ${limit} cap: ${tool.name}`
       )
-      return false
-    })
-    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
-  if (publishable.length > MAX_TOOL_SCHEMA_ARTIFACTS) {
-    console.error(
-      `Dropping ${publishable.length - MAX_TOOL_SCHEMA_ARTIFACTS} schema artifact(s) past the ${MAX_TOOL_SCHEMA_ARTIFACTS} cap: ${tool.name}`
+    }
+    return Object.fromEntries(
+      publishable
+        .slice(0, limit)
+        .map(([path, artifact]) => [path, rewriteArtifact(artifact)])
     )
   }
-  const schemas = Object.fromEntries(
-    publishable
-      .slice(0, MAX_TOOL_SCHEMA_ARTIFACTS)
-      .map(([path, artifact]) => [path, rewriteArtifact(artifact)])
+  const schemas = publishableArtifacts(
+    "schema",
+    tool.schemas,
+    MAX_TOOL_SCHEMA_ARTIFACTS
+  )
+  const prompts = publishableArtifacts(
+    "prompt",
+    tool.prompts,
+    MAX_TOOL_PROMPT_ARTIFACTS
   )
 
   return {
@@ -70,5 +88,6 @@ export function officialToolEntry(
     capabilities: rewriteArtifact(tool.capabilities),
     ...(tool.manifest ? { manifest: rewriteArtifact(tool.manifest) } : {}),
     ...(Object.keys(schemas).length > 0 ? { schemas } : {}),
+    ...(Object.keys(prompts).length > 0 ? { prompts } : {}),
   }
 }

--- a/web/lib/catalog/versions.test.mjs
+++ b/web/lib/catalog/versions.test.mjs
@@ -79,6 +79,25 @@ test("a schema-only change moves the tool digest", () => {
   )
 })
 
+test("a prompt-only change moves the tool digest", () => {
+  const path = "prompts/youtube/get_transcript.md"
+  const before = toVersionIndex(
+    manifest({
+      tools: [tool({ prompts: { [path]: artifact("1".repeat(64)) } })],
+    })
+  ).entries
+  const after = toVersionIndex(
+    manifest({
+      tools: [tool({ prompts: { [path]: artifact("2".repeat(64)) } })],
+    })
+  ).entries
+
+  assert.notEqual(
+    digestOf(before, "tool", "attio"),
+    digestOf(after, "tool", "attio")
+  )
+})
+
 test("renaming a schema moves the tool digest even when its bytes are identical", () => {
   const bytes = artifact("1".repeat(64))
   const before = toVersionIndex(

--- a/web/lib/catalog/versions.ts
+++ b/web/lib/catalog/versions.ts
@@ -31,8 +31,8 @@ function byPath(left: { path: string }, right: { path: string }) {
   return comparePath(left.path, right.path)
 }
 
-function toolSchemaArtifacts(tool: HubManifest["tools"][number]) {
-  return Object.entries(tool.schemas ?? {})
+function toolPathArtifacts(artifacts: Record<string, HubArtifact> | undefined) {
+  return Object.entries(artifacts ?? {})
     .sort(([left], [right]) => comparePath(left, right))
     .map(([path, artifact]) => ({ ...artifact, path }))
 }
@@ -47,7 +47,8 @@ export function toVersionEntries(manifest: HubManifest): VersionEntry[] {
         tool.wasm,
         tool.capabilities,
         tool.manifest,
-        ...toolSchemaArtifacts(tool),
+        ...toolPathArtifacts(tool.schemas),
+        ...toolPathArtifacts(tool.prompts),
       ]),
     })),
     ...manifest.skills.map((skill) => ({


### PR DESCRIPTION
## Summary

Publishes every native tool manifest's `prompt_doc_ref` Markdown file as a bounded, digest-pinned release artifact and carries those artifacts through IronHub's proxied signed catalog. This fixes installation for all 15 affected tools (141 prompt documents total), including YouTube, without modifying individual tool manifests.

## Closes

None

## Type

- [ ] Use case
- [ ] New tool
- [ ] New skill
- [x] Bug fix
- [x] Documentation / process
- [x] Infrastructure

## Artifact checklist

Use case PRs:

- [ ] Adds or updates `use-cases/<slug>/USE_CASE.md`
- [ ] Uses the exact seven-section `USE_CASE.md` template
- [ ] Uses strict skill/tool rows: `- name — description`
- [ ] Selects at least one category
- [ ] Passes `node scripts/validate-use-cases.mjs`

Skill PRs:

- [ ] Adds or updates `skills/<skill-name>/SKILL.md`
- [ ] Documents required tool dependencies
- [ ] Includes activation behavior in `SKILL.md`
- [ ] Tests at least one prompt that should activate the skill

Tool PRs:

- [ ] Adds or updates `tools/<tool-name>/README.md`
- [ ] Adds or updates `tools/<tool-name>/<tool-name>-tool.capabilities.json`
- [x] Adds input/output schema assets that exactly match the generated manifest refs (unchanged; validator passes all 28 tools)
- [ ] Documents auth, scopes, limits, and target use cases
- [ ] Tests representative action calls and records the results below

Docs/process PRs:

- [x] No `tracking.md` or README shipped-catalog change is needed
- [ ] Or, shipped catalog changes are reflected in both `tracking.md` and README

The unchecked artifact items are not applicable because this changes shared release/catalog packaging rather than adding or modifying a tool, skill, or use case.

## Testing

- `PYTHONDONTWRITEBYTECODE=1 /opt/homebrew/bin/python3 -m unittest discover -s scripts -p 'test_*.py'` — 20 passed, 1 skipped
- `PATH="/opt/homebrew/bin:$PATH" ./scripts/check-extension-manifests.sh` — all 28 tools valid
- `pnpm --filter web test:catalog` — 43 passed
- `DATABASE_URL=postgresql://localhost/ironhub pnpm --filter web db:generate && pnpm --filter web typecheck`
- `pnpm --filter web exec eslint lib/catalog/manifest-types.ts lib/catalog/official-tools.ts lib/catalog/official-tools.test.mjs lib/catalog/versions.ts lib/catalog/versions.test.mjs`
- `pnpm --filter web signing:check`
- `bash -n scripts/generate-manifest.sh`
- Packaging audit: 15 affected native tools, 141 referenced prompt documents staged with exact manifest/path matching
