### PR TITLE
Pass catalog arrays to jq as files, not arguments

### DIFF
--- a/scripts/generate-manifest.sh
+++ b/scripts/generate-manifest.sh
@@ -201,20 +201,27 @@ if [ -d "$ROOT/skills" ]; then
 fi
 skills_json+="]"
 
+# The catalog outgrew ARG_MAX once tools carry schema and prompt artifacts, so
+# the two arrays are handed to jq as files rather than command-line arguments.
+catalog_tmp="$(mktemp -d)"
+trap 'rm -rf "$catalog_tmp"' EXIT
+printf '%s' "$tools_json" > "$catalog_tmp/tools.json"
+printf '%s' "$skills_json" > "$catalog_tmp/skills.json"
+
 jq -n \
   --arg version "1" \
   --arg generated_at "$generated_at" \
   --arg release_tag "$TAG" \
   --arg repo "$REPO" \
-  --argjson tools "$tools_json" \
-  --argjson skills "$skills_json" \
+  --slurpfile tools "$catalog_tmp/tools.json" \
+  --slurpfile skills "$catalog_tmp/skills.json" \
   '{
     version: $version,
     generated_at: $generated_at,
     release_tag: $release_tag,
     repo: $repo,
-    tools: $tools,
-    skills: $skills
+    tools: $tools[0],
+    skills: $skills[0]
   }' > "$STAGING/tools.json"
 
 echo "wrote $STAGING/tools.json"


### PR DESCRIPTION
The release workflow has failed on every push to main since the catalog reached 28 tools carrying both schema and prompt artifacts:

```
./scripts/generate-manifest.sh: line 204: /usr/bin/jq: Argument list too long
```

No release has been cut since, so the catalog is frozen at `release-2026-08-05-105` and #271's prompt-doc artifacts cannot reach the signed catalog.

The cause is `MAX_ARG_STRLEN`, the 128KB cap on a single argv entry, not `ARG_MAX`. `ARG_MAX` is 2MB on the runner and the whole catalog is ~173KB, which is why the error reads as impossible until you notice the limit applies per argument. The tools array crossed it once tools started carrying schemas and prompts together.

Both arrays now reach jq as files via `--slurpfile` instead of `--argjson`. Temp files go to `mktemp -d` with a trap, deliberately not `$STAGING`, whose contents are uploaded as release assets.

Verified by reproducing the failure directly: a 150010-byte single argument fails with the same error under `--argjson` and succeeds under `--slurpfile`. Every other `--argjson` in the script is a number, a single artifact, or bounded by an existing cap (32 schemas, 64 prompts, 256 bundle files), so the final aggregate was the only unbounded one.
