### PR TITLE
Fix skill companion release asset names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Test skill release asset names
+        run: python3 scripts/test_skill_files.py
+
       - name: Smoke test every skill
         run: |
           failed=0

--- a/scripts/lib/skill-files.sh
+++ b/scripts/lib/skill-files.sh
@@ -1,9 +1,9 @@
 SKILL_FILE_PREFIX="files"
-SKILL_FILE_SEPARATOR="~"
 
 skill_file_asset_name() {
   local skill="$1"
   local rel="$2"
+  local path_digest
 
   if [ -z "$rel" ]; then
     echo "error: $skill has a skill file with an empty path" >&2
@@ -19,10 +19,6 @@ skill_file_asset_name() {
       echo "error: $skill ships '$rel', which escapes the skill directory" >&2
       return 1
       ;;
-    *"$SKILL_FILE_SEPARATOR"*)
-      echo "error: $skill ships '$rel', which contains the reserved '$SKILL_FILE_SEPARATOR' separator" >&2
-      return 1
-      ;;
   esac
 
   if printf '%s' "$rel" | grep -qv '^[A-Za-z0-9._/-]\+$'; then
@@ -30,5 +26,8 @@ skill_file_asset_name() {
     return 1
   fi
 
-  printf '%s.%s.%s' "$skill" "$SKILL_FILE_PREFIX" "$(printf '%s' "$rel" | tr '/' "$SKILL_FILE_SEPARATOR")"
+  # GitHub normalizes unsupported release-asset characters, so keep the
+  # filename provider-safe while the manifest retains the logical path.
+  path_digest="$(printf '%s' "$rel" | sha256sum | awk '{print $1}')"
+  printf '%s.%s.%s' "$skill" "$SKILL_FILE_PREFIX" "$path_digest"
 }

--- a/scripts/test_skill_files.py
+++ b/scripts/test_skill_files.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+import re
+import subprocess
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL_FILES = ROOT / "scripts" / "lib" / "skill-files.sh"
+
+
+def asset_name(skill: str, relative_path: str) -> str:
+    completed = subprocess.run(
+        [
+            "bash",
+            "-c",
+            '. "$1"; skill_file_asset_name "$2" "$3"',
+            "skill-file-test",
+            str(SKILL_FILES),
+            skill,
+            relative_path,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout
+
+
+def github_asset_name(name: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9._-]", ".", name)
+    return re.sub(r"\.{2,}", ".", normalized)
+
+
+class SkillFileAssetNameTests(unittest.TestCase):
+    def test_current_companion_assets_are_unique_and_provider_stable(self) -> None:
+        generated: list[str] = []
+        for skill_dir in sorted((ROOT / "skills").iterdir()):
+            if not skill_dir.is_dir():
+                continue
+            for file_path in sorted(skill_dir.rglob("*")):
+                if not file_path.is_file() or file_path.name == "SKILL.md":
+                    continue
+                relative_path = file_path.relative_to(skill_dir).as_posix()
+                name = asset_name(skill_dir.name, relative_path)
+                self.assertEqual(github_asset_name(name), name)
+                generated.append(name)
+
+        self.assertTrue(generated, "expected at least one companion skill asset")
+        self.assertEqual(len(generated), len(set(generated)))
+
+    def test_nested_and_hidden_paths_survive_github_asset_normalization(self) -> None:
+        for relative_path in (
+            "assets/near-presentation-template.html",
+            ".smoke-fixtures.json",
+        ):
+            generated = asset_name("presentation-generation", relative_path)
+            self.assertEqual(github_asset_name(generated), generated)
+
+    def test_provider_normalization_cannot_collapse_distinct_relative_paths(self) -> None:
+        nested = github_asset_name(asset_name("example", "assets/template.html"))
+        dotted = github_asset_name(asset_name("example", "assets.template.html"))
+        self.assertNotEqual(nested, dotted)
+
+    def test_asset_name_is_path_addressed(self) -> None:
+        relative_path = "assets/near-presentation-template.html"
+        path_digest = hashlib.sha256(relative_path.encode()).hexdigest()
+        self.assertEqual(
+            asset_name("presentation-generation", relative_path),
+            f"presentation-generation.files.{path_digest}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- name skill companion release assets with a SHA-256 of their logical relative path
- avoid GitHub release filename normalization changing signed artifact URLs
- test every current companion asset for provider-stable, collision-free names

## Root cause

Ironclaw PR nearai/ironclaw#7442 exposed this with presentation-generation. Its signed catalog URL named the companion asset presentation-generation.files.assets~near-presentation-template.html, but GitHub normalized the uploaded release asset to presentation-generation.files.assets.near-presentation-template.html. The proxy therefore returned 502 for the signed URL even though the uploaded bytes and digest were correct.

The logical companion path remains in the signed manifest; only the provider-facing release filename becomes path-addressed.

## Validation

- python3 scripts/test_skill_files.py (4 passed)
- python3 -m unittest discover -s scripts -p test_*.py (24 passed, 2 skipped)
- node scripts/validate-use-cases.mjs (107 validated)
- ./scripts/smoke-test-skill.sh skills/presentation-generation/ (passed)
- bash -n scripts/lib/skill-files.sh (passed)

## Compatibility and rollout

The catalog schema and Ironclaw installer contract are unchanged. The next IronHub release will publish companion assets under the new names and sign those URLs. Existing published releases are immutable and remain unchanged. Reverting this commit before release is sufficient rollback.